### PR TITLE
Handle single-leg position closure in recursive_backtest

### DIFF
--- a/polygonio/recursive_backtest.py
+++ b/polygonio/recursive_backtest.py
@@ -845,11 +845,19 @@ async def backtest_options_sync_or_async(cfg: RecursionConfig) -> Dict[str, Any]
                         pos["put_closed_date"] = cur
                         pos["put_closed_profit"] = entry_credit_put + realised_loss
 
-                # Keep if any leg still open
-                still_open.append(pos if (not pos.get("call_closed_by_stop", False) or not pos.get("put_closed_by_stop", False)) else pos)
+                # Keep for filtering after evaluating both legs
+                still_open.append(pos)
 
-            # Replace open_positions with filtered list (expired ones are dropped via 'continue' above)
-            open_positions = [p for p in still_open if not (p.get("call_closed_by_stop", False) and p.get("put_closed_by_stop", False))]
+            # Replace open_positions with positions that still have an open leg
+            # Treat a leg as closed if it was never opened (no corresponding short premium)
+            open_positions = [
+                p
+                for p in still_open
+                if not (
+                    (p.get("call_closed_by_stop", False) or p.get("short_call_prem_open") is None)
+                    and (p.get("put_closed_by_stop", False) or p.get("short_put_prem_open") is None)
+                )
+            ]
 
             # bookkeeping row
             pnl_row = {


### PR DESCRIPTION
## Summary
- simplify still_open tracking
- treat missing legs as closed so single-leg strategies drop from open list

## Testing
- `python -m py_compile polygonio/recursive_backtest.py`
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68bc8435e21c8326a4af999f4fa4d849