### PR TITLE
Propagate closure fields to final positions list

### DIFF
--- a/polygonio/recursive_backtest.py
+++ b/polygonio/recursive_backtest.py
@@ -664,12 +664,26 @@ async def backtest_options_sync_or_async(cfg: RecursionConfig) -> Dict[str, Any]
 
             # Helper to append/update open_positions on open day
             def _register_open_position(position_dict: Dict[str, Any]):
-                pos = dict(position_dict)  # copy
+                """Register a newly-opened position in the open list.
+
+                ``position_dict`` is already appended to ``daily_positions`` above.
+                To ensure any later mutations (e.g. call/put closure fields) are
+                reflected in the final ``positions`` output, we must operate on
+                the same dictionary object rather than a copy.  Otherwise the
+                open/close logic below would update a separate object and the
+                caller would never see the enriched fields.
+                """
+
+                # Use the original dict so that open_positions and daily_positions
+                # share the same reference.
+                pos = position_dict
+
                 pos.setdefault("position_open_date", datetime.strptime(as_of_str, "%Y-%m-%d"))
                 pos.setdefault("call_closed_by_stop", False)
                 pos.setdefault("put_closed_by_stop", False)
                 pos.setdefault("call_closed_date", None)
                 pos.setdefault("put_closed_date", None)
+
                 # Extract per-leg info
                 for leg in position_dict.get("legs", []):
                     side = leg.get("side"); action = leg.get("action")
@@ -686,6 +700,7 @@ async def backtest_options_sync_or_async(cfg: RecursionConfig) -> Dict[str, Any]
                     if side == "put" and action == "buy":
                         pos["put_strike_bought"] = strike
                         pos["long_put_prem_open"] = prem
+
                 open_positions.append(pos)
 
             # Register this newly-opened position, if any
@@ -875,7 +890,6 @@ async def backtest_options_sync_or_async(cfg: RecursionConfig) -> Dict[str, Any]
                 "open_positions": len(open_positions),
             }
             print(f"pnl_row init: {pnl_row} open_positions={len(open_positions)}")
-            breakpoint()
             daily_pnls.append(pnl_row)
 # <--- END YOUR P&L / EXIT LOGIC
 # <--- END YOUR P&L / EXIT LOGIC

--- a/scripts/run_backtest.py
+++ b/scripts/run_backtest.py
@@ -17,6 +17,8 @@ def parse_args():
     p.add_argument("--expiring-wks", type=int, default=1, help="Weeks out for option expiry (1=next week)")
     p.add_argument("--qty", type=int, default=1, help="Contracts per leg")
     p.add_argument("--log-level", default="INFO")
+    p.add_argument("--plot", action="store_true", help="Display a simple plot of results")
+    p.add_argument("--save-plot", help="If provided, save plot image to this path")
     return p.parse_args()
 
 def main():
@@ -33,6 +35,9 @@ def main():
         expiring_wks=a.expiring_wks,
         contract_qty=a.qty,
     )
+    if a.plot or a.save_plot:
+        from polygonio.daily_report import plot_recursive_results
+        plot_recursive_results(res, show=a.plot, save_path=a.save_plot)
     print("Done.")
     return 0
 


### PR DESCRIPTION
## Summary
- Ensure `_register_open_position` keeps the same dictionary instance for both `daily_positions` and `open_positions`
- Include explanatory docstring and share references so closing fields propagate to the final result
- Expand daily report logic so positions closed on a given day are displayed even when new trades open
- Add `plot_recursive_results` to graph cumulative PnL and open position count and expose plotting via `run_backtest.py`

## Testing
- `pytest`
- `PYTHONPATH=$PWD python - <<'PY' ...` (verified plot creation)
- `PYTHONPATH=$PWD python scripts/run_backtest.py -t SPY -s 2020-06-01 -e 2020-06-05 --trade-type iron_condor --plot --save-plot /tmp/backtest_plot.png` *(ProxyError: Tunnel connection failed: 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_68bc93deccf48326a7d6575d74f53804