### PR TITLE
refactor cache save logic for option data

### DIFF
--- a/polygonio/recursive_backtest.py
+++ b/polygonio/recursive_backtest.py
@@ -34,7 +34,7 @@ from .market_calendar import list_expiries  # maps your old get_all_weekdays
 from .poly_client import PolygonAPIClient
 from .chains import pull_option_chain_data
 from .pricing import interpolate_option_price, calculate_delta
-from .cache_io import stored_option_price, save_stored_option_data
+from .cache_io import stored_option_price, save_stored_option_data, option_data_needs_update
 from .symbols import convert_polygon_to_etrade_ticker
 from .paths import ROOT_DIR
 
@@ -937,8 +937,11 @@ async def backtest_options_sync_or_async(cfg: RecursionConfig) -> Dict[str, Any]
         cache_dir = None
         if "_lite" in (cfg.trade_type or ""):
             cache_dir = (ROOT_DIR / "polygon_api_option_data").resolve()
-        save_stored_option_data(cfg.ticker, cache_dir=cache_dir)
-        print("[DEBUG] saved.")
+        if option_data_needs_update(cfg.ticker, cache_dir=cache_dir):
+            save_stored_option_data(cfg.ticker, cache_dir=cache_dir)
+            print("[DEBUG] saved.")
+        else:
+            print("[DEBUG] no changes detected; skip saving.")
     except Exception:
         pass
     


### PR DESCRIPTION
## Summary
- add `option_data_needs_update` to check for unsaved option cache changes
- simplify `save_stored_option_data` to write unconditionally
- use new check in `recursive_backtest` to skip saving when no changes

## Testing
- `pip install matplotlib`
- `pip install pandas`
- `pip install requests`
- `pip install pandas_market_calendars`
- `pip install aiohttp`
- `pip install scipy`
- `PYTHONPATH=. pytest -q` *(fails: POLYGON_API_KEY must be set)*

------
https://chatgpt.com/codex/tasks/task_e_68bdf39911f883269e938ba0c5b0d4ce