### PR TITLE
ci: expose polygon api key

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,11 +5,12 @@ on:
   push:
     branches: [ main ]
 
+env:
+  POLYGON_API_KEY: ${{ secrets.POLYGON_API_KEY }}
+
 jobs:
   integration:
     runs-on: ubuntu-latest
-    env:
-      POLYGON_API_KEY: ${{ secrets.POLYGON_API_KEY }}
     steps:
       - uses: actions/checkout@v4
 


### PR DESCRIPTION
## Summary
- expose POLYGON_API_KEY secret to workflow

## Testing
- `POLYGON_API_KEY=dummy pytest -q -m "integration"` *(fails: HTTPSConnectionPool(host='query1.finance.yahoo.com', port=443): Max retries exceeded with url: /v8/finance/chart/SPY?...)*

------
https://chatgpt.com/codex/tasks/task_e_68bd20370b70832680a086fbe9f4b70c