### PR TITLE
Add causal regime market-data contract

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,13 +1,10 @@
-#Note to Codex: run test by "PYTHONPATH=. POLYGON_API_KEY=dummy pytest -q"
+# Required PR gate: deterministic offline tests only.
 name: ci
 
 on:
   pull_request:
   push:
     branches: [ main ]
-
-env:
-  POLYGON_API_KEY: ${{ secrets.POLYGON_API_KEY }}
 
 jobs:
   integration:
@@ -27,5 +24,8 @@ jobs:
           # pip install pytest pandas numpy matplotlib requests python-dateutil pytz pandas_market_calendars aiohttp
           pip install -r requirements.txt
           
-      - name: Run integration tests
-        run: pytest -q -m "integration"
+      - name: Run deterministic tests
+        working-directory: etrade_python_client
+        env:
+          PYTHONPATH: .
+        run: pytest -q tests

--- a/etrade_python_client/RELIABILITY.md
+++ b/etrade_python_client/RELIABILITY.md
@@ -33,6 +33,15 @@ For every reliability incident:
   request volume is part of the reliability budget.
 - Persist both the last attempt and the last successful synchronization. A
   stale-but-confirmed result must be distinguishable from a fresh result.
+- Regime inputs must persist provider/field identity, exchange event time,
+  `available_at`, `ingested_at`, finality, and a payload checksum. A caller-
+  supplied provenance flag or filesystem modification time is not evidence;
+  verified status additionally requires a durable raw response and parser
+  receipt linked to the selected observation.
+- A regime-data range is complete only when every expected NYSE session has
+  one independent final SPY close and one independent final VIX close. A
+  partial leg, holiday-only row, or conflicting correction must not overwrite
+  the last confirmed snapshot.
 
 ### Calculations
 

--- a/etrade_python_client/accounts/accounts_bo.py
+++ b/etrade_python_client/accounts/accounts_bo.py
@@ -1078,7 +1078,7 @@ class StockPosition:
 
 
 class Accounts:
-    def __init__(self, session, base_url, use_sandbox=False):
+    def __init__(self, session, base_url, use_sandbox=False, consumer_key=None):
         """
         Initialize Accounts object with session and account information
 
@@ -1088,10 +1088,22 @@ class Accounts:
         self.account = {}
         self.base_url = base_url
         self.use_sandbox = use_sandbox
-        if self.use_sandbox:
-            self.consumer_key = config["DEFAULT"]["SANDBOX_CONSUMER_KEY"]
-        else: 
-            self.consumer_key = config["DEFAULT"]["PROD_CONSUMER_KEY"]
+        config_key = "SANDBOX_CONSUMER_KEY" if self.use_sandbox else "PROD_CONSUMER_KEY"
+        self.consumer_key = (
+            consumer_key
+            if consumer_key is not None
+            else config["DEFAULT"].get(config_key)
+        )
+
+    def _consumer_key_headers(self):
+        if not self.consumer_key:
+            environment = "sandbox" if self.use_sandbox else "production"
+            config_key = "SANDBOX_CONSUMER_KEY" if self.use_sandbox else "PROD_CONSUMER_KEY"
+            raise RuntimeError(
+                f"Missing E*TRADE {environment} consumer key; pass consumer_key "
+                f"to Accounts or configure {config_key}."
+            )
+        return {"consumerKey": self.consumer_key}
 
     def _refresh_auth_session_if_possible(self, reason):
         callback = getattr(self, "auth_refresh_callback", None)
@@ -5563,7 +5575,7 @@ class Accounts:
         """
         # Base URL for the API
         base_url = f"{self.base_url}/v1/market/quote"
-        headers = {"consumerKey": self.consumer_key}
+        headers = self._consumer_key_headers()
 
         # Prepare the symbol
         symbol = "NVDA:2024:12:20:PUT:139"
@@ -5607,7 +5619,7 @@ class Accounts:
         """
         # Base URL for the API
         base_url = f"{self.base_url}/v1/market/quote"
-        headers = {"consumerKey": self.consumer_key}
+        headers = self._consumer_key_headers()
 
         # Prepare the symbol
         symbol = stock_option.symbol

--- a/etrade_python_client/docs/project_overview.md
+++ b/etrade_python_client/docs/project_overview.md
@@ -47,13 +47,18 @@ flowchart TD
 ```
 
 ### 2. Regime Detection, EV Engine, & Audit Flow
-The Market Regime Detection (MRD) stack ingests market indices, cleanses them for stationarity, runs causal PCA, trains rolling HMM state models, fits GMM probability densities to forward returns, and generates diagnostic charts and audits.
+The Market Regime Detection (MRD) stack retains the existing causal HMM/GMM
+research path and adds a separate V2 shadow path. V2 validates immutable
+SPY/VIX evidence and separates persistent background stress from fast event
+shocks. It is not connected to order execution.
 
 ```mermaid
 flowchart TD
     subgraph Data & Feature Layer
         DI["live_trading/data_ingestion.py<br/>(Fractional-Diff & Stationarity Checks)"]
         YF[("yfinance Cache / Flat Files<br/>(SPY, SPX, VIX, IRX Close Prices)")]
+        RMD["live_trading/regime_market_data.py<br/>(Immutable SPY/VIX Evidence Contract)"]
+        RES[("regime_evidence_store.py<br/>(Attempts, Revisions, Snapshots)")]
     end
 
     subgraph Dimensionality Reduction
@@ -63,11 +68,13 @@ flowchart TD
     subgraph Modeling & Calibration
         EE["live_trading/ev_engine.py<br/>(Causal HMM/GMM Fitting & EV Logic)"]
         Snap[("backtest_cache/regime_snapshots/*.pkl<br/>(Causal HMM/GMM Cache)")]
+        RD2["live_trading/regime_detector_v2.py<br/>(Background + Shock Shadow Detector)"]
     end
 
     subgraph Visual Analytics
         EP["live_trading/ev_plots.py<br/>(Diagnostic Plotter)"]
         RPA["scratch/regime_probability_audit.py<br/>(SPY vs SPX Statistical Auditor)"]
+        RVA["scratch/regime_detector_v2_audit.py<br/>(Unverified Legacy Replay Audit)"]
     end
 
     subgraph Generated Frontends & Images
@@ -78,6 +85,10 @@ flowchart TD
     end
 
     YF --> DI
+    YF --> RMD
+    RMD -.->|"adapter persistence pending"| RES
+    RMD --> RD2
+    RD2 --> RVA
     DI --> PF
     PF --> EE
     EE -->|Caches causal states| Snap
@@ -107,8 +118,12 @@ flowchart TD
 *   **Data Ingestion** ([`data_ingestion.py`](file:///Users/btian/EtradePythonClient/etrade_python_client/live_trading/data_ingestion.py)): Ingests raw market series (SPY, SPX, VIX, IRX) and transforms them to stationary inputs (log returns, fractional differencing) while running ADF (Augmented Dickey-Fuller) stationarity assertions.
 *   **PCA Fusion** ([`pca_fusion.py`](file:///Users/btian/EtradePythonClient/etrade_python_client/live_trading/pca_fusion.py)): Projects scaled stationary features into mathematically orthogonal components using rolling/expanding window PCA, enforcing eigenvector sign alignment over consecutive steps.
 *   **Core Engine** ([`ev_engine.py`](file:///Users/btian/EtradePythonClient/etrade_python_client/live_trading/ev_engine.py)): Implements walk-forward Hidden Markov Model (HMM) fits, deterministic state mapping (by variance/VIX to prevent label switching), and GMM (Gaussian Mixture Model) conditional forward return density estimates to calculate quantitative Expected Values (EV) for OTM puts.
+*   **V2 Evidence Contract** ([`regime_market_data.py`](file:///Users/btian/EtradePythonClient/etrade_python_client/live_trading/regime_market_data.py)): Defines exact NYSE/Cboe clocks, immutable source observations, deterministic input hashes, and policy-bound provenance metadata. It refuses to call checksums verified until raw provider bytes and parser receipts are durably linked.
+*   **V2 Evidence Store** ([`regime_evidence_store.py`](file:///Users/btian/EtradePythonClient/etrade_python_client/live_trading/regime_evidence_store.py)): Persists source attempts, last-confirmed health, append-only corrections, and channel-scoped detector snapshots in SQLite. Raw-response and live adapter wiring are still pending.
+*   **V2 Shadow Detector** ([`regime_detector_v2.py`](file:///Users/btian/EtradePythonClient/etrade_python_client/live_trading/regime_detector_v2.py)): Produces independent background and shock states from causal daily SPY/VIX inputs. Every current output is execution-ineligible.
 *   **Plotting & Diagnostics** ([`ev_plots.py`](file:///Users/btian/EtradePythonClient/etrade_python_client/live_trading/ev_plots.py)): Orchestrates visualizations of regime timelines, HMM state returns, GMM distribution fits, and Expected Value curves. It is also equipped to trigger out-of-sample calibration backtests.
 *   **Regime Audit** ([`regime_probability_audit.py`](file:///Users/btian/EtradePythonClient/etrade_python_client/scratch/regime_probability_audit.py)): A rigorous statistical audit script that merges SPY/SPX data, fits a causal walk-forward HMM, checks for statistical equivalence via Kolmogorov-Smirnov (KS) tests, audits options assignment frequencies against BS/Skew probabilities, and compiles a comprehensive audit report.
+*   **V2 Legacy Replay Audit** ([`regime_detector_v2_audit.py`](file:///Users/btian/EtradePythonClient/etrade_python_client/scratch/regime_detector_v2_audit.py)): Wraps legacy cache values in an explicitly unverified snapshot, surfaces conflicts/quarantined rows, and compares the two-timescale shadow result with the old overlay.
 
 ---
 
@@ -153,6 +168,9 @@ python live_trading/ev_plots.py --gmm-dist
 ```bash
 # Run the SPY vs SPX quantitative regime probability & option assignment audit
 python scratch/regime_probability_audit.py
+
+# Run the read-only V2 background/shock replay (always unverified)
+python scratch/regime_detector_v2_audit.py
 ```
 
 ---

--- a/etrade_python_client/docs/regime_detection_v2_design.md
+++ b/etrade_python_client/docs/regime_detection_v2_design.md
@@ -1,7 +1,8 @@
 # Regime Detection V2: Persistent Climate + Event Shock
 
-**Review date:** 2026-07-25  
-**Status:** shadow-mode prototype; not connected to order execution  
+**Review date:** 2026-07-26
+
+**Status:** shadow-mode detector plus evidence contract; not connected to order execution
 **Related roadmap:** `docs/production_readiness_upgrade_plan.md`
 
 ## Decision
@@ -44,17 +45,17 @@ dashboard cache and gives the dashboard cache priority on overlapping dates.
 The latest observation is the July 24, 2026 close.
 
 The cache does not persist trustworthy per-symbol `available_at` provenance.
-The replay therefore uses nominal historical finalization cutoffs and the
-latest file modification time only as timing proxies, and marks source
-provenance `UNVERIFIED`; its results are diagnostic, not eligible to drive a
-live order.
+The replay therefore wraps normalized cache values and historical finalization
+assumptions in an immutable evidence snapshot marked `UNVERIFIED`; its results
+are diagnostic and explicitly ineligible to drive a live order. A filesystem
+modification time is never treated as market-data provenance.
 
 | Window | Observed behavior | Legacy overlay | V2 shadow result |
 |---|---|---|---|
 | Mar 20–Apr 7, 12 sessions | VIX median 25.97, maximum 31.05; mean V2 background score 0.916 | 9 `cautious_decline`, 3 `expansion` | 12/12 `persistent_stress`; 3 fresh shocks |
 | Full April, 21 sessions | VIX median 18.92; early stress followed by rapid normalization | 20 `expansion`, 1 `cautious_decline` | 18 `persistent_stress`, then 3 `elevated` because exit requires confirmation |
 | Jun 15–Jul 24, 28 sessions | VIX median 16.81, maximum 19.49; five VIX increases above 10% | 28/28 `expansion` | 22 `elevated`, 6 `calm`; all five jumps detected |
-| Jul 9–Jul 24, 12 sessions | Mean background score 0.493; three VIX increases above 10% | 12/12 `expansion` | Jul 17 and Jul 23 were `calm + active`; Jul 24 was `calm + aftershock` |
+| Jul 9–Jul 24, 12 sessions | Mean background score 0.494; three VIX increases above 10% | 12/12 `expansion` | Jul 17 and Jul 23 were `calm + active`; Jul 24 was `calm + aftershock` |
 
 The recent raw shock dates were:
 
@@ -334,20 +335,36 @@ Each row contains:
   "VIX_Finalization_At": "2026-07-23T20:15:00+00:00",
   "Signal_Available_At": "2026-07-23T20:16:00+00:00",
   "Tradable_Session": "2026-07-24",
-  "Detector_Version": "regime_v2_shadow_0.1.0",
+  "Detector_Version": "regime_v2_shadow_0.2.0",
   "Config_Hash": "<sha256>",
+  "Input_Snapshot_SHA256": "<sha256>",
+  "Input_Schema_Version": "regime_market_data.v2",
+  "Calendar_Policy_Version": "nyse+cboe_index_options.v1",
+  "Source_Policy_Version": "regime_source_identity.v1",
+  "Source_Policy_SHA256": "<sha256>",
+  "Input_Provenance_Status": "unverified",
+  "Input_Provenance_Evidence": "complete_but_not_durably_verified",
+  "Detector_Stage": "shadow",
+  "Execution_Eligible": false,
   "Reason_Codes": "vix_daily_change_extreme",
   "Regime_Signal_Timestamp": "after_spy_vix_finalization_T_for_next_session"
 }
 ```
 
-The function requires timezone-aware, per-session `spy_available_at` and
-`vix_available_at` series, a timezone-aware run `as_of`, and an explicit
-source-provenance status. It verifies that every row is an exact, contiguous
-NYSE session, that availability metadata aligns one-to-one with those rows,
-that the final row is the latest jointly finalized session at `as_of`, that SPY
-is no earlier than the official NYSE close, and that VIX is no earlier than
-Cboe's nominal 4:15 p.m. ET calculation cutoff.
+The typed shadow entry point accepts only a
+`RegimeMarketDataSnapshot`. It derives provenance from immutable source
+metadata rather than accepting a caller-supplied Boolean. Each observation
+carries provider/dataset/symbol/field identity, payload checksum and kind,
+event time, availability time, ingestion time, request ID, finality, and a
+frozen source-policy verdict. The snapshot binds the version and hash of that
+policy, verifies exact contiguous NYSE sessions, one independent SPY and VIX
+observation per session, recognized identities, deterministic input and
+calendar hashes, and timezone-aware clock ordering.
+
+SPY event time comes from the versioned NYSE schedule. VIX event time comes
+from the versioned `CBOE_Index_Options` schedule, including shortened sessions;
+the paired publication boundary is the later of the two exchange closes. The
+final row must be the latest jointly finalized session at `as_of`.
 
 `Signal_Available_At` is the cumulative maximum of both source timestamps
 through T. This dependency watermark matters because returns, rolling features,
@@ -357,15 +374,43 @@ watermark. If either the current row or a required historical row arrives after
 the next session has opened, the signal rolls to the following session instead
 of being backdated into that morning.
 
-The calling market-data gateway must still provide truthful source provenance;
-a timestamp supplied by a caller—or a filesystem modification time—cannot prove
-where the values came from. Unverified provenance is carried in
+The compatibility entry point for loose arrays is research-only and rejects
+any attempt to claim verified provenance. Unverified provenance is carried in
 `Data_Quality`, makes `freshness_assessed=false`, and must hard-block any
-regime-dependent execution. Invalid, missing, non-finite, nonpositive,
-non-session, stale, or premature required data raise an error. Insufficient
-calibration history returns `unavailable`, and the first row's shock state is
-`unavailable` because a daily change cannot yet be observed. None of these
-cases silently produces `calm` or `none`.
+regime-dependent execution. Both entry points currently emit
+`Execution_Eligible=false`; promotion requires a later, separately reviewed
+risk-policy release. Invalid, missing, non-finite, nonpositive, non-session,
+stale, premature, duplicated, or tampered required data fail closed.
+Insufficient calibration history returns `unavailable`, and the first row's
+shock state is `unavailable` because a daily change cannot yet be observed.
+None of these cases silently produces `calm` or `none`.
+
+R1 intentionally does **not** call a checksum “verified provenance.” The
+current snapshot retains a digest but not the provider response bytes or a
+trusted parser receipt, so even structurally complete source metadata is
+labeled `complete_but_not_durably_verified`. No current R1 path emits
+`Input_Provenance_Status=verified`. A later provider-adapter release must store
+content-addressed raw responses, link each chosen observation revision to the
+fetch attempt and parser version, and re-derive the parsed close before this
+gate can be promoted.
+
+### R1 evidence persistence
+
+`live_trading/regime_evidence_store.py` provides the first durable manifest
+boundary. It stores source attempts, source health, append-only observation
+revisions, and channel-scoped, content-addressed input snapshots in SQLite with WAL,
+`synchronous=FULL`, foreign keys, restrictive file permissions, and immediate
+write transactions. Failed or time-inconsistent attempts roll back without
+advancing last-success state. A successful range must include exactly one
+currently ingested observation for every requested NYSE session. Snapshot
+reload verifies its canonical hash before returning data, and an older
+backfill cannot replace a newer-as-of snapshot in the same channel.
+
+This store is not yet wired into the live collection worker. That adapter and
+the raw-payload/parser receipts and two-leg retry/publication scheduler belong
+to the later live-shadow phase.
+The legacy JSON and Parquet caches remain research/display artifacts and cannot
+be promoted into verified evidence.
 
 ## Why not another single HMM
 
@@ -517,6 +562,14 @@ and skipped-trade effects must be included.
 - A delayed historical dependency propagates its availability watermark to
   every later signal that consumes it.
 - Filesystem modification time never upgrades source provenance to verified.
+- A checksum without retained raw bytes and a linked parser receipt remains
+  unverified.
+- Source-policy version, hash, and frozen verdict are bound into the snapshot
+  identity.
+- A stale observation from an older attempt cannot advance last-success
+  freshness for a new attempt.
+- Publishing an older backfill cannot regress the latest-as-of snapshot in the
+  research or shadow channel.
 - Invalid VIX3M cannot enter a term-structure calculation.
 - A probabilistic challenger is rejected if any state exceeds 95% OOS
   occupancy, centroids duplicate, posterior entropy collapses, or minimum
@@ -570,7 +623,11 @@ and skipped-trade effects must be included.
 ## Prototype artifacts and verification
 
 - Detector: `live_trading/regime_detector_v2.py`
-- Focused tests: `tests/test_regime_detector_v2.py`
+- Evidence contract: `live_trading/regime_market_data.py`
+- Evidence store: `live_trading/regime_evidence_store.py`
+- Focused tests: `tests/test_regime_detector_v2.py`,
+  `tests/test_regime_market_data.py`, and
+  `tests/test_regime_evidence_store.py`
 - Read-only replay: `scratch/regime_detector_v2_audit.py`
 
 The focused tests verify:
@@ -583,6 +640,10 @@ The focused tests verify:
 - No `calm` label while absolute stress evidence is present.
 - Explicit market-close timestamp and exact next tradable NYSE session.
 - Per-session source availability and delayed-delivery rollover.
+- Actual NYSE/Cboe regular and shortened-session clocks.
+- Deterministic snapshot, calendar, and source-policy hashes.
+- Exact requested-range coverage and transactional failure rollback.
+- Stale-attempt rejection and channel-scoped, monotonic snapshot publication.
 - Unavailable first-return shock evidence.
 
 The read-only replay prints the causal record and reproduces the 2026 comparison
@@ -594,6 +655,12 @@ without downloading or mutating data.
   <https://www.cboe.com/tradable-products/vix/term-structure>
 - Cboe, VIX calculation and trading-hour specification:
   <https://www.cboe.com/tradable-products/vix/vix-options/specifications/>
+- Cboe, current VIX methodology:
+  <https://cdn.cboe.com/api/global/us_indices/governance/VIX_Methodology.pdf>
+- Cboe, exchange hours and shortened sessions:
+  <https://www.cboe.com/about/hours/us-options>
+- Cboe DataShop, VIX end-of-day calculation inputs and early-close timing:
+  <https://datashop.cboe.com/vix-index-eod-calculation-inputs>
 - Cboe, March 2026 volatility and hedging-demand decomposition:
   <https://www.cboe.com/insights/posts/stagflation-fears-drive-widening-volatility-risk-premium>
 - Cboe, June 2026 volatility spike:

--- a/etrade_python_client/live_trading/regime_detector_v2.py
+++ b/etrade_python_client/live_trading/regime_detector_v2.py
@@ -16,9 +16,15 @@ import numpy as np
 import pandas as pd
 import pandas_market_calendars as mcal
 
+from live_trading.regime_market_data import (
+    CALENDAR_POLICY_VERSION,
+    RegimeMarketDataSnapshot,
+    regime_market_schedule,
+)
+
 
 SIGNAL_TIMESTAMP = "after_spy_vix_finalization_T_for_next_session"
-DETECTOR_VERSION = "regime_v2_shadow_0.1.0"
+DETECTOR_VERSION = "regime_v2_shadow_0.2.0"
 BACKGROUND_UNAVAILABLE = "unavailable"
 BACKGROUND_CALM = "calm"
 BACKGROUND_ELEVATED = "elevated"
@@ -159,13 +165,25 @@ def _as_aware_utc(value, field_name: str) -> pd.Timestamp:
 
 
 def _vix_finalization_times(session_dates: pd.DatetimeIndex) -> pd.DatetimeIndex:
-    """Return Cboe's nominal 4:15 p.m. ET VIX calculation cutoff."""
+    """Return the versioned Cboe Index Options close for each NYSE session."""
 
     dates = pd.DatetimeIndex(session_dates)
     if dates.tz is not None:
         dates = dates.tz_convert("America/New_York").tz_localize(None)
-    eastern_midnights = dates.normalize().tz_localize("America/New_York")
-    return eastern_midnights + pd.Timedelta(hours=16, minutes=15)
+    dates = dates.normalize()
+    if dates.empty:
+        return pd.DatetimeIndex([], dtype="datetime64[ns, UTC]")
+    schedule = regime_market_schedule(
+        dates.min().date(),
+        dates.max().date(),
+    )
+    missing = dates.difference(schedule.index)
+    if len(missing):
+        raise ValueError(
+            "Could not resolve Cboe finalization times for sessions: "
+            f"{[item.date().isoformat() for item in missing[:5]]}"
+        )
+    return pd.DatetimeIndex(schedule.loc[dates, "vix_event_at"])
 
 
 def _normalize_availability(
@@ -231,16 +249,10 @@ def _validate_latest_session(
     as_of_eastern = as_of_utc.tz_convert("America/New_York")
     start_date = (as_of_eastern.normalize() - pd.Timedelta(days=31)).date()
     end_date = as_of_eastern.normalize().date()
-    recent_schedule = NYSE.schedule(start_date=start_date, end_date=end_date)
-    vix_finalization_utc = pd.Series(
-        _vix_finalization_times(recent_schedule.index).tz_convert("UTC"),
-        index=recent_schedule.index,
-    )
-    joint_finalization_utc = pd.concat(
-        [recent_schedule["market_close"], vix_finalization_utc],
-        axis=1,
-    ).max(axis=1)
-    completed = recent_schedule[joint_finalization_utc <= as_of_utc]
+    recent_schedule = regime_market_schedule(start_date, end_date)
+    completed = recent_schedule[
+        recent_schedule["joint_finalization_at"] <= as_of_utc
+    ]
     if completed.empty:
         raise ValueError("No jointly finalized SPY/VIX session is available at as_of")
 
@@ -264,7 +276,7 @@ def _validate_latest_session(
     if early_vix.any():
         first_session = early_vix[early_vix].index[0]
         raise ValueError(
-            "VIX observation was available before the Cboe 4:15 p.m. ET cutoff: "
+            "VIX observation was available before the official Cboe close: "
             f"{first_session.date()}"
         )
     return as_of_utc, spy_available_utc, vix_available_utc
@@ -274,18 +286,21 @@ def _session_finalization_metadata(
     index: pd.DatetimeIndex,
 ) -> tuple[pd.Series, pd.Series]:
     extended_end = index.max() + pd.Timedelta(days=31)
-    schedule = NYSE.schedule(start_date=index.min(), end_date=extended_end)
+    schedule = regime_market_schedule(
+        index.min().date(),
+        extended_end.date(),
+    )
     sessions = pd.DatetimeIndex(schedule.index).tz_localize(None).normalize()
     positions = sessions.get_indexer(index)
     if np.any(positions < 0):
         raise ValueError("Could not resolve exact NYSE finalization metadata")
 
     closes = pd.Series(
-        pd.DatetimeIndex(schedule.iloc[positions]["market_close"].to_numpy()),
+        pd.DatetimeIndex(schedule.iloc[positions]["spy_event_at"]),
         index=index,
     )
     vix_finalizations = pd.Series(
-        _vix_finalization_times(sessions)[positions].tz_convert("UTC"),
+        pd.DatetimeIndex(schedule.iloc[positions]["vix_event_at"]),
         index=index,
     )
     return closes, vix_finalizations
@@ -472,7 +487,7 @@ def _reason_codes(row: pd.Series, config: RegimeDetectorConfig) -> str:
     return "|".join(reasons) if reasons else "no_stress_evidence"
 
 
-def detect_regimes(
+def _detect_regimes_from_arrays(
     prices: pd.DataFrame,
     config: RegimeDetectorConfig | None = None,
     *,
@@ -481,7 +496,7 @@ def detect_regimes(
     vix_available_at,
     source_provenance_verified: bool,
 ) -> pd.DataFrame:
-    """Return a causal background regime and an orthogonal shock state.
+    """Low-level detector core for already validated array inputs.
 
     Required input columns are ``SPY_Close`` and ``VIX_Close``. Source
     availability must be supplied as timezone-aware Series aligned one-to-one
@@ -621,5 +636,103 @@ def detect_regimes(
     result.attrs["latest_jointly_finalized_session"] = (
         frame.index.max().date().isoformat()
     )
-    result.attrs["exchange_calendar"] = "NYSE"
+    result.attrs["exchange_calendars"] = ("NYSE", "CBOE_Index_Options")
+    result.attrs["calendar_policy_version"] = CALENDAR_POLICY_VERSION
+    return result
+
+
+def detect_regimes(
+    prices: pd.DataFrame,
+    config: RegimeDetectorConfig | None = None,
+    *,
+    as_of,
+    spy_available_at,
+    vix_available_at,
+    source_provenance_verified: bool = False,
+) -> pd.DataFrame:
+    """Research-only compatibility interface for loose array inputs.
+
+    Loose DataFrames cannot prove source identity or raw lineage.  They may be
+    used for diagnostics with explicitly unverified provenance, but callers
+    cannot promote them by passing a trusted Boolean.  Production/shadow
+    ingestion must use :func:`detect_regimes_from_snapshot`.
+    """
+
+    if source_provenance_verified:
+        raise ValueError(
+            "Verified provenance requires RegimeMarketDataSnapshot; "
+            "loose array inputs are research-only"
+        )
+    result = _detect_regimes_from_arrays(
+        prices,
+        config,
+        as_of=as_of,
+        spy_available_at=spy_available_at,
+        vix_available_at=vix_available_at,
+        source_provenance_verified=False,
+    )
+    result["Detector_Stage"] = "research_raw_inputs"
+    result["Execution_Eligible"] = False
+    result.attrs["detector_stage"] = "research_raw_inputs"
+    result.attrs["execution_eligible"] = False
+    result.attrs["input_contract"] = "loose_arrays_unverified"
+    return result
+
+
+def detect_regimes_from_snapshot(
+    snapshot: RegimeMarketDataSnapshot,
+    config: RegimeDetectorConfig | None = None,
+) -> pd.DataFrame:
+    """Run the shadow detector from an immutable evidence-backed snapshot."""
+
+    if not isinstance(snapshot, RegimeMarketDataSnapshot):
+        raise TypeError("snapshot must be a RegimeMarketDataSnapshot")
+    inputs = snapshot.detector_inputs()
+    result = _detect_regimes_from_arrays(
+        inputs.pop("prices"),
+        config,
+        **inputs,
+    )
+    original_attrs = result.attrs.copy()
+    metadata = snapshot.source_metadata_frame()
+    if not metadata.index.equals(result.index):
+        raise ValueError("Snapshot source metadata does not align with detector output")
+    result = result.join(metadata)
+    result.attrs.update(original_attrs)
+
+    provenance_failure_codes = sorted(
+        {
+            failure.rsplit(":", 1)[-1]
+            for failure in snapshot.provenance_failures
+        }
+    )
+    result["Input_Snapshot_SHA256"] = snapshot.snapshot_sha256
+    result["Input_Schema_Version"] = snapshot.schema_version
+    result["Calendar_Policy_Version"] = CALENDAR_POLICY_VERSION
+    result["Calendar_Schedule_SHA256"] = snapshot.schedule_sha256
+    result["Source_Policy_Version"] = snapshot.source_policy_version
+    result["Source_Policy_SHA256"] = snapshot.source_policy_sha256
+    result["Input_Provenance_Status"] = (
+        "verified" if snapshot.provenance_verified else "unverified"
+    )
+    result["Input_Provenance_Evidence"] = (
+        "complete_but_not_durably_verified"
+        if snapshot.provenance_evidence_complete
+        else "incomplete"
+    )
+    result["Detector_Stage"] = "shadow"
+    result["Execution_Eligible"] = False
+
+    result.attrs["detector_stage"] = "shadow"
+    result.attrs["execution_eligible"] = False
+    result.attrs["input_contract"] = snapshot.schema_version
+    result.attrs["input_snapshot_sha256"] = snapshot.snapshot_sha256
+    result.attrs["calendar_policy_version"] = CALENDAR_POLICY_VERSION
+    result.attrs["calendar_schedule_sha256"] = snapshot.schedule_sha256
+    result.attrs["source_policy_version"] = snapshot.source_policy_version
+    result.attrs["source_policy_sha256"] = snapshot.source_policy_sha256
+    result.attrs["input_provenance_evidence_complete"] = (
+        snapshot.provenance_evidence_complete
+    )
+    result.attrs["input_provenance_failure_codes"] = provenance_failure_codes
     return result

--- a/etrade_python_client/live_trading/regime_evidence_store.py
+++ b/etrade_python_client/live_trading/regime_evidence_store.py
@@ -1,0 +1,913 @@
+"""Durable storage for canonical regime-market-data evidence.
+
+The store deliberately has a small surface:
+
+* source attempts and their last-attempt/last-success health;
+* append-only market-observation revisions; and
+* immutable, content-addressed regime input snapshots with channel-scoped
+  publications.
+
+It does not fetch data or run the detector.  Those concerns stay in the market
+data gateway and the pure regime detector respectively. It stores payload
+checksums, not raw provider bytes, so publication here does not confer verified
+provenance.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import os
+import sqlite3
+import uuid
+from contextlib import contextmanager
+from datetime import date, datetime, timezone
+from pathlib import Path
+from typing import Any, Iterator
+
+import pandas as pd
+
+from live_trading.regime_market_data import (
+    REGIME_DATA_SCHEMA_VERSION,
+    MarketObservation,
+    RegimeMarketDataSnapshot,
+    load_snapshot_json,
+    regime_market_schedule,
+)
+
+
+SCHEMA_VERSION = 2
+_BUSY_TIMEOUT_MS = 5_000
+_SNAPSHOT_CHANNELS = frozenset({"research", "shadow"})
+
+
+class RegimeEvidenceStoreError(RuntimeError):
+    """Base error for evidence-store failures."""
+
+
+class RegimeEvidenceIntegrityError(RegimeEvidenceStoreError):
+    """Raised when persisted evidence does not match its recorded identity."""
+
+
+_SCHEMA_STATEMENTS = (
+    """
+    CREATE TABLE IF NOT EXISTS source_attempts (
+        attempt_id         TEXT PRIMARY KEY,
+        provider           TEXT NOT NULL,
+        instrument         TEXT NOT NULL,
+        requested_start    TEXT NOT NULL,
+        requested_end      TEXT NOT NULL,
+        attempted_at       TEXT NOT NULL,
+        completed_at       TEXT,
+        status             TEXT NOT NULL
+                           CHECK (status IN ('in_progress', 'success', 'failure')),
+        observation_count  INTEGER NOT NULL DEFAULT 0
+                           CHECK (observation_count >= 0),
+        error_code         TEXT,
+        error_message      TEXT
+    )
+    """,
+    """
+    CREATE INDEX IF NOT EXISTS idx_source_attempts_source_time
+    ON source_attempts(provider, instrument, attempted_at)
+    """,
+    """
+    CREATE TABLE IF NOT EXISTS source_state (
+        provider             TEXT NOT NULL,
+        instrument           TEXT NOT NULL,
+        last_attempt_id      TEXT NOT NULL,
+        last_attempt_at      TEXT NOT NULL,
+        last_attempt_status  TEXT NOT NULL
+                             CHECK (last_attempt_status IN
+                                    ('in_progress', 'success', 'failure')),
+        last_success_id      TEXT,
+        last_success_at      TEXT,
+        PRIMARY KEY (provider, instrument),
+        FOREIGN KEY (last_attempt_id)
+            REFERENCES source_attempts(attempt_id),
+        FOREIGN KEY (last_success_id)
+            REFERENCES source_attempts(attempt_id)
+    )
+    """,
+    """
+    CREATE TABLE IF NOT EXISTS market_observations (
+        observation_sequence  INTEGER PRIMARY KEY AUTOINCREMENT,
+        observation_sha256    TEXT NOT NULL,
+        attempt_id             TEXT NOT NULL,
+        provider               TEXT NOT NULL,
+        instrument             TEXT NOT NULL,
+        session_date           TEXT NOT NULL,
+        revision               INTEGER NOT NULL CHECK (revision >= 1),
+        close_value            TEXT NOT NULL,
+        dataset                TEXT NOT NULL,
+        provider_symbol        TEXT NOT NULL,
+        price_field            TEXT NOT NULL,
+        adjustment             TEXT NOT NULL,
+        unit                   TEXT NOT NULL,
+        source_identity_json   TEXT NOT NULL,
+        event_at               TEXT NOT NULL,
+        available_at           TEXT NOT NULL,
+        ingested_at            TEXT NOT NULL,
+        request_id             TEXT NOT NULL,
+        raw_payload_sha256      TEXT NOT NULL,
+        payload_kind           TEXT NOT NULL,
+        availability_basis     TEXT NOT NULL,
+        is_final               INTEGER NOT NULL CHECK (is_final IN (0, 1)),
+        observation_schema_version TEXT NOT NULL,
+        observation_json       TEXT NOT NULL,
+        UNIQUE (provider, instrument, session_date, revision),
+        FOREIGN KEY (attempt_id)
+            REFERENCES source_attempts(attempt_id)
+    )
+    """,
+    """
+    CREATE INDEX IF NOT EXISTS idx_market_observations_lookup
+    ON market_observations(provider, instrument, session_date, revision)
+    """,
+    """
+    CREATE TABLE IF NOT EXISTS regime_input_snapshots (
+        snapshot_sequence  INTEGER PRIMARY KEY AUTOINCREMENT,
+        snapshot_sha256    TEXT NOT NULL UNIQUE,
+        snapshot_as_of     TEXT NOT NULL,
+        snapshot_json      TEXT NOT NULL
+    )
+    """,
+    """
+    CREATE TABLE IF NOT EXISTS regime_snapshot_publications (
+        publication_sequence  INTEGER PRIMARY KEY AUTOINCREMENT,
+        channel               TEXT NOT NULL
+                              CHECK (channel IN ('research', 'shadow')),
+        snapshot_sha256       TEXT NOT NULL,
+        published_at          TEXT NOT NULL,
+        UNIQUE (channel, snapshot_sha256),
+        FOREIGN KEY (snapshot_sha256)
+            REFERENCES regime_input_snapshots(snapshot_sha256)
+    )
+    """,
+    """
+    CREATE INDEX IF NOT EXISTS idx_regime_snapshot_publications_channel
+    ON regime_snapshot_publications(channel, publication_sequence)
+    """,
+)
+
+
+def _required_text(value: Any, field_name: str) -> str:
+    if value is None:
+        raise ValueError(f"{field_name} must be non-empty")
+    text = str(value).strip()
+    if not text:
+        raise ValueError(f"{field_name} must be non-empty")
+    return text
+
+
+def _snapshot_channel(value: Any) -> str:
+    channel = _required_text(value, "channel").lower()
+    if channel not in _SNAPSHOT_CHANNELS:
+        raise ValueError(
+            f"channel must be one of {sorted(_SNAPSHOT_CHANNELS)}"
+        )
+    return channel
+
+
+def _date_iso(value: Any, field_name: str) -> str:
+    if isinstance(value, datetime):
+        value = value.date()
+    if isinstance(value, date):
+        return value.isoformat()
+    try:
+        return date.fromisoformat(str(value)).isoformat()
+    except (TypeError, ValueError) as exc:
+        raise ValueError(f"{field_name} must be an ISO date") from exc
+
+
+def _utc_iso(value: Any, field_name: str) -> str:
+    try:
+        timestamp = pd.Timestamp(value)
+    except Exception as exc:
+        raise ValueError(f"{field_name} must be an ISO timestamp") from exc
+    if timestamp.tzinfo is None:
+        raise ValueError(f"{field_name} must be a timezone-aware timestamp")
+    return (
+        timestamp.tz_convert("UTC")
+        .isoformat(timespec="nanoseconds")
+        .replace("+00:00", "Z")
+    )
+
+
+def _canonical_json(payload: Any) -> str:
+    return json.dumps(
+        payload,
+        sort_keys=True,
+        separators=(",", ":"),
+        ensure_ascii=False,
+        allow_nan=False,
+    )
+
+
+def _nested_source_identity(payload: dict[str, Any]) -> dict[str, Any]:
+    identity = payload.get(
+        "identity",
+        payload.get("source_identity", payload.get("source")),
+    )
+    if not isinstance(identity, dict):
+        raise ValueError("MarketObservation must contain a source identity")
+    return identity
+
+
+class RegimeEvidenceStore:
+    """SQLite-backed evidence store for one-host, one-writer operation."""
+
+    def __init__(self, path: str | os.PathLike[str]):
+        self.path = Path(path)
+        self.path.parent.mkdir(parents=True, exist_ok=True)
+        self._conn: sqlite3.Connection | None = None
+
+        try:
+            connection = sqlite3.connect(
+                str(self.path),
+                timeout=_BUSY_TIMEOUT_MS / 1_000,
+                isolation_level=None,
+            )
+            connection.row_factory = sqlite3.Row
+            self._conn = connection
+            self._enforce_permissions()
+            connection.execute("PRAGMA foreign_keys = ON")
+            connection.execute(f"PRAGMA busy_timeout = {_BUSY_TIMEOUT_MS}")
+            journal_mode = connection.execute("PRAGMA journal_mode = WAL").fetchone()[0]
+            if str(journal_mode).lower() != "wal":
+                raise RegimeEvidenceStoreError(
+                    f"Could not enable SQLite WAL mode: {journal_mode}"
+                )
+            connection.execute("PRAGMA synchronous = FULL")
+            self._initialize_schema()
+            self._enforce_permissions()
+        except Exception:
+            if self._conn is not None:
+                self._conn.close()
+                self._conn = None
+            raise
+
+    @property
+    def _connection(self) -> sqlite3.Connection:
+        if self._conn is None:
+            raise RegimeEvidenceStoreError("Evidence store is closed")
+        return self._conn
+
+    def __enter__(self) -> "RegimeEvidenceStore":
+        return self
+
+    def __exit__(self, exc_type, exc_value, traceback) -> None:
+        self.close()
+
+    def close(self) -> None:
+        if self._conn is None:
+            return
+        self._enforce_permissions()
+        self._conn.close()
+        self._conn = None
+
+    def _enforce_permissions(self) -> None:
+        for candidate in (
+            self.path,
+            Path(f"{self.path}-wal"),
+            Path(f"{self.path}-shm"),
+        ):
+            if candidate.exists():
+                os.chmod(candidate, 0o600)
+
+    def _initialize_schema(self) -> None:
+        connection = self._connection
+        version = int(connection.execute("PRAGMA user_version").fetchone()[0])
+        if version > SCHEMA_VERSION:
+            raise RegimeEvidenceStoreError(
+                f"Evidence schema {version} is newer than supported version "
+                f"{SCHEMA_VERSION}"
+            )
+        if version == SCHEMA_VERSION:
+            return
+        if version != 0:
+            raise RegimeEvidenceStoreError(
+                f"No migration is defined from evidence schema {version}"
+            )
+
+        with self._immediate_transaction():
+            for statement in _SCHEMA_STATEMENTS:
+                connection.execute(statement)
+            connection.execute(f"PRAGMA user_version = {SCHEMA_VERSION}")
+
+    @contextmanager
+    def _immediate_transaction(self) -> Iterator[None]:
+        connection = self._connection
+        connection.execute("BEGIN IMMEDIATE")
+        try:
+            yield
+        except Exception:
+            connection.rollback()
+            raise
+        else:
+            connection.commit()
+        finally:
+            self._enforce_permissions()
+
+    def begin_attempt(
+        self,
+        provider: str,
+        instrument: str,
+        requested_start,
+        requested_end,
+        attempted_at,
+    ) -> str:
+        provider_text = _required_text(provider, "provider")
+        instrument_text = _required_text(instrument, "instrument")
+        start_text = _date_iso(requested_start, "requested_start")
+        end_text = _date_iso(requested_end, "requested_end")
+        if end_text < start_text:
+            raise ValueError("requested_end cannot be before requested_start")
+        attempted_text = _utc_iso(attempted_at, "attempted_at")
+        attempt_id = uuid.uuid4().hex
+
+        with self._immediate_transaction():
+            self._connection.execute(
+                """
+                INSERT INTO source_attempts (
+                    attempt_id, provider, instrument, requested_start,
+                    requested_end, attempted_at, status
+                ) VALUES (?, ?, ?, ?, ?, ?, 'in_progress')
+                """,
+                (
+                    attempt_id,
+                    provider_text,
+                    instrument_text,
+                    start_text,
+                    end_text,
+                    attempted_text,
+                ),
+            )
+            self._connection.execute(
+                """
+                INSERT INTO source_state (
+                    provider, instrument, last_attempt_id, last_attempt_at,
+                    last_attempt_status
+                ) VALUES (?, ?, ?, ?, 'in_progress')
+                ON CONFLICT(provider, instrument) DO UPDATE SET
+                    last_attempt_id = excluded.last_attempt_id,
+                    last_attempt_at = excluded.last_attempt_at,
+                    last_attempt_status = excluded.last_attempt_status
+                """,
+                (provider_text, instrument_text, attempt_id, attempted_text),
+            )
+        return attempt_id
+
+    def _attempt_row(self, attempt_id: str) -> sqlite3.Row:
+        row = self._connection.execute(
+            "SELECT * FROM source_attempts WHERE attempt_id = ?",
+            (attempt_id,),
+        ).fetchone()
+        if row is None:
+            raise KeyError(f"Unknown source attempt: {attempt_id}")
+        return row
+
+    @staticmethod
+    def _validate_completion_time(
+        attempt: sqlite3.Row,
+        completed_at: str,
+    ) -> None:
+        attempted = pd.Timestamp(attempt["attempted_at"])
+        completed = pd.Timestamp(completed_at)
+        if completed < attempted:
+            raise ValueError("completed_at cannot be before attempted_at")
+
+    @staticmethod
+    def _validate_success_observations(
+        attempt: sqlite3.Row,
+        completed_at: str,
+        observations: list[dict[str, Any]],
+    ) -> None:
+        actual_sessions = [item["session_date"] for item in observations]
+        seen_sessions: set[str] = set()
+        duplicate_sessions: set[str] = set()
+        for session in actual_sessions:
+            if session in seen_sessions:
+                duplicate_sessions.add(session)
+            seen_sessions.add(session)
+        if duplicate_sessions:
+            raise ValueError(
+                "observations contain duplicate sessions: "
+                f"{sorted(duplicate_sessions)}"
+            )
+
+        schedule = regime_market_schedule(
+            attempt["requested_start"],
+            attempt["requested_end"],
+        )
+        expected_sessions = {
+            session.date().isoformat()
+            for session in schedule.index
+        }
+        actual_session_set = set(actual_sessions)
+        missing = sorted(expected_sessions - actual_session_set)
+        unexpected = sorted(actual_session_set - expected_sessions)
+        if missing or unexpected:
+            raise ValueError(
+                "observations do not exactly cover requested NYSE sessions; "
+                f"missing={missing}, unexpected={unexpected}"
+            )
+
+        attempted = pd.Timestamp(attempt["attempted_at"])
+        completed = pd.Timestamp(completed_at)
+        for item in observations:
+            if not item["source_identity_recognized"]:
+                raise ValueError(
+                    "observation source identity is not recognized"
+                )
+            if not item["is_final"]:
+                raise ValueError("observation must be final")
+            event_column = (
+                "spy_event_at"
+                if item["instrument"] == "SPY"
+                else "vix_event_at"
+            )
+            expected_event = pd.Timestamp(
+                schedule.loc[
+                    pd.Timestamp(item["session_date"]),
+                    event_column,
+                ]
+            )
+            if pd.Timestamp(item["event_at"]) != expected_event:
+                raise ValueError(
+                    "observation event_at does not match the exchange close"
+                )
+            ingested = pd.Timestamp(item["ingested_at"])
+            if ingested < attempted:
+                raise ValueError(
+                    "observation.ingested_at cannot be before attempted_at"
+                )
+            if ingested > completed:
+                raise ValueError(
+                    "completed_at cannot be before observation.ingested_at"
+                )
+
+    def record_failure(
+        self,
+        attempt_id: str,
+        completed_at,
+        error_code: str,
+        error_message: str,
+    ) -> None:
+        completed_text = _utc_iso(completed_at, "completed_at")
+        error_code_text = _required_text(error_code, "error_code")[:100]
+        error_message_text = _required_text(error_message, "error_message")[:1_000]
+
+        with self._immediate_transaction():
+            attempt = self._attempt_row(attempt_id)
+            if attempt["status"] != "in_progress":
+                raise RegimeEvidenceStoreError(
+                    f"Attempt {attempt_id} is already {attempt['status']}"
+                )
+            self._validate_completion_time(attempt, completed_text)
+            self._connection.execute(
+                """
+                UPDATE source_attempts
+                SET completed_at = ?, status = 'failure',
+                    error_code = ?, error_message = ?
+                WHERE attempt_id = ?
+                """,
+                (
+                    completed_text,
+                    error_code_text,
+                    error_message_text,
+                    attempt_id,
+                ),
+            )
+            self._connection.execute(
+                """
+                UPDATE source_state
+                SET last_attempt_status = 'failure'
+                WHERE provider = ? AND instrument = ?
+                  AND last_attempt_id = ?
+                """,
+                (attempt["provider"], attempt["instrument"], attempt_id),
+            )
+
+    def record_success(
+        self,
+        attempt_id: str,
+        completed_at,
+        observations: tuple[MarketObservation, ...],
+    ) -> None:
+        completed_text = _utc_iso(completed_at, "completed_at")
+        if not isinstance(observations, tuple) or not observations:
+            raise ValueError("observations must be a non-empty tuple")
+
+        serialized = [
+            self._serialize_observation(observation)
+            for observation in observations
+        ]
+
+        with self._immediate_transaction():
+            attempt = self._attempt_row(attempt_id)
+            if attempt["status"] != "in_progress":
+                raise RegimeEvidenceStoreError(
+                    f"Attempt {attempt_id} is already {attempt['status']}"
+                )
+            self._validate_completion_time(attempt, completed_text)
+            for item in serialized:
+                if item["provider"] != attempt["provider"]:
+                    raise ValueError(
+                        "Observation provider does not match the source attempt"
+                    )
+                if item["instrument"] != attempt["instrument"]:
+                    raise ValueError(
+                        "Observation instrument does not match the source attempt"
+                    )
+            self._validate_success_observations(
+                attempt,
+                completed_text,
+                serialized,
+            )
+            for item in serialized:
+                existing = self._connection.execute(
+                    """
+                    SELECT revision
+                    FROM market_observations
+                    WHERE provider = ? AND instrument = ?
+                      AND session_date = ? AND observation_sha256 = ?
+                    LIMIT 1
+                    """,
+                    (
+                        item["provider"],
+                        item["instrument"],
+                        item["session_date"],
+                        item["observation_sha256"],
+                    ),
+                ).fetchone()
+                if existing is not None:
+                    continue
+
+                revision = int(
+                    self._connection.execute(
+                        """
+                        SELECT COALESCE(MAX(revision), 0) + 1
+                        FROM market_observations
+                        WHERE provider = ? AND instrument = ? AND session_date = ?
+                        """,
+                        (
+                            item["provider"],
+                            item["instrument"],
+                            item["session_date"],
+                        ),
+                    ).fetchone()[0]
+                )
+                self._connection.execute(
+                    """
+                    INSERT INTO market_observations (
+                        observation_sha256, attempt_id, provider, instrument,
+                        session_date, revision, close_value, dataset,
+                        provider_symbol, price_field, adjustment, unit,
+                        source_identity_json, event_at, available_at,
+                        ingested_at, request_id, raw_payload_sha256,
+                        payload_kind, availability_basis, is_final,
+                        observation_schema_version, observation_json
+                    ) VALUES (
+                        ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?,
+                        ?, ?, ?, ?, ?
+                    )
+                    """,
+                    (
+                        item["observation_sha256"],
+                        attempt_id,
+                        item["provider"],
+                        item["instrument"],
+                        item["session_date"],
+                        revision,
+                        item["close_value"],
+                        item["dataset"],
+                        item["provider_symbol"],
+                        item["price_field"],
+                        item["adjustment"],
+                        item["unit"],
+                        item["source_identity_json"],
+                        item["event_at"],
+                        item["available_at"],
+                        item["ingested_at"],
+                        item["request_id"],
+                        item["raw_payload_sha256"],
+                        item["payload_kind"],
+                        item["availability_basis"],
+                        item["is_final"],
+                        item["observation_schema_version"],
+                        item["observation_json"],
+                    ),
+                )
+
+            self._connection.execute(
+                """
+                UPDATE source_attempts
+                SET completed_at = ?, status = 'success',
+                    observation_count = ?, error_code = NULL,
+                    error_message = NULL
+                WHERE attempt_id = ?
+                """,
+                (completed_text, len(serialized), attempt_id),
+            )
+            self._connection.execute(
+                """
+                UPDATE source_state
+                SET
+                    last_attempt_status = CASE
+                        WHEN last_attempt_id = ? THEN 'success'
+                        ELSE last_attempt_status
+                    END,
+                    last_success_id = CASE
+                        WHEN last_success_at IS NULL OR last_success_at <= ?
+                        THEN ? ELSE last_success_id
+                    END,
+                    last_success_at = CASE
+                        WHEN last_success_at IS NULL OR last_success_at <= ?
+                        THEN ? ELSE last_success_at
+                    END
+                WHERE provider = ? AND instrument = ?
+                """,
+                (
+                    attempt_id,
+                    completed_text,
+                    attempt_id,
+                    completed_text,
+                    completed_text,
+                    attempt["provider"],
+                    attempt["instrument"],
+                ),
+            )
+
+    def _serialize_observation(
+        self,
+        observation: MarketObservation,
+    ) -> dict[str, Any]:
+        if not isinstance(observation, MarketObservation):
+            raise TypeError("observations must contain MarketObservation values")
+
+        payload = observation.to_dict()
+        if not isinstance(payload, dict):
+            raise TypeError("MarketObservation.to_dict() must return a dictionary")
+        identity = _nested_source_identity(payload)
+        observation_json = _canonical_json(payload)
+
+        provider = _required_text(identity.get("provider"), "source.provider")
+        dataset = _required_text(
+            identity.get("dataset"),
+            "source.dataset",
+        )
+        provider_symbol = _required_text(
+            identity.get("provider_symbol"),
+            "source.provider_symbol",
+        )
+        price_field = _required_text(
+            identity.get("field"),
+            "source.field",
+        )
+        session_date = _date_iso(
+            payload.get("session"),
+            "observation.session",
+        )
+        instrument = _required_text(
+            identity.get("canonical_instrument"),
+            "source.canonical_instrument",
+        )
+        raw_payload_sha256 = _required_text(
+            payload.get("raw_payload_sha256"),
+            "observation.raw_payload_sha256",
+        )
+        if len(raw_payload_sha256) != 64:
+            raise ValueError(
+                "observation.raw_payload_sha256 must be a SHA-256 hex digest"
+            )
+        try:
+            int(raw_payload_sha256, 16)
+        except ValueError as exc:
+            raise ValueError(
+                "observation.raw_payload_sha256 must be a SHA-256 hex digest"
+            ) from exc
+
+        is_final = payload.get("is_final")
+        if not isinstance(is_final, bool):
+            raise ValueError("observation.is_final must be a boolean")
+        return {
+            "observation_sha256": hashlib.sha256(
+                observation_json.encode("utf-8")
+            ).hexdigest(),
+            "provider": provider,
+            "instrument": instrument,
+            "session_date": session_date,
+            "close_value": str(observation.close),
+            "dataset": dataset,
+            "provider_symbol": provider_symbol,
+            "price_field": price_field,
+            "adjustment": _required_text(
+                identity.get("adjustment"),
+                "source.adjustment",
+            ),
+            "unit": _required_text(identity.get("unit"), "source.unit"),
+            "source_identity_json": _canonical_json(identity),
+            "event_at": _utc_iso(
+                payload.get("event_at"),
+                "observation.event_at",
+            ),
+            "available_at": _utc_iso(
+                payload.get("available_at"),
+                "observation.available_at",
+            ),
+            "ingested_at": _utc_iso(
+                payload.get("ingested_at"),
+                "observation.ingested_at",
+            ),
+            "request_id": _required_text(
+                payload.get("request_id"),
+                "observation.request_id",
+            ),
+            "raw_payload_sha256": raw_payload_sha256,
+            "payload_kind": _required_text(
+                payload.get("payload_kind"),
+                "observation.payload_kind",
+            ),
+            "availability_basis": _required_text(
+                payload.get("availability_basis"),
+                "observation.availability_basis",
+            ),
+            "is_final": int(is_final),
+            "source_identity_recognized": (
+                observation.source_identity_recognized
+            ),
+            "observation_schema_version": REGIME_DATA_SCHEMA_VERSION,
+            "observation_json": observation_json,
+        }
+
+    def publish_snapshot(
+        self,
+        snapshot: RegimeMarketDataSnapshot,
+        channel: str = "research",
+    ) -> str:
+        if not isinstance(snapshot, RegimeMarketDataSnapshot):
+            raise TypeError("snapshot must be a RegimeMarketDataSnapshot")
+        channel_text = _snapshot_channel(channel)
+        snapshot_json = snapshot.to_json()
+        verified = self._verify_snapshot_json(snapshot_json)
+        snapshot_sha256 = verified.snapshot_sha256
+        snapshot_as_of = _utc_iso(verified.as_of, "snapshot.as_of")
+        published_at = _utc_iso(
+            datetime.now(timezone.utc),
+            "published_at",
+        )
+
+        with self._immediate_transaction():
+            existing = self._connection.execute(
+                """
+                SELECT snapshot_as_of, snapshot_json
+                FROM regime_input_snapshots
+                WHERE snapshot_sha256 = ?
+                """,
+                (snapshot_sha256,),
+            ).fetchone()
+            if existing is not None:
+                if (
+                    existing["snapshot_as_of"] != snapshot_as_of
+                    or existing["snapshot_json"] != snapshot_json
+                ):
+                    raise RegimeEvidenceIntegrityError(
+                        "Existing snapshot content does not match its SHA-256"
+                    )
+            else:
+                self._connection.execute(
+                    """
+                    INSERT INTO regime_input_snapshots (
+                        snapshot_sha256, snapshot_as_of, snapshot_json
+                    ) VALUES (?, ?, ?)
+                    """,
+                    (snapshot_sha256, snapshot_as_of, snapshot_json),
+                )
+            self._connection.execute(
+                """
+                INSERT INTO regime_snapshot_publications (
+                    channel, snapshot_sha256, published_at
+                ) VALUES (?, ?, ?)
+                ON CONFLICT(channel, snapshot_sha256) DO NOTHING
+                """,
+                (channel_text, snapshot_sha256, published_at),
+            )
+        return snapshot_sha256
+
+    def _verify_snapshot_json(self, snapshot_json: str) -> RegimeMarketDataSnapshot:
+        if not isinstance(snapshot_json, str):
+            raise RegimeEvidenceIntegrityError("Snapshot payload is not text")
+        try:
+            snapshot = load_snapshot_json(snapshot_json)
+            canonical = snapshot.to_json()
+        except Exception as exc:
+            raise RegimeEvidenceIntegrityError(
+                "Snapshot JSON failed schema or checksum validation"
+            ) from exc
+        if canonical != snapshot_json:
+            raise RegimeEvidenceIntegrityError(
+                "Snapshot JSON is not in canonical form"
+            )
+        return snapshot
+
+    def _snapshot_from_row(
+        self,
+        row: sqlite3.Row,
+        context: str,
+    ) -> RegimeMarketDataSnapshot:
+        snapshot = self._verify_snapshot_json(row["snapshot_json"])
+        if snapshot.snapshot_sha256 != row["snapshot_sha256"]:
+            raise RegimeEvidenceIntegrityError(
+                f"{context} content does not match the stored SHA-256"
+            )
+        if _utc_iso(snapshot.as_of, "snapshot.as_of") != row["snapshot_as_of"]:
+            raise RegimeEvidenceIntegrityError(
+                f"{context} as_of does not match the stored timestamp"
+            )
+        return snapshot
+
+    def load_snapshot(self, sha256: str) -> RegimeMarketDataSnapshot:
+        snapshot_sha256 = _required_text(sha256, "sha256")
+        row = self._connection.execute(
+            """
+            SELECT snapshot_sha256, snapshot_as_of, snapshot_json
+            FROM regime_input_snapshots
+            WHERE snapshot_sha256 = ?
+            """,
+            (snapshot_sha256,),
+        ).fetchone()
+        if row is None:
+            raise KeyError(f"Unknown regime input snapshot: {snapshot_sha256}")
+        return self._snapshot_from_row(row, "Snapshot")
+
+    def latest_snapshot(
+        self,
+        channel: str = "research",
+    ) -> RegimeMarketDataSnapshot | None:
+        channel_text = _snapshot_channel(channel)
+        row = self._connection.execute(
+            """
+            SELECT
+                snapshot.snapshot_sha256,
+                snapshot.snapshot_as_of,
+                snapshot.snapshot_json
+            FROM regime_snapshot_publications AS publication
+            JOIN regime_input_snapshots AS snapshot
+              ON snapshot.snapshot_sha256 = publication.snapshot_sha256
+            WHERE publication.channel = ?
+            ORDER BY
+                snapshot.snapshot_as_of DESC,
+                publication.publication_sequence DESC
+            LIMIT 1
+            """,
+            (channel_text,),
+        ).fetchone()
+        if row is None:
+            return None
+        return self._snapshot_from_row(row, "Latest snapshot")
+
+    def source_health(self, provider: str, instrument: str) -> dict[str, Any]:
+        provider_text = _required_text(provider, "provider")
+        instrument_text = _required_text(instrument, "instrument")
+        row = self._connection.execute(
+            """
+            SELECT
+                state.provider,
+                state.instrument,
+                state.last_attempt_id,
+                state.last_attempt_at,
+                state.last_attempt_status,
+                state.last_success_id,
+                state.last_success_at,
+                attempt.completed_at AS last_attempt_completed_at,
+                attempt.error_code AS last_error_code,
+                attempt.error_message AS last_error_message
+            FROM source_state AS state
+            JOIN source_attempts AS attempt
+              ON attempt.attempt_id = state.last_attempt_id
+            WHERE state.provider = ? AND state.instrument = ?
+            """,
+            (provider_text, instrument_text),
+        ).fetchone()
+        if row is None:
+            return {
+                "provider": provider_text,
+                "instrument": instrument_text,
+                "last_attempt_id": None,
+                "last_attempt_at": None,
+                "last_attempt_completed_at": None,
+                "last_attempt_status": None,
+                "last_success_id": None,
+                "last_success_at": None,
+                "last_error_code": None,
+                "last_error_message": None,
+            }
+        return dict(row)
+
+    def quick_check(self) -> bool:
+        try:
+            rows = self._connection.execute("PRAGMA quick_check").fetchall()
+        except sqlite3.DatabaseError:
+            return False
+        return bool(rows) and all(str(row[0]).lower() == "ok" for row in rows)

--- a/etrade_python_client/live_trading/regime_market_data.py
+++ b/etrade_python_client/live_trading/regime_market_data.py
@@ -1,0 +1,927 @@
+"""Immutable, causal SPY/VIX input contract for regime detection.
+
+The legacy market-data caches store source-free scalar values.  This module
+defines the stricter boundary required by the V2 detector: each close carries
+an explicit session, source identity, payload-checksum lineage, event time, source
+availability time, and local ingestion time.
+
+The contract is deliberately independent of networking and broker code.  It
+can validate and replay a stored snapshot offline, but it cannot upgrade a
+normalized cache or an assumed historical timestamp into verified provenance.
+Until a provider adapter durably links raw bytes and a parser receipt, even a
+structurally complete provider-response manifest remains unverified.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import re
+from dataclasses import dataclass, field
+from datetime import date, datetime
+from typing import Any, Mapping
+
+import numpy as np
+import pandas as pd
+import pandas_market_calendars as mcal
+
+
+REGIME_DATA_SCHEMA_VERSION = "regime_market_data.v2"
+CALENDAR_POLICY_VERSION = "nyse+cboe_index_options.v1"
+SOURCE_POLICY_VERSION = "regime_source_identity.v1"
+
+PAYLOAD_PROVIDER_RESPONSE = "provider_response"
+PAYLOAD_NORMALIZED_ONLY = "normalized_only"
+
+AVAILABILITY_PROVIDER_TIMESTAMP = "provider_timestamp"
+AVAILABILITY_LIVE_RETRIEVAL = "live_retrieval"
+AVAILABILITY_HISTORICAL_ASSUMPTION = "historical_finalization_assumption"
+
+REQUIRED_INSTRUMENTS = ("SPY", "VIX")
+
+_PAYLOAD_KINDS = {
+    PAYLOAD_PROVIDER_RESPONSE,
+    PAYLOAD_NORMALIZED_ONLY,
+}
+_AVAILABILITY_BASES = {
+    AVAILABILITY_PROVIDER_TIMESTAMP,
+    AVAILABILITY_LIVE_RETRIEVAL,
+    AVAILABILITY_HISTORICAL_ASSUMPTION,
+}
+_OBSERVED_AVAILABILITY_BASES = {
+    AVAILABILITY_PROVIDER_TIMESTAMP,
+    AVAILABILITY_LIVE_RETRIEVAL,
+}
+_SAFE_REQUEST_ID = re.compile(r"^[A-Za-z0-9][A-Za-z0-9._:/-]{0,127}$")
+_SHA256 = re.compile(r"^[0-9a-f]{64}$")
+
+NYSE = mcal.get_calendar("NYSE")
+CBOE_INDEX_OPTIONS = mcal.get_calendar("CBOE_Index_Options")
+
+
+class RegimeMarketDataError(ValueError):
+    """A fail-closed market-data contract error with a stable code."""
+
+    def __init__(self, code: str, message: str):
+        self.code = code
+        super().__init__(f"{code}: {message}")
+
+
+def _fail(code: str, message: str) -> None:
+    raise RegimeMarketDataError(code, message)
+
+
+def _nonempty_text(value: Any, field_name: str, *, lower: bool = False) -> str:
+    if not isinstance(value, str):
+        raise TypeError(f"{field_name} must be a string")
+    text = value.strip()
+    if not text:
+        _fail("EMPTY_FIELD", f"{field_name} cannot be empty")
+    if len(text) > 128:
+        _fail("FIELD_TOO_LONG", f"{field_name} exceeds 128 characters")
+    return text.lower() if lower else text
+
+
+def _session_date(value: Any) -> date:
+    """Parse an explicit session date without deriving it from a timestamp."""
+
+    if isinstance(value, datetime) or isinstance(value, pd.Timestamp):
+        raise TypeError("session must be a date, not a datetime/timestamp")
+    if isinstance(value, date):
+        return value
+    if isinstance(value, str) and re.fullmatch(r"\d{4}-\d{2}-\d{2}", value):
+        try:
+            return date.fromisoformat(value)
+        except ValueError as exc:
+            raise RegimeMarketDataError(
+                "INVALID_SESSION",
+                f"session is not a valid calendar date: {value}",
+            ) from exc
+    raise TypeError("session must be datetime.date or an ISO YYYY-MM-DD string")
+
+
+def _aware_utc(value: Any, field_name: str) -> pd.Timestamp:
+    try:
+        timestamp = pd.Timestamp(value)
+    except Exception as exc:
+        raise RegimeMarketDataError(
+            "INVALID_TIMESTAMP",
+            f"{field_name} is not a valid timestamp",
+        ) from exc
+    if timestamp.tzinfo is None:
+        _fail("NAIVE_TIMESTAMP", f"{field_name} must be timezone-aware")
+    return timestamp.tz_convert("UTC")
+
+
+def _positive_close(value: Any) -> float:
+    if isinstance(value, (bool, np.bool_)):
+        raise TypeError("close must be a real number, not a boolean")
+    try:
+        close = float(value)
+    except (TypeError, ValueError) as exc:
+        raise TypeError("close must be numeric") from exc
+    if not np.isfinite(close) or close <= 0:
+        _fail("INVALID_CLOSE", "close must be finite and strictly positive")
+    return close
+
+
+def _sha256_text(value: Any, field_name: str) -> str:
+    text = _nonempty_text(value, field_name, lower=True)
+    if not _SHA256.fullmatch(text) or text == "0" * 64:
+        _fail("INVALID_SHA256", f"{field_name} must be a non-zero SHA-256 digest")
+    return text
+
+
+def _iso_utc(timestamp: pd.Timestamp) -> str:
+    return timestamp.tz_convert("UTC").isoformat()
+
+
+def _canonical_json(payload: Mapping[str, Any]) -> str:
+    return json.dumps(
+        payload,
+        sort_keys=True,
+        separators=(",", ":"),
+        allow_nan=False,
+    )
+
+
+@dataclass(frozen=True)
+class SourceIdentity:
+    """Semantic identity of one provider field.
+
+    Construction normalizes textual fields but intentionally does not confer
+    trust.  A snapshot accepts only identities in the explicit registry below.
+    """
+
+    provider: str
+    dataset: str
+    provider_symbol: str
+    canonical_instrument: str
+    field: str
+    adjustment: str
+    unit: str
+
+    def __post_init__(self) -> None:
+        object.__setattr__(
+            self,
+            "provider",
+            _nonempty_text(self.provider, "provider", lower=True),
+        )
+        object.__setattr__(
+            self,
+            "dataset",
+            _nonempty_text(self.dataset, "dataset", lower=True),
+        )
+        object.__setattr__(
+            self,
+            "provider_symbol",
+            _nonempty_text(self.provider_symbol, "provider_symbol").upper(),
+        )
+        object.__setattr__(
+            self,
+            "canonical_instrument",
+            _nonempty_text(
+                self.canonical_instrument,
+                "canonical_instrument",
+            ).upper(),
+        )
+        object.__setattr__(
+            self,
+            "field",
+            _nonempty_text(self.field, "field", lower=True),
+        )
+        object.__setattr__(
+            self,
+            "adjustment",
+            _nonempty_text(self.adjustment, "adjustment", lower=True),
+        )
+        object.__setattr__(
+            self,
+            "unit",
+            _nonempty_text(self.unit, "unit", lower=True),
+        )
+        if self.canonical_instrument not in REQUIRED_INSTRUMENTS:
+            _fail(
+                "UNSUPPORTED_INSTRUMENT",
+                f"unsupported canonical instrument: {self.canonical_instrument}",
+            )
+
+    @property
+    def registry_key(self) -> tuple[str, ...]:
+        return (
+            self.provider,
+            self.dataset,
+            self.provider_symbol,
+            self.canonical_instrument,
+            self.field,
+            self.adjustment,
+            self.unit,
+        )
+
+    @property
+    def source_field_key(self) -> tuple[str, ...]:
+        return (
+            self.provider,
+            self.dataset,
+            self.provider_symbol,
+            self.field,
+            self.adjustment,
+            self.unit,
+        )
+
+    @property
+    def is_recognized(self) -> bool:
+        return self.registry_key in _SOURCE_IDENTITY_POLICY
+
+    @property
+    def is_provenance_capable(self) -> bool:
+        return bool(_SOURCE_IDENTITY_POLICY.get(self.registry_key, False))
+
+    def to_dict(self) -> dict[str, str]:
+        return {
+            "provider": self.provider,
+            "dataset": self.dataset,
+            "provider_symbol": self.provider_symbol,
+            "canonical_instrument": self.canonical_instrument,
+            "field": self.field,
+            "adjustment": self.adjustment,
+            "unit": self.unit,
+        }
+
+    @classmethod
+    def from_dict(cls, payload: Mapping[str, Any]) -> "SourceIdentity":
+        return cls(
+            provider=payload["provider"],
+            dataset=payload["dataset"],
+            provider_symbol=payload["provider_symbol"],
+            canonical_instrument=payload["canonical_instrument"],
+            field=payload["field"],
+            adjustment=payload["adjustment"],
+            unit=payload["unit"],
+        )
+
+
+# The Boolean says whether the identity could support raw provenance once a
+# provider adapter persists bytes and a parser receipt. It does not itself
+# confer verified status. Local artifacts are shadow-only.
+_SOURCE_IDENTITY_POLICY: dict[tuple[str, ...], bool] = {
+    (
+        "yahoo",
+        "daily_prices",
+        "SPY",
+        "SPY",
+        "close",
+        "unadjusted",
+        "usd",
+    ): True,
+    (
+        "massive",
+        "aggregates",
+        "SPY",
+        "SPY",
+        "close",
+        "unadjusted",
+        "usd",
+    ): True,
+    (
+        "cboe",
+        "vix_daily",
+        "VIX",
+        "VIX",
+        "close",
+        "none",
+        "index_points",
+    ): True,
+    (
+        "yahoo",
+        "daily_prices",
+        "^VIX",
+        "VIX",
+        "close",
+        "none",
+        "index_points",
+    ): True,
+    (
+        "local_artifact",
+        "derived_cache",
+        "SPY",
+        "SPY",
+        "close",
+        "unknown",
+        "usd",
+    ): False,
+    (
+        "local_artifact",
+        "derived_cache",
+        "VIX",
+        "VIX",
+        "close",
+        "unknown",
+        "index_points",
+    ): False,
+}
+
+
+def _current_source_policy_sha256() -> str:
+    entries = [
+        {
+            "identity": list(identity),
+            "raw_provenance_capable": capable,
+        }
+        for identity, capable in sorted(_SOURCE_IDENTITY_POLICY.items())
+    ]
+    payload = {
+        "source_policy_version": SOURCE_POLICY_VERSION,
+        "entries": entries,
+    }
+    return hashlib.sha256(_canonical_json(payload).encode("utf-8")).hexdigest()
+
+
+def regime_market_schedule(start: Any, end: Any) -> pd.DataFrame:
+    """Return the exact paired NYSE and Cboe close clock.
+
+    SPY uses the NYSE market close.  VIX uses the Cboe Index Options market
+    close, which correctly moves from 4:15 p.m. ET to 1:15 p.m. ET on the
+    exchange's shortened sessions.
+    """
+
+    start_date = _session_date(start)
+    end_date = _session_date(end)
+    if start_date > end_date:
+        _fail("INVALID_RANGE", "schedule start cannot be later than end")
+
+    nyse = NYSE.schedule(start_date=start_date, end_date=end_date)
+    cboe = CBOE_INDEX_OPTIONS.schedule(start_date=start_date, end_date=end_date)
+    if nyse.empty:
+        return pd.DataFrame(
+            {
+                "spy_event_at": pd.Series(dtype="datetime64[ns, UTC]"),
+                "vix_event_at": pd.Series(dtype="datetime64[ns, UTC]"),
+                "joint_finalization_at": pd.Series(dtype="datetime64[ns, UTC]"),
+            },
+            index=pd.DatetimeIndex([], dtype="datetime64[ns]"),
+        )
+
+    nyse_index = pd.DatetimeIndex(nyse.index).tz_localize(None).normalize()
+    cboe_index = pd.DatetimeIndex(cboe.index).tz_localize(None).normalize()
+    missing_cboe = nyse_index.difference(cboe_index)
+    if len(missing_cboe):
+        preview = [item.date().isoformat() for item in missing_cboe[:5]]
+        _fail(
+            "CALENDAR_SESSION_MISMATCH",
+            f"Cboe calendar is missing NYSE sessions: {preview}",
+        )
+
+    nyse_closes = pd.Series(
+        pd.DatetimeIndex(nyse["market_close"]).tz_convert("UTC"),
+        index=nyse_index,
+        name="spy_event_at",
+    )
+    cboe_closes = pd.Series(
+        pd.DatetimeIndex(cboe["market_close"]).tz_convert("UTC"),
+        index=cboe_index,
+        name="vix_event_at",
+    ).reindex(nyse_index)
+    schedule = pd.concat([nyse_closes, cboe_closes], axis=1)
+    schedule["joint_finalization_at"] = schedule.max(axis=1)
+    return schedule
+
+
+def _schedule_sha256(schedule: pd.DataFrame) -> str:
+    rows = [
+        {
+            "session": session.date().isoformat(),
+            "spy_event_at": _iso_utc(pd.Timestamp(row.spy_event_at)),
+            "vix_event_at": _iso_utc(pd.Timestamp(row.vix_event_at)),
+        }
+        for session, row in schedule.iterrows()
+    ]
+    payload = {
+        "calendar_policy_version": CALENDAR_POLICY_VERSION,
+        "sessions": rows,
+    }
+    return hashlib.sha256(_canonical_json(payload).encode("utf-8")).hexdigest()
+
+
+@dataclass(frozen=True)
+class MarketObservation:
+    """One immutable finalized close and its source/clock lineage."""
+
+    session: date
+    identity: SourceIdentity
+    close: float
+    event_at: pd.Timestamp
+    available_at: pd.Timestamp
+    ingested_at: pd.Timestamp
+    request_id: str
+    raw_payload_sha256: str
+    payload_kind: str
+    availability_basis: str
+    is_final: bool = True
+    source_policy_version: str = field(init=False)
+    source_policy_sha256: str = field(init=False)
+    source_identity_recognized: bool = field(init=False)
+    source_identity_provenance_capable: bool = field(init=False)
+
+    def __post_init__(self) -> None:
+        object.__setattr__(self, "session", _session_date(self.session))
+        if not isinstance(self.identity, SourceIdentity):
+            raise TypeError("identity must be a SourceIdentity")
+        object.__setattr__(
+            self,
+            "source_policy_version",
+            SOURCE_POLICY_VERSION,
+        )
+        object.__setattr__(
+            self,
+            "source_policy_sha256",
+            _current_source_policy_sha256(),
+        )
+        object.__setattr__(
+            self,
+            "source_identity_recognized",
+            self.identity.is_recognized,
+        )
+        object.__setattr__(
+            self,
+            "source_identity_provenance_capable",
+            self.identity.is_provenance_capable,
+        )
+        object.__setattr__(self, "close", _positive_close(self.close))
+        object.__setattr__(
+            self,
+            "event_at",
+            _aware_utc(self.event_at, "event_at"),
+        )
+        object.__setattr__(
+            self,
+            "available_at",
+            _aware_utc(self.available_at, "available_at"),
+        )
+        object.__setattr__(
+            self,
+            "ingested_at",
+            _aware_utc(self.ingested_at, "ingested_at"),
+        )
+        request_id = _nonempty_text(self.request_id, "request_id")
+        if not _SAFE_REQUEST_ID.fullmatch(request_id):
+            _fail(
+                "INVALID_REQUEST_ID",
+                "request_id must be an opaque identifier without whitespace or query data",
+            )
+        object.__setattr__(self, "request_id", request_id)
+        object.__setattr__(
+            self,
+            "raw_payload_sha256",
+            _sha256_text(self.raw_payload_sha256, "raw_payload_sha256"),
+        )
+        payload_kind = _nonempty_text(
+            self.payload_kind,
+            "payload_kind",
+            lower=True,
+        )
+        if payload_kind not in _PAYLOAD_KINDS:
+            _fail("UNSUPPORTED_PAYLOAD_KIND", f"unsupported payload kind: {payload_kind}")
+        object.__setattr__(self, "payload_kind", payload_kind)
+        availability_basis = _nonempty_text(
+            self.availability_basis,
+            "availability_basis",
+            lower=True,
+        )
+        if availability_basis not in _AVAILABILITY_BASES:
+            _fail(
+                "UNSUPPORTED_AVAILABILITY_BASIS",
+                f"unsupported availability basis: {availability_basis}",
+            )
+        object.__setattr__(self, "availability_basis", availability_basis)
+        if not isinstance(self.is_final, (bool, np.bool_)):
+            raise TypeError("is_final must be a boolean")
+        object.__setattr__(self, "is_final", bool(self.is_final))
+
+        if not self.event_at <= self.available_at <= self.ingested_at:
+            _fail(
+                "INVALID_TIMESTAMP_ORDER",
+                "timestamps must satisfy event_at <= available_at <= ingested_at",
+            )
+
+    @property
+    def instrument(self) -> str:
+        return self.identity.canonical_instrument
+
+    @property
+    def effective_available_at(self) -> pd.Timestamp:
+        return max(self.event_at, self.available_at, self.ingested_at)
+
+    @property
+    def provenance_evidence_failures(self) -> tuple[str, ...]:
+        failures: list[str] = []
+        if not self.source_identity_recognized:
+            failures.append("source_identity_unrecognized")
+        elif not self.source_identity_provenance_capable:
+            failures.append("source_identity_shadow_only")
+        if self.payload_kind != PAYLOAD_PROVIDER_RESPONSE:
+            failures.append("raw_provider_payload_unavailable")
+        if self.availability_basis not in _OBSERVED_AVAILABILITY_BASES:
+            failures.append("availability_historical_assumption")
+        if not self.is_final:
+            failures.append("observation_not_final")
+        return tuple(failures)
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "session": self.session.isoformat(),
+            "identity": self.identity.to_dict(),
+            "close": self.close,
+            "event_at": _iso_utc(self.event_at),
+            "available_at": _iso_utc(self.available_at),
+            "ingested_at": _iso_utc(self.ingested_at),
+            "request_id": self.request_id,
+            "raw_payload_sha256": self.raw_payload_sha256,
+            "payload_kind": self.payload_kind,
+            "availability_basis": self.availability_basis,
+            "is_final": self.is_final,
+            "source_policy": {
+                "version": self.source_policy_version,
+                "sha256": self.source_policy_sha256,
+                "identity_recognized": self.source_identity_recognized,
+                "identity_provenance_capable": (
+                    self.source_identity_provenance_capable
+                ),
+            },
+        }
+
+    @classmethod
+    def from_dict(cls, payload: Mapping[str, Any]) -> "MarketObservation":
+        if "is_final" not in payload:
+            _fail(
+                "MISSING_IS_FINAL",
+                "serialized observations must declare finality explicitly",
+            )
+        observation = cls(
+            session=payload["session"],
+            identity=SourceIdentity.from_dict(payload["identity"]),
+            close=payload["close"],
+            event_at=payload["event_at"],
+            available_at=payload["available_at"],
+            ingested_at=payload["ingested_at"],
+            request_id=payload["request_id"],
+            raw_payload_sha256=payload["raw_payload_sha256"],
+            payload_kind=payload["payload_kind"],
+            availability_basis=payload["availability_basis"],
+            is_final=payload["is_final"],
+        )
+        stored_policy = payload.get("source_policy")
+        expected_policy = {
+            "version": observation.source_policy_version,
+            "sha256": observation.source_policy_sha256,
+            "identity_recognized": observation.source_identity_recognized,
+            "identity_provenance_capable": (
+                observation.source_identity_provenance_capable
+            ),
+        }
+        if stored_policy != expected_policy:
+            _fail(
+                "SOURCE_POLICY_MISMATCH",
+                "stored observation source-policy verdict does not match "
+                "the current versioned policy",
+            )
+        return observation
+
+
+@dataclass(frozen=True)
+class RegimeMarketDataSnapshot:
+    """Exact, immutable SPY/VIX history used for one detector publication."""
+
+    as_of: pd.Timestamp
+    observations: tuple[MarketObservation, ...]
+    schema_version: str = REGIME_DATA_SCHEMA_VERSION
+    source_policy_version: str = field(init=False)
+    source_policy_sha256: str = field(init=False)
+
+    def __post_init__(self) -> None:
+        as_of = _aware_utc(self.as_of, "as_of")
+        object.__setattr__(self, "as_of", as_of)
+        if self.schema_version != REGIME_DATA_SCHEMA_VERSION:
+            _fail(
+                "UNSUPPORTED_SCHEMA",
+                f"unsupported regime data schema: {self.schema_version}",
+            )
+
+        try:
+            observations = tuple(self.observations)
+        except TypeError as exc:
+            raise TypeError("observations must be an iterable") from exc
+        if not observations:
+            _fail("EMPTY_SNAPSHOT", "snapshot has no observations")
+        if not all(isinstance(item, MarketObservation) for item in observations):
+            raise TypeError("every observation must be a MarketObservation")
+        policy_versions = {item.source_policy_version for item in observations}
+        policy_hashes = {item.source_policy_sha256 for item in observations}
+        if len(policy_versions) != 1 or len(policy_hashes) != 1:
+            _fail(
+                "MIXED_SOURCE_POLICY",
+                "all observations must use one source-policy version and hash",
+            )
+        object.__setattr__(
+            self,
+            "source_policy_version",
+            policy_versions.pop(),
+        )
+        object.__setattr__(
+            self,
+            "source_policy_sha256",
+            policy_hashes.pop(),
+        )
+
+        observations = tuple(
+            sorted(
+                observations,
+                key=lambda item: (
+                    item.session,
+                    item.instrument,
+                    item.identity.registry_key,
+                    item.request_id,
+                ),
+            )
+        )
+        object.__setattr__(self, "observations", observations)
+
+        duplicate_keys: set[tuple[str, date]] = set()
+        seen_keys: set[tuple[str, date]] = set()
+        for item in observations:
+            key = (item.instrument, item.session)
+            if key in seen_keys:
+                duplicate_keys.add(key)
+            seen_keys.add(key)
+            if item.ingested_at > as_of:
+                _fail(
+                    "OBSERVATION_AFTER_AS_OF",
+                    f"{item.instrument} {item.session} was ingested after as_of",
+                )
+            if not item.is_final:
+                _fail(
+                    "OBSERVATION_NOT_FINAL",
+                    f"{item.instrument} {item.session} is not final",
+                )
+            if not item.source_identity_recognized:
+                _fail(
+                    "SOURCE_IDENTITY_MISMATCH",
+                    f"unrecognized source identity for {item.instrument}: "
+                    f"{item.identity.registry_key}",
+                )
+        if duplicate_keys:
+            preview = sorted(
+                f"{instrument}:{session.isoformat()}"
+                for instrument, session in duplicate_keys
+            )
+            _fail("DUPLICATE_OBSERVATION", f"duplicate observation keys: {preview[:5]}")
+
+        source_fields: dict[tuple[str, ...], str] = {}
+        for item in observations:
+            previous = source_fields.setdefault(
+                item.identity.source_field_key,
+                item.instrument,
+            )
+            if previous != item.instrument:
+                _fail(
+                    "SOURCE_IDENTITY_COLLISION",
+                    "one provider field cannot represent multiple canonical instruments",
+                )
+
+        sessions = sorted({item.session for item in observations})
+        schedule = regime_market_schedule(sessions[0], sessions[-1])
+        expected_sessions = {
+            session.date()
+            for session in pd.DatetimeIndex(schedule.index)
+        }
+        actual_sessions = set(sessions)
+        if actual_sessions != expected_sessions:
+            missing = sorted(expected_sessions - actual_sessions)
+            unexpected = sorted(actual_sessions - expected_sessions)
+            _fail(
+                "SESSION_COVERAGE_MISMATCH",
+                "snapshot must cover contiguous NYSE sessions; "
+                f"missing={[item.isoformat() for item in missing[:5]]}, "
+                f"unexpected={[item.isoformat() for item in unexpected[:5]]}",
+            )
+
+        for item in observations:
+            event_column = (
+                "spy_event_at"
+                if item.instrument == "SPY"
+                else "vix_event_at"
+            )
+            expected_event = pd.Timestamp(
+                schedule.loc[pd.Timestamp(item.session), event_column]
+            )
+            if item.event_at != expected_event:
+                _fail(
+                    "EVENT_TIME_MISMATCH",
+                    f"{item.instrument} event_at must equal "
+                    f"{expected_event.isoformat()} for session "
+                    f"{item.session.isoformat()}",
+                )
+
+        by_session: dict[date, set[str]] = {}
+        for item in observations:
+            by_session.setdefault(item.session, set()).add(item.instrument)
+        incomplete = {
+            session: sorted(set(REQUIRED_INSTRUMENTS) - instruments)
+            for session, instruments in by_session.items()
+            if instruments != set(REQUIRED_INSTRUMENTS)
+        }
+        if incomplete:
+            preview = {
+                session.isoformat(): missing
+                for session, missing in sorted(incomplete.items())[:5]
+            }
+            _fail(
+                "MISSING_REQUIRED_OBSERVATION",
+                f"each session requires independent SPY and VIX observations: {preview}",
+            )
+
+    @property
+    def schedule_sha256(self) -> str:
+        schedule = regime_market_schedule(
+            self.observations[0].session,
+            self.observations[-1].session,
+        )
+        return _schedule_sha256(schedule)
+
+    @property
+    def provenance_failures(self) -> tuple[str, ...]:
+        failures = {
+            f"{item.instrument}:{item.session.isoformat()}:{failure}"
+            for item in self.observations
+            for failure in item.provenance_evidence_failures
+        }
+        failures.add("SNAPSHOT:durable_raw_payload_unverified")
+        return tuple(sorted(failures))
+
+    @property
+    def provenance_verified(self) -> bool:
+        return not self.provenance_failures
+
+    @property
+    def provenance_evidence_complete(self) -> bool:
+        return not any(
+            item.provenance_evidence_failures
+            for item in self.observations
+        )
+
+    def _canonical_body(self) -> dict[str, Any]:
+        return {
+            "schema_version": self.schema_version,
+            "calendar_policy_version": CALENDAR_POLICY_VERSION,
+            "source_policy_version": self.source_policy_version,
+            "source_policy_sha256": self.source_policy_sha256,
+            "schedule_sha256": self.schedule_sha256,
+            "as_of": _iso_utc(self.as_of),
+            "observations": [item.to_dict() for item in self.observations],
+        }
+
+    @property
+    def snapshot_sha256(self) -> str:
+        return hashlib.sha256(
+            _canonical_json(self._canonical_body()).encode("utf-8")
+        ).hexdigest()
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            **self._canonical_body(),
+            "snapshot_sha256": self.snapshot_sha256,
+        }
+
+    @classmethod
+    def from_dict(cls, payload: Mapping[str, Any]) -> "RegimeMarketDataSnapshot":
+        if not isinstance(payload, Mapping):
+            raise TypeError("snapshot payload must be a mapping")
+        stored_digest = _sha256_text(
+            payload.get("snapshot_sha256"),
+            "snapshot_sha256",
+        )
+        if payload.get("calendar_policy_version") != CALENDAR_POLICY_VERSION:
+            _fail(
+                "UNSUPPORTED_CALENDAR_POLICY",
+                f"unsupported calendar policy: {payload.get('calendar_policy_version')}",
+            )
+        snapshot = cls(
+            as_of=payload["as_of"],
+            observations=tuple(
+                MarketObservation.from_dict(item)
+                for item in payload["observations"]
+            ),
+            schema_version=payload["schema_version"],
+        )
+        if (
+            payload.get("source_policy_version")
+            != snapshot.source_policy_version
+            or payload.get("source_policy_sha256")
+            != snapshot.source_policy_sha256
+        ):
+            _fail(
+                "SOURCE_POLICY_MISMATCH",
+                "stored snapshot source policy does not match its observations",
+            )
+        if payload.get("schedule_sha256") != snapshot.schedule_sha256:
+            _fail(
+                "SCHEDULE_CHECKSUM_MISMATCH",
+                "stored calendar schedule checksum does not match observations",
+            )
+        if stored_digest != snapshot.snapshot_sha256:
+            _fail(
+                "SNAPSHOT_CHECKSUM_MISMATCH",
+                "stored snapshot checksum does not match canonical contents",
+            )
+        return snapshot
+
+    def to_json(self) -> str:
+        return _canonical_json(self.to_dict())
+
+    def detector_inputs(self) -> dict[str, Any]:
+        """Return the exact low-level arguments accepted by the V2 detector."""
+
+        sessions = sorted({item.session for item in self.observations})
+        index = pd.DatetimeIndex(sessions)
+        observations = {
+            (item.instrument, item.session): item
+            for item in self.observations
+        }
+        prices = pd.DataFrame(
+            {
+                "SPY_Close": [
+                    observations[("SPY", session)].close
+                    for session in sessions
+                ],
+                "VIX_Close": [
+                    observations[("VIX", session)].close
+                    for session in sessions
+                ],
+            },
+            index=index,
+        )
+        spy_available_at = pd.Series(
+            [
+                observations[("SPY", session)].effective_available_at
+                for session in sessions
+            ],
+            index=index,
+            name="spy_available_at",
+        )
+        vix_available_at = pd.Series(
+            [
+                observations[("VIX", session)].effective_available_at
+                for session in sessions
+            ],
+            index=index,
+            name="vix_available_at",
+        )
+        return {
+            "prices": prices,
+            "as_of": self.as_of,
+            "spy_available_at": spy_available_at,
+            "vix_available_at": vix_available_at,
+            "source_provenance_verified": self.provenance_verified,
+        }
+
+    def source_metadata_frame(self) -> pd.DataFrame:
+        """Return per-session provenance columns for detector/audit output."""
+
+        rows: dict[pd.Timestamp, dict[str, Any]] = {}
+        for item in self.observations:
+            prefix = item.instrument
+            row = rows.setdefault(pd.Timestamp(item.session), {})
+            row[f"{prefix}_Provider"] = item.identity.provider
+            row[f"{prefix}_Dataset"] = item.identity.dataset
+            row[f"{prefix}_Provider_Symbol"] = item.identity.provider_symbol
+            row[f"{prefix}_Event_At"] = item.event_at
+            row[f"{prefix}_Available_At"] = item.available_at
+            row[f"{prefix}_Ingested_At"] = item.ingested_at
+            row[f"{prefix}_Request_ID"] = item.request_id
+            row[f"{prefix}_Raw_Payload_SHA256"] = item.raw_payload_sha256
+            row[f"{prefix}_Payload_Kind"] = item.payload_kind
+            row[f"{prefix}_Availability_Basis"] = item.availability_basis
+        return pd.DataFrame.from_dict(rows, orient="index").sort_index()
+
+
+def load_snapshot_json(text: str | bytes) -> RegimeMarketDataSnapshot:
+    """Load and verify a canonical snapshot JSON document."""
+
+    if isinstance(text, bytes):
+        try:
+            text = text.decode("utf-8")
+        except UnicodeDecodeError as exc:
+            raise RegimeMarketDataError(
+                "INVALID_SNAPSHOT_ENCODING",
+                "snapshot must be UTF-8",
+            ) from exc
+    if not isinstance(text, str):
+        raise TypeError("snapshot JSON must be str or bytes")
+    try:
+        payload = json.loads(text)
+    except json.JSONDecodeError as exc:
+        raise RegimeMarketDataError(
+            "INVALID_SNAPSHOT_JSON",
+            "snapshot is not valid JSON",
+        ) from exc
+    return RegimeMarketDataSnapshot.from_dict(payload)

--- a/etrade_python_client/scratch/regime_detector_v2_audit.py
+++ b/etrade_python_client/scratch/regime_detector_v2_audit.py
@@ -1,36 +1,65 @@
 """Read-only audit for the causal two-timescale regime detector.
 
-The script combines the longer local SPY/VIX Parquet history with the fresher
-dashboard cache, preferring the dashboard value on overlapping dates.  It never
-downloads or writes data.
+The source-free legacy caches are wrapped in an explicitly unverified snapshot.
+That preserves their usefulness for research replay without allowing normalized
+local artifacts or assumed timestamps to masquerade as production provenance.
+The script never downloads or writes data.
 """
 
+import hashlib
 import json
 from pathlib import Path
 import sys
 
 import numpy as np
 import pandas as pd
-import pandas_market_calendars as mcal
 
 
 PROJECT_ROOT = Path(__file__).resolve().parents[1]
 if str(PROJECT_ROOT) not in sys.path:
     sys.path.insert(0, str(PROJECT_ROOT))
 
-from live_trading.regime_detector_v2 import RegimeDetectorConfig, detect_regimes
+from live_trading.regime_detector_v2 import (
+    RegimeDetectorConfig,
+    detect_regimes_from_snapshot,
+)
+from live_trading.regime_market_data import (
+    AVAILABILITY_HISTORICAL_ASSUMPTION,
+    PAYLOAD_NORMALIZED_ONLY,
+    MarketObservation,
+    RegimeMarketDataSnapshot,
+    SourceIdentity,
+    regime_market_schedule,
+)
 
-NYSE = mcal.get_calendar("NYSE")
+SPY_LEGACY_IDENTITY = SourceIdentity(
+    provider="local_artifact",
+    dataset="derived_cache",
+    provider_symbol="SPY",
+    canonical_instrument="SPY",
+    field="close",
+    adjustment="unknown",
+    unit="usd",
+)
+VIX_LEGACY_IDENTITY = SourceIdentity(
+    provider="local_artifact",
+    dataset="derived_cache",
+    provider_symbol="VIX",
+    canonical_instrument="VIX",
+    field="close",
+    adjustment="unknown",
+    unit="index_points",
+)
 
 
-def _load_prices() -> tuple[pd.DataFrame, pd.Timestamp, pd.DataFrame]:
+def _load_prices() -> tuple[pd.DataFrame, pd.DataFrame, pd.DataFrame]:
     spy_path = PROJECT_ROOT / "s_and_p_data" / "api_cache" / "SPY.parquet"
     vix_path = PROJECT_ROOT / "s_and_p_data" / "api_cache" / "INDEX_VIX.parquet"
     live_path = PROJECT_ROOT / "spy_vix_price_cache.json"
 
     spy = pd.read_parquet(spy_path)["Close"].rename("SPY_Close")
     vix = pd.read_parquet(vix_path)["Close"].rename("VIX_Close")
-    historical = pd.concat([spy, vix], axis=1)
+    historical = pd.concat([spy, vix], axis=1).sort_index()
 
     with live_path.open("r", encoding="utf-8") as handle:
         cache = json.load(handle)
@@ -43,26 +72,119 @@ def _load_prices() -> tuple[pd.DataFrame, pd.Timestamp, pd.DataFrame]:
     )
     live.index = pd.to_datetime(live.index)
 
+    conflicts = []
+    for column in ("SPY_Close", "VIX_Close"):
+        overlap = pd.concat(
+            [
+                historical[column].rename("parquet"),
+                live[column].rename("dashboard_cache"),
+            ],
+            axis=1,
+            join="inner",
+        ).dropna()
+        mismatch = overlap[
+            ~np.isclose(
+                overlap["parquet"],
+                overlap["dashboard_cache"],
+                rtol=0.0,
+                atol=0.005,
+            )
+        ].copy()
+        mismatch = mismatch.reset_index(names="session")
+        mismatch["instrument"] = column.removesuffix("_Close")
+        mismatch["absolute_difference"] = (
+            mismatch["dashboard_cache"] - mismatch["parquet"]
+        ).abs()
+        conflicts.append(mismatch)
+    conflicts = (
+        pd.concat(conflicts, ignore_index=True).sort_values(["session", "instrument"])
+        if conflicts
+        else pd.DataFrame()
+    )
+
+    # This precedence reproduces the old audit for comparison only.  The
+    # resulting snapshot remains explicitly unverified and execution-ineligible.
     combined = pd.concat([historical, live]).sort_index()
     combined = combined[~combined.index.duplicated(keep="last")]
 
     observed_rows = combined.dropna(how="all")
-    full_schedule = NYSE.schedule(
-        start_date=observed_rows.index.min(),
-        end_date=observed_rows.index.max(),
+    full_schedule = regime_market_schedule(
+        observed_rows.index.min().date(),
+        observed_rows.index.max().date(),
     )
     full_sessions = pd.DatetimeIndex(full_schedule.index).tz_localize(None).normalize()
     unexpected = observed_rows.index.difference(full_sessions)
     quarantined = observed_rows.loc[unexpected].copy()
 
     common_start = max(combined[column].first_valid_index() for column in combined.columns)
-    common_end = max(combined[column].last_valid_index() for column in combined.columns)
-    common_schedule = NYSE.schedule(start_date=common_start, end_date=common_end)
+    common_end = min(combined[column].last_valid_index() for column in combined.columns)
+    common_schedule = regime_market_schedule(
+        common_start.date(),
+        common_end.date(),
+    )
     common_sessions = pd.DatetimeIndex(common_schedule.index).tz_localize(None).normalize()
     combined = combined.reindex(common_sessions)
+    if combined.isna().any().any():
+        missing = combined[combined.isna().any(axis=1)].index
+        raise ValueError(
+            "Legacy replay has missing SPY/VIX sessions: "
+            f"{[item.date().isoformat() for item in missing[:5]]}"
+        )
 
-    file_modified_at = pd.Timestamp(live_path.stat().st_mtime, unit="s", tz="UTC")
-    return combined, file_modified_at, quarantined
+    return combined, quarantined, conflicts
+
+
+def _legacy_snapshot(prices: pd.DataFrame) -> RegimeMarketDataSnapshot:
+    schedule = regime_market_schedule(
+        prices.index.min().date(),
+        prices.index.max().date(),
+    )
+    observations = []
+    for session, row in prices.iterrows():
+        session_date = session.date()
+        clocks = schedule.loc[session]
+        for identity, close, event_column in (
+            (SPY_LEGACY_IDENTITY, row["SPY_Close"], "spy_event_at"),
+            (VIX_LEGACY_IDENTITY, row["VIX_Close"], "vix_event_at"),
+        ):
+            event_at = pd.Timestamp(clocks[event_column])
+            normalized_payload = json.dumps(
+                {
+                    "instrument": identity.canonical_instrument,
+                    "session": session_date.isoformat(),
+                    "selected_close": float(close),
+                    "source_class": "legacy_derived_artifact",
+                },
+                sort_keys=True,
+                separators=(",", ":"),
+            ).encode("utf-8")
+            observations.append(
+                MarketObservation(
+                    session=session_date,
+                    identity=identity,
+                    close=close,
+                    event_at=event_at,
+                    available_at=event_at,
+                    ingested_at=event_at,
+                    request_id=(
+                        f"legacy-replay:{identity.canonical_instrument.lower()}:"
+                        f"{session_date.isoformat()}"
+                    ),
+                    raw_payload_sha256=hashlib.sha256(
+                        normalized_payload
+                    ).hexdigest(),
+                    payload_kind=PAYLOAD_NORMALIZED_ONLY,
+                    availability_basis=AVAILABILITY_HISTORICAL_ASSUMPTION,
+                    is_final=True,
+                )
+            )
+    as_of = pd.Timestamp(
+        schedule.loc[prices.index.max(), "joint_finalization_at"]
+    ) + pd.Timedelta(minutes=1)
+    return RegimeMarketDataSnapshot(
+        as_of=as_of,
+        observations=tuple(observations),
+    )
 
 
 def _legacy_overlay(prices: pd.DataFrame) -> pd.Series:
@@ -108,43 +230,11 @@ def _term_structure_cache_status() -> str:
     return f"not_identically_copied; VIX3M ends {vix3m.index.max().date()}"
 
 
-def _availability_proxies(
-    prices: pd.DataFrame,
-    file_modified_at: pd.Timestamp,
-) -> tuple[pd.Series, pd.Series]:
-    schedule = NYSE.schedule(start_date=prices.index.min(), end_date=prices.index.max())
-    sessions = pd.DatetimeIndex(schedule.index).tz_localize(None).normalize()
-    spy_available_at = pd.Series(
-        pd.DatetimeIndex(schedule["market_close"]) + pd.Timedelta(minutes=1),
-        index=sessions,
-    )
-    vix_available_at = pd.Series(
-        (
-            sessions.tz_localize("America/New_York")
-            + pd.Timedelta(hours=16, minutes=16)
-        ).tz_convert("UTC"),
-        index=sessions,
-    )
-    spy_available_at.iloc[-1] = max(spy_available_at.iloc[-1], file_modified_at)
-    vix_available_at.iloc[-1] = max(vix_available_at.iloc[-1], file_modified_at)
-    return spy_available_at, vix_available_at
-
-
 def main():
-    prices, file_modified_at, quarantined = _load_prices()
+    prices, quarantined, conflicts = _load_prices()
     config = RegimeDetectorConfig()
-    spy_available_at, vix_available_at = _availability_proxies(
-        prices,
-        file_modified_at,
-    )
-    result = detect_regimes(
-        prices,
-        config,
-        as_of=pd.Timestamp.now(tz="UTC"),
-        spy_available_at=spy_available_at,
-        vix_available_at=vix_available_at,
-        source_provenance_verified=False,
-    )
+    snapshot = _legacy_snapshot(prices)
+    result = detect_regimes_from_snapshot(snapshot, config)
     result["Legacy_Overlay"] = _legacy_overlay(prices)
 
     print("CAUSAL SHADOW AUDIT")
@@ -160,12 +250,26 @@ def main():
     print(f"Threshold status: {result.attrs['threshold_status']}")
     print(f"Signal time: {result.attrs['regime_signal_timestamp']}")
     print(f"As-of: {result.attrs['as_of']}")
-    print(f"SPY available-at proxy: {result.attrs['spy_available_at']}")
-    print(f"VIX available-at proxy: {result.attrs['vix_available_at']}")
+    print(f"Input snapshot SHA-256: {snapshot.snapshot_sha256}")
+    print(f"Calendar schedule SHA-256: {snapshot.schedule_sha256}")
+    print(f"Input schema: {snapshot.schema_version}")
+    print(
+        "Source policy: "
+        f"{snapshot.source_policy_version} / {snapshot.source_policy_sha256}"
+    )
     print(
         "Source provenance: UNVERIFIED "
-        "(nominal historical cutoffs; latest filesystem mtime proxy)"
+        "(normalized legacy artifacts; historical finalization assumptions)"
     )
+    print(
+        "Provenance failure codes: "
+        f"{result.attrs['input_provenance_failure_codes']}"
+    )
+    print(
+        "Provenance metadata complete: "
+        f"{result.attrs['input_provenance_evidence_complete']}"
+    )
+    print(f"Execution eligible: {result.attrs['execution_eligible']}")
     print(
         "Latest jointly finalized session: "
         f"{result.attrs['latest_jointly_finalized_session']}"
@@ -173,6 +277,10 @@ def main():
     print(
         "Quarantined non-NYSE source rows: "
         f"{quarantined.to_dict(orient='index') if len(quarantined) else 'none'}"
+    )
+    print(
+        "Conflicting overlapping legacy values: "
+        f"{conflicts.to_dict(orient='records') if len(conflicts) else 'none'}"
     )
     print("Regime lag for trade entry: one trading session required")
     print("Return buckets: not used by this detector")

--- a/etrade_python_client/tests/test_dashboard_quotes.py
+++ b/etrade_python_client/tests/test_dashboard_quotes.py
@@ -49,7 +49,7 @@ class DashboardQuoteTests(unittest.TestCase):
                 }]
             }
         })
-        accounts = Accounts(session, "https://api.etrade.com")
+        accounts = Accounts(session, "https://api.etrade.com", consumer_key="")
 
         prices, metadata = accounts.get_stock_prices(["SPX"], include_metadata=True)
 
@@ -132,7 +132,7 @@ class DashboardQuoteTests(unittest.TestCase):
                 "AccountPortfolio": [],
             }
         })
-        accounts = Accounts(expired_session, "https://api.etrade.test")
+        accounts = Accounts(expired_session, "https://api.etrade.test", consumer_key="")
         accounts.account = {"accountIdKey": "account-key"}
         accounts.auth_refresh_callback = lambda reason: (
             refreshed_session,
@@ -149,11 +149,24 @@ class DashboardQuoteTests(unittest.TestCase):
         session = _Session(responses=[
             _Response({}, status_code=401, text="oauth_problem=token_rejected"),
         ])
-        accounts = Accounts(session, "https://api.etrade.test")
+        accounts = Accounts(session, "https://api.etrade.test", consumer_key="")
         accounts.account = {"accountIdKey": "account-key"}
 
         with self.assertRaisesRegex(RuntimeError, "status code 401"):
             accounts.portfolio(require_success=True)
+
+    def test_consumer_key_is_required_only_for_calls_that_use_its_header(self):
+        session = _Session({})
+        accounts = Accounts(
+            session,
+            "https://api.etrade.test",
+            consumer_key="",
+        )
+
+        with self.assertRaisesRegex(RuntimeError, "Missing E\\*TRADE production consumer key"):
+            accounts.check_earning_date(SimpleNamespace(symbol="SPY"))
+
+        self.assertEqual(session.calls, [])
 
 
 if __name__ == "__main__":

--- a/etrade_python_client/tests/test_regime_detector_v2.py
+++ b/etrade_python_client/tests/test_regime_detector_v2.py
@@ -64,7 +64,7 @@ def _context(prices):
         "spy_available_at": spy_available_at,
         "vix_available_at": vix_available_at,
         "as_of": signal_available_at + pd.Timedelta(minutes=1),
-        "source_provenance_verified": True,
+        "source_provenance_verified": False,
     }
 
 
@@ -143,7 +143,7 @@ class RegimeDetectorV2Tests(unittest.TestCase):
                 as_of=pd.Timestamp("2025-01-03T22:00:00Z"),
                 spy_available_at=pd.Series(dtype="object"),
                 vix_available_at=pd.Series(dtype="object"),
-                source_provenance_verified=True,
+                source_provenance_verified=False,
             )
 
         prices = _calm_prices()
@@ -167,7 +167,7 @@ class RegimeDetectorV2Tests(unittest.TestCase):
                 as_of=weekend_date.tz_localize("UTC") + pd.Timedelta(days=2),
                 spy_available_at=weekend_date.tz_localize("UTC"),
                 vix_available_at=weekend_date.tz_localize("UTC"),
-                source_provenance_verified=True,
+                source_provenance_verified=False,
             )
 
     def test_missing_interior_nyse_session_fails_closed(self):
@@ -185,7 +185,8 @@ class RegimeDetectorV2Tests(unittest.TestCase):
         self.assertEqual(result.attrs["regime_signal_timestamp"], SIGNAL_TIMESTAMP)
         self.assertEqual(result.attrs["detector_version"], DETECTOR_VERSION)
         self.assertEqual(len(result.attrs["config_hash"]), 64)
-        self.assertTrue(result.attrs["freshness_assessed"])
+        self.assertFalse(result.attrs["freshness_assessed"])
+        self.assertFalse(result.attrs["execution_eligible"])
         self.assertEqual(
             result.attrs["latest_jointly_finalized_session"],
             prices.index.max().date().isoformat(),
@@ -236,19 +237,19 @@ class RegimeDetectorV2Tests(unittest.TestCase):
                 as_of=context["as_of"],
                 spy_available_at=premature_spy,
                 vix_available_at=context["vix_available_at"],
-                source_provenance_verified=True,
+                source_provenance_verified=False,
             )
 
         premature_vix = context["vix_available_at"].copy()
         premature_vix.iloc[-1] -= pd.Timedelta(minutes=2)
-        with self.assertRaisesRegex(ValueError, "before the Cboe 4:15 p.m. ET cutoff"):
+        with self.assertRaisesRegex(ValueError, "before the official Cboe close"):
             detect_regimes(
                 prices,
                 _config(),
                 as_of=context["as_of"],
                 spy_available_at=context["spy_available_at"],
                 vix_available_at=premature_vix,
-                source_provenance_verified=True,
+                source_provenance_verified=False,
             )
 
     def test_latest_session_is_not_available_at_401_pm_eastern(self):
@@ -270,7 +271,7 @@ class RegimeDetectorV2Tests(unittest.TestCase):
                 as_of=as_of,
                 spy_available_at=spy_available_at,
                 vix_available_at=vix_available_at,
-                source_provenance_verified=True,
+                source_provenance_verified=False,
             )
 
     def test_unverified_source_provenance_is_explicit(self):
@@ -307,7 +308,7 @@ class RegimeDetectorV2Tests(unittest.TestCase):
             as_of=delayed_arrival + pd.Timedelta(minutes=1),
             spy_available_at=spy_available_at,
             vix_available_at=vix_available_at,
-            source_provenance_verified=True,
+            source_provenance_verified=False,
         )
 
         expected = pd.Timestamp(following.index[1]).tz_localize(None).normalize()
@@ -335,7 +336,7 @@ class RegimeDetectorV2Tests(unittest.TestCase):
             as_of=delayed_arrival + pd.Timedelta(minutes=1),
             spy_available_at=spy_available_at,
             vix_available_at=vix_available_at,
-            source_provenance_verified=True,
+            source_provenance_verified=False,
         )
 
         expected = pd.Timestamp(following.index[1]).tz_localize(None).normalize()
@@ -355,6 +356,17 @@ class RegimeDetectorV2Tests(unittest.TestCase):
         self.assertEqual(result.iloc[-1]["Tradable_Session"], expected)
         self.assertIsNotNone(pd.Timestamp(result.iloc[-1]["Market_Close_At"]).tzinfo)
         self.assertIsNotNone(pd.Timestamp(result.iloc[-1]["VIX_Finalization_At"]).tzinfo)
+
+    def test_loose_arrays_cannot_claim_verified_provenance(self):
+        prices = _calm_prices()
+        context = _context(prices)
+        context["source_provenance_verified"] = True
+
+        with self.assertRaisesRegex(
+            ValueError,
+            "Verified provenance requires RegimeMarketDataSnapshot",
+        ):
+            detect_regimes(prices, _config(), **context)
 
 
 if __name__ == "__main__":

--- a/etrade_python_client/tests/test_regime_evidence_store.py
+++ b/etrade_python_client/tests/test_regime_evidence_store.py
@@ -1,0 +1,841 @@
+import dataclasses
+import hashlib
+import json
+import os
+import sqlite3
+import tempfile
+import unittest
+from datetime import date
+from pathlib import Path
+
+import pandas as pd
+
+from live_trading.regime_evidence_store import (
+    SCHEMA_VERSION,
+    RegimeEvidenceIntegrityError,
+    RegimeEvidenceStore,
+    RegimeEvidenceStoreError,
+)
+from live_trading.regime_market_data import (
+    AVAILABILITY_PROVIDER_TIMESTAMP,
+    PAYLOAD_PROVIDER_RESPONSE,
+    MarketObservation,
+    RegimeMarketDataSnapshot,
+    SourceIdentity,
+    regime_market_schedule,
+)
+
+
+SPY_IDENTITY = SourceIdentity(
+    provider="yahoo",
+    dataset="daily_prices",
+    provider_symbol="SPY",
+    canonical_instrument="SPY",
+    field="close",
+    adjustment="unadjusted",
+    unit="USD",
+)
+VIX_IDENTITY = SourceIdentity(
+    provider="cboe",
+    dataset="vix_daily",
+    provider_symbol="VIX",
+    canonical_instrument="VIX",
+    field="close",
+    adjustment="none",
+    unit="index_points",
+)
+SESSIONS = (
+    date(2025, 3, 6),
+    date(2025, 3, 7),
+    date(2025, 3, 10),
+)
+
+
+def _observation(session, identity, close, *, ingested_at=None):
+    schedule = regime_market_schedule(session, session)
+    row = schedule.loc[pd.Timestamp(session)]
+    event_at = pd.Timestamp(
+        row[
+            "spy_event_at"
+            if identity.canonical_instrument == "SPY"
+            else "vix_event_at"
+        ]
+    )
+    ingestion_time = (
+        pd.Timestamp(ingested_at)
+        if ingested_at is not None
+        else event_at + pd.Timedelta(minutes=2)
+    )
+    raw_payload = (
+        f"{identity.provider}|{identity.dataset}|{identity.provider_symbol}|"
+        f"{session.isoformat()}|{close}"
+    ).encode("utf-8")
+    return MarketObservation(
+        session=session,
+        identity=identity,
+        close=float(close),
+        event_at=event_at,
+        available_at=event_at + pd.Timedelta(minutes=1),
+        ingested_at=ingestion_time,
+        request_id=(
+            f"{identity.provider}:{session.isoformat()}:{close}:"
+            f"{ingestion_time.strftime('%Y%m%dT%H%M%SZ')}"
+        ),
+        raw_payload_sha256=hashlib.sha256(raw_payload).hexdigest(),
+        payload_kind=PAYLOAD_PROVIDER_RESPONSE,
+        availability_basis=AVAILABILITY_PROVIDER_TIMESTAMP,
+        is_final=True,
+    )
+
+
+def _all_observations(close_offset=0.0):
+    observations = []
+    for position, session in enumerate(SESSIONS):
+        observations.extend(
+            (
+                _observation(
+                    session,
+                    SPY_IDENTITY,
+                    500.0 + position + close_offset,
+                ),
+                _observation(
+                    session,
+                    VIX_IDENTITY,
+                    16.0 + position + close_offset,
+                ),
+            )
+        )
+    return tuple(observations)
+
+
+def _snapshot(*, as_of=None, close_offset=0.0):
+    observations = _all_observations(close_offset)
+    snapshot_as_of = (
+        pd.Timestamp(as_of)
+        if as_of is not None
+        else max(item.ingested_at for item in observations)
+        + pd.Timedelta(minutes=1)
+    )
+    return RegimeMarketDataSnapshot(
+        as_of=snapshot_as_of,
+        observations=observations,
+    )
+
+
+class RegimeEvidenceStoreTests(unittest.TestCase):
+    def setUp(self):
+        self.temp_dir = tempfile.TemporaryDirectory()
+        self.db_path = Path(self.temp_dir.name) / "regime_evidence.sqlite3"
+
+    def tearDown(self):
+        self.temp_dir.cleanup()
+
+    def _record_spy_success(self, store, close_offset=0.0):
+        attempted_at = pd.Timestamp("2025-03-10T20:30:00Z")
+        attempt_id = store.begin_attempt(
+            "yahoo",
+            "SPY",
+            SESSIONS[0],
+            SESSIONS[-1],
+            attempted_at,
+        )
+        observations = tuple(
+            _observation(
+                session,
+                SPY_IDENTITY,
+                500.0 + position + close_offset,
+                ingested_at=attempted_at + pd.Timedelta(seconds=30),
+            )
+            for position, session in enumerate(SESSIONS)
+        )
+        store.record_success(
+            attempt_id,
+            attempted_at + pd.Timedelta(minutes=1),
+            observations,
+        )
+        return attempt_id
+
+    def test_schema_quick_check_and_file_permissions(self):
+        with RegimeEvidenceStore(self.db_path) as store:
+            self.assertTrue(store.quick_check())
+            user_version = store._connection.execute(
+                "PRAGMA user_version"
+            ).fetchone()[0]
+            self.assertEqual(
+                store._connection.execute("PRAGMA journal_mode").fetchone()[0],
+                "wal",
+            )
+            self.assertEqual(
+                store._connection.execute("PRAGMA synchronous").fetchone()[0],
+                2,
+            )
+            self.assertEqual(
+                store._connection.execute("PRAGMA foreign_keys").fetchone()[0],
+                1,
+            )
+            self.assertEqual(
+                store._connection.execute("PRAGMA busy_timeout").fetchone()[0],
+                5_000,
+            )
+            tables = {
+                row[0]
+                for row in store._connection.execute(
+                    """
+                    SELECT name
+                    FROM sqlite_master
+                    WHERE type = 'table'
+                    """
+                )
+            }
+
+        self.assertEqual(user_version, SCHEMA_VERSION)
+        self.assertTrue(
+            {
+                "source_attempts",
+                "source_state",
+                "market_observations",
+                "regime_input_snapshots",
+                "regime_snapshot_publications",
+            }.issubset(tables)
+        )
+        self.assertEqual(os.stat(self.db_path).st_mode & 0o777, 0o600)
+
+    def test_failure_preserves_last_success_observations_and_snapshot(self):
+        with RegimeEvidenceStore(self.db_path) as store:
+            successful_attempt = self._record_spy_success(store)
+            snapshot_sha256 = store.publish_snapshot(_snapshot())
+            observation_count = store._connection.execute(
+                "SELECT COUNT(*) FROM market_observations"
+            ).fetchone()[0]
+
+            failed_attempt = store.begin_attempt(
+                "yahoo",
+                "SPY",
+                SESSIONS[0],
+                SESSIONS[-1],
+                pd.Timestamp("2025-03-10T21:00:00Z"),
+            )
+            store.record_failure(
+                failed_attempt,
+                pd.Timestamp("2025-03-10T21:01:00Z"),
+                "upstream_timeout",
+                "The provider did not complete the request",
+            )
+
+            health = store.source_health("yahoo", "SPY")
+            self.assertEqual(health["last_attempt_id"], failed_attempt)
+            self.assertEqual(health["last_attempt_status"], "failure")
+            self.assertEqual(health["last_success_id"], successful_attempt)
+            self.assertEqual(health["last_error_code"], "upstream_timeout")
+            self.assertEqual(
+                store._connection.execute(
+                    "SELECT COUNT(*) FROM market_observations"
+                ).fetchone()[0],
+                observation_count,
+            )
+            self.assertEqual(
+                store.latest_snapshot().snapshot_sha256,
+                snapshot_sha256,
+            )
+
+    def test_tampered_snapshot_fails_closed(self):
+        with RegimeEvidenceStore(self.db_path) as store:
+            snapshot = _snapshot()
+            snapshot_sha256 = store.publish_snapshot(snapshot)
+            payload = json.loads(snapshot.to_json())
+            payload["observations"][0]["close"] += 1.0
+            tampered_json = json.dumps(
+                payload,
+                sort_keys=True,
+                separators=(",", ":"),
+            )
+            store._connection.execute(
+                """
+                UPDATE regime_input_snapshots
+                SET snapshot_json = ?
+                WHERE snapshot_sha256 = ?
+                """,
+                (tampered_json, snapshot_sha256),
+            )
+
+            with self.assertRaises(RegimeEvidenceIntegrityError):
+                store.load_snapshot(snapshot_sha256)
+            with self.assertRaises(RegimeEvidenceIntegrityError):
+                store.latest_snapshot()
+
+    def test_snapshot_publication_is_idempotent(self):
+        with RegimeEvidenceStore(self.db_path) as store:
+            snapshot = _snapshot()
+            first = store.publish_snapshot(snapshot)
+            second = store.publish_snapshot(snapshot)
+            shadow = store.publish_snapshot(snapshot, channel="shadow")
+
+            self.assertEqual(first, second)
+            self.assertEqual(first, shadow)
+            self.assertEqual(
+                store._connection.execute(
+                    "SELECT COUNT(*) FROM regime_input_snapshots"
+                ).fetchone()[0],
+                1,
+            )
+            publications = store._connection.execute(
+                """
+                SELECT channel
+                FROM regime_snapshot_publications
+                ORDER BY publication_sequence
+                """
+            ).fetchall()
+            self.assertEqual(
+                [row["channel"] for row in publications],
+                ["research", "shadow"],
+            )
+            self.assertEqual(
+                store.load_snapshot(first).to_json(),
+                snapshot.to_json(),
+            )
+            self.assertEqual(
+                store.latest_snapshot("shadow").snapshot_sha256,
+                first,
+            )
+
+    def test_later_published_older_backfill_does_not_regress_channel(self):
+        older = _snapshot(close_offset=1.0)
+        newer = _snapshot(
+            as_of=older.as_of + pd.Timedelta(days=1),
+            close_offset=2.0,
+        )
+        with RegimeEvidenceStore(self.db_path) as store:
+            newer_sha256 = store.publish_snapshot(newer)
+            store.publish_snapshot(older)
+
+            self.assertEqual(
+                store.latest_snapshot().snapshot_sha256,
+                newer_sha256,
+            )
+
+    def test_latest_snapshot_orders_fractional_seconds_correctly(self):
+        older = _snapshot(
+            as_of="2025-03-10T22:00:00.000000100Z",
+            close_offset=1.0,
+        )
+        newer = _snapshot(
+            as_of="2025-03-10T22:00:00.000000900Z",
+            close_offset=2.0,
+        )
+        with RegimeEvidenceStore(self.db_path) as store:
+            newer_sha256 = store.publish_snapshot(newer)
+            store.publish_snapshot(older)
+
+            self.assertEqual(
+                store.latest_snapshot().snapshot_sha256,
+                newer_sha256,
+            )
+
+    def test_equal_as_of_uses_latest_channel_publication(self):
+        first = _snapshot(close_offset=1.0)
+        second = _snapshot(
+            as_of=first.as_of,
+            close_offset=2.0,
+        )
+        with RegimeEvidenceStore(self.db_path) as store:
+            store.publish_snapshot(first)
+            second_sha256 = store.publish_snapshot(second)
+
+            self.assertEqual(
+                store.latest_snapshot().snapshot_sha256,
+                second_sha256,
+            )
+
+    def test_latest_snapshot_is_channel_scoped(self):
+        research = _snapshot(close_offset=1.0)
+        shadow = _snapshot(close_offset=2.0)
+        with RegimeEvidenceStore(self.db_path) as store:
+            research_sha256 = store.publish_snapshot(
+                research,
+                channel="research",
+            )
+            shadow_sha256 = store.publish_snapshot(
+                shadow,
+                channel="shadow",
+            )
+
+            self.assertEqual(
+                store.latest_snapshot("research").snapshot_sha256,
+                research_sha256,
+            )
+            self.assertEqual(
+                store.latest_snapshot("shadow").snapshot_sha256,
+                shadow_sha256,
+            )
+
+    def test_snapshot_channel_must_be_research_or_shadow(self):
+        with RegimeEvidenceStore(self.db_path) as store:
+            with self.assertRaisesRegex(ValueError, "channel must be one of"):
+                store.publish_snapshot(_snapshot(), channel="production")
+            with self.assertRaisesRegex(ValueError, "channel must be one of"):
+                store.latest_snapshot("production")
+
+            self.assertEqual(
+                store._connection.execute(
+                    "SELECT COUNT(*) FROM regime_input_snapshots"
+                ).fetchone()[0],
+                0,
+            )
+
+    def test_corrected_observation_appends_a_revision(self):
+        with RegimeEvidenceStore(self.db_path) as store:
+            first_attempt = store.begin_attempt(
+                "yahoo",
+                "SPY",
+                SESSIONS[0],
+                SESSIONS[0],
+                pd.Timestamp("2025-03-06T21:03:00Z"),
+            )
+            store.record_success(
+                first_attempt,
+                pd.Timestamp("2025-03-06T21:04:00Z"),
+                (
+                    _observation(
+                        SESSIONS[0],
+                        SPY_IDENTITY,
+                        500.0,
+                        ingested_at=pd.Timestamp("2025-03-06T21:03:30Z"),
+                    ),
+                ),
+            )
+            second_attempt = store.begin_attempt(
+                "yahoo",
+                "SPY",
+                SESSIONS[0],
+                SESSIONS[0],
+                pd.Timestamp("2025-03-06T22:00:00Z"),
+            )
+            store.record_success(
+                second_attempt,
+                pd.Timestamp("2025-03-06T22:01:00Z"),
+                (
+                    _observation(
+                        SESSIONS[0],
+                        SPY_IDENTITY,
+                        500.5,
+                        ingested_at=pd.Timestamp("2025-03-06T22:00:30Z"),
+                    ),
+                ),
+            )
+
+            revisions = store._connection.execute(
+                """
+                SELECT revision, close_value
+                FROM market_observations
+                WHERE provider = 'yahoo' AND instrument = 'SPY'
+                  AND session_date = ?
+                ORDER BY revision
+                """,
+                (SESSIONS[0].isoformat(),),
+            ).fetchall()
+
+            self.assertEqual(
+                [(row["revision"], row["close_value"]) for row in revisions],
+                [(1, "500.0"), (2, "500.5")],
+            )
+            self.assertEqual(
+                store.source_health("yahoo", "SPY")["last_success_id"],
+                second_attempt,
+            )
+
+    def test_old_observation_replay_cannot_be_a_fresh_success(self):
+        observation = _observation(
+            SESSIONS[0],
+            SPY_IDENTITY,
+            500.0,
+            ingested_at=pd.Timestamp("2025-03-06T21:03:30Z"),
+        )
+        with RegimeEvidenceStore(self.db_path) as store:
+            first_attempt = store.begin_attempt(
+                "yahoo",
+                "SPY",
+                SESSIONS[0],
+                SESSIONS[0],
+                pd.Timestamp("2025-03-06T21:03:00Z"),
+            )
+            store.record_success(
+                first_attempt,
+                pd.Timestamp("2025-03-06T21:04:00Z"),
+                (observation,),
+            )
+            second_attempt = store.begin_attempt(
+                "yahoo",
+                "SPY",
+                SESSIONS[0],
+                SESSIONS[0],
+                pd.Timestamp("2025-03-06T22:00:00Z"),
+            )
+
+            with self.assertRaisesRegex(
+                ValueError,
+                "observation.ingested_at cannot be before attempted_at",
+            ):
+                store.record_success(
+                    second_attempt,
+                    pd.Timestamp("2025-03-06T22:01:00Z"),
+                    (observation,),
+                )
+
+            health = store.source_health("yahoo", "SPY")
+            self.assertEqual(health["last_attempt_status"], "in_progress")
+            self.assertEqual(
+                health["last_success_id"],
+                first_attempt,
+            )
+            self.assertEqual(
+                store._connection.execute(
+                    "SELECT COUNT(*) FROM market_observations"
+                ).fetchone()[0],
+                1,
+            )
+
+    def test_current_refetch_appends_a_revision_and_advances_success(self):
+        with RegimeEvidenceStore(self.db_path) as store:
+            first_attempt = store.begin_attempt(
+                "yahoo",
+                "SPY",
+                SESSIONS[0],
+                SESSIONS[0],
+                pd.Timestamp("2025-03-06T21:03:00Z"),
+            )
+            store.record_success(
+                first_attempt,
+                pd.Timestamp("2025-03-06T21:04:00Z"),
+                (
+                    _observation(
+                        SESSIONS[0],
+                        SPY_IDENTITY,
+                        500.0,
+                        ingested_at=pd.Timestamp("2025-03-06T21:03:30Z"),
+                    ),
+                ),
+            )
+            second_attempt = store.begin_attempt(
+                "yahoo",
+                "SPY",
+                SESSIONS[0],
+                SESSIONS[0],
+                pd.Timestamp("2025-03-06T22:00:00Z"),
+            )
+            store.record_success(
+                second_attempt,
+                pd.Timestamp("2025-03-06T22:01:00Z"),
+                (
+                    _observation(
+                        SESSIONS[0],
+                        SPY_IDENTITY,
+                        500.0,
+                        ingested_at=pd.Timestamp("2025-03-06T22:00:30Z"),
+                    ),
+                ),
+            )
+
+            revisions = store._connection.execute(
+                """
+                SELECT revision, attempt_id, ingested_at
+                FROM market_observations
+                WHERE provider = 'yahoo' AND instrument = 'SPY'
+                  AND session_date = ?
+                ORDER BY revision
+                """,
+                (SESSIONS[0].isoformat(),),
+            ).fetchall()
+
+            self.assertEqual(
+                [
+                    (row["revision"], row["attempt_id"], row["ingested_at"])
+                    for row in revisions
+                ],
+                [
+                    (1, first_attempt, "2025-03-06T21:03:30.000000000Z"),
+                    (2, second_attempt, "2025-03-06T22:00:30.000000000Z"),
+                ],
+            )
+            self.assertEqual(
+                store.source_health("yahoo", "SPY")["last_success_id"],
+                second_attempt,
+            )
+
+    def test_partial_success_rolls_back_without_advancing_attempt(self):
+        with RegimeEvidenceStore(self.db_path) as store:
+            attempt_id = store.begin_attempt(
+                "yahoo",
+                "SPY",
+                SESSIONS[0],
+                SESSIONS[-1],
+                pd.Timestamp("2025-03-10T20:30:00Z"),
+            )
+            partial_observations = tuple(
+                _observation(session, SPY_IDENTITY, 500.0 + position)
+                for position, session in enumerate(SESSIONS[:-1])
+            )
+
+            with self.assertRaisesRegex(
+                ValueError,
+                "exactly cover requested NYSE sessions",
+            ):
+                store.record_success(
+                    attempt_id,
+                    pd.Timestamp("2025-03-10T20:31:00Z"),
+                    partial_observations,
+                )
+
+            health = store.source_health("yahoo", "SPY")
+            self.assertEqual(health["last_attempt_status"], "in_progress")
+            self.assertIsNone(health["last_success_id"])
+            self.assertEqual(
+                store._connection.execute(
+                    "SELECT COUNT(*) FROM market_observations"
+                ).fetchone()[0],
+                0,
+            )
+
+    def test_semantically_invalid_observations_cannot_advance_success(self):
+        unrecognized_identity = dataclasses.replace(
+            SPY_IDENTITY,
+            dataset="unregistered_daily_prices",
+        )
+        base = _observation(
+            SESSIONS[0],
+            SPY_IDENTITY,
+            500.0,
+            ingested_at=pd.Timestamp("2025-03-06T22:00:30Z"),
+        )
+        variants = (
+            (
+                dataclasses.replace(base, is_final=False),
+                "observation must be final",
+            ),
+            (
+                dataclasses.replace(base, identity=unrecognized_identity),
+                "source identity is not recognized",
+            ),
+            (
+                dataclasses.replace(
+                    base,
+                    event_at=base.event_at + pd.Timedelta(minutes=1),
+                ),
+                "event_at does not match the exchange close",
+            ),
+        )
+
+        with RegimeEvidenceStore(self.db_path) as store:
+            for observation, error in variants:
+                with self.subTest(error=error):
+                    attempt_id = store.begin_attempt(
+                        "yahoo",
+                        "SPY",
+                        SESSIONS[0],
+                        SESSIONS[0],
+                        pd.Timestamp("2025-03-06T22:00:00Z"),
+                    )
+                    with self.assertRaisesRegex(ValueError, error):
+                        store.record_success(
+                            attempt_id,
+                            pd.Timestamp("2025-03-06T22:01:00Z"),
+                            (observation,),
+                        )
+                    health = store.source_health("yahoo", "SPY")
+                    self.assertEqual(
+                        health["last_attempt_status"],
+                        "in_progress",
+                    )
+                    self.assertIsNone(health["last_success_id"])
+                    self.assertEqual(
+                        store._connection.execute(
+                            "SELECT COUNT(*) FROM market_observations"
+                        ).fetchone()[0],
+                        0,
+                    )
+
+    def test_duplicate_success_sessions_roll_back(self):
+        observation = _observation(SESSIONS[0], SPY_IDENTITY, 500.0)
+        with RegimeEvidenceStore(self.db_path) as store:
+            attempt_id = store.begin_attempt(
+                "yahoo",
+                "SPY",
+                SESSIONS[0],
+                SESSIONS[0],
+                pd.Timestamp("2025-03-06T21:03:00Z"),
+            )
+
+            with self.assertRaisesRegex(
+                ValueError,
+                "duplicate sessions",
+            ):
+                store.record_success(
+                    attempt_id,
+                    pd.Timestamp("2025-03-06T21:04:00Z"),
+                    (observation, observation),
+                )
+
+            self.assertEqual(
+                store.source_health("yahoo", "SPY")["last_attempt_status"],
+                "in_progress",
+            )
+            self.assertEqual(
+                store._connection.execute(
+                    "SELECT COUNT(*) FROM market_observations"
+                ).fetchone()[0],
+                0,
+            )
+
+    def test_unexpected_success_session_rolls_back(self):
+        with RegimeEvidenceStore(self.db_path) as store:
+            attempt_id = store.begin_attempt(
+                "yahoo",
+                "SPY",
+                SESSIONS[0],
+                SESSIONS[0],
+                pd.Timestamp("2025-03-06T21:03:00Z"),
+            )
+
+            with self.assertRaisesRegex(
+                ValueError,
+                "unexpected=",
+            ):
+                store.record_success(
+                    attempt_id,
+                    pd.Timestamp("2025-03-07T22:00:00Z"),
+                    (
+                        _observation(SESSIONS[0], SPY_IDENTITY, 500.0),
+                        _observation(SESSIONS[1], SPY_IDENTITY, 501.0),
+                    ),
+                )
+
+            self.assertEqual(
+                store.source_health("yahoo", "SPY")["last_attempt_status"],
+                "in_progress",
+            )
+            self.assertEqual(
+                store._connection.execute(
+                    "SELECT COUNT(*) FROM market_observations"
+                ).fetchone()[0],
+                0,
+            )
+
+    def test_success_completion_cannot_precede_observation_ingestion(self):
+        with RegimeEvidenceStore(self.db_path) as store:
+            attempt_id = store.begin_attempt(
+                "yahoo",
+                "SPY",
+                SESSIONS[0],
+                SESSIONS[0],
+                pd.Timestamp("2025-03-06T21:00:00Z"),
+            )
+
+            with self.assertRaisesRegex(
+                ValueError,
+                "completed_at cannot be before observation.ingested_at",
+            ):
+                store.record_success(
+                    attempt_id,
+                    pd.Timestamp("2025-03-06T21:01:00Z"),
+                    (_observation(SESSIONS[0], SPY_IDENTITY, 500.0),),
+                )
+
+            health = store.source_health("yahoo", "SPY")
+            self.assertEqual(health["last_attempt_status"], "in_progress")
+            self.assertIsNone(health["last_success_id"])
+            self.assertEqual(
+                store._connection.execute(
+                    "SELECT COUNT(*) FROM market_observations"
+                ).fetchone()[0],
+                0,
+            )
+
+    def test_success_completion_cannot_precede_attempt(self):
+        with RegimeEvidenceStore(self.db_path) as store:
+            attempt_id = store.begin_attempt(
+                "yahoo",
+                "SPY",
+                SESSIONS[0],
+                SESSIONS[0],
+                pd.Timestamp("2025-03-06T22:00:00Z"),
+            )
+
+            with self.assertRaisesRegex(
+                ValueError,
+                "completed_at cannot be before attempted_at",
+            ):
+                store.record_success(
+                    attempt_id,
+                    pd.Timestamp("2025-03-06T21:59:59Z"),
+                    (_observation(SESSIONS[0], SPY_IDENTITY, 500.0),),
+                )
+
+            self.assertEqual(
+                store.source_health("yahoo", "SPY")["last_attempt_status"],
+                "in_progress",
+            )
+            self.assertEqual(
+                store._connection.execute(
+                    "SELECT COUNT(*) FROM market_observations"
+                ).fetchone()[0],
+                0,
+            )
+
+    def test_failure_completion_cannot_precede_attempt(self):
+        with RegimeEvidenceStore(self.db_path) as store:
+            attempt_id = store.begin_attempt(
+                "yahoo",
+                "SPY",
+                SESSIONS[0],
+                SESSIONS[0],
+                pd.Timestamp("2025-03-06T22:00:00Z"),
+            )
+
+            with self.assertRaisesRegex(
+                ValueError,
+                "completed_at cannot be before attempted_at",
+            ):
+                store.record_failure(
+                    attempt_id,
+                    pd.Timestamp("2025-03-06T21:59:59Z"),
+                    "clock_error",
+                    "Completion timestamp moved backward",
+                )
+
+            health = store.source_health("yahoo", "SPY")
+            self.assertEqual(health["last_attempt_status"], "in_progress")
+            self.assertIsNone(health["last_success_id"])
+            self.assertIsNone(health["last_error_code"])
+
+    def test_unsupported_legacy_schema_fails_closed(self):
+        connection = sqlite3.connect(self.db_path)
+        connection.execute(
+            """
+            CREATE TABLE regime_input_snapshots (
+                snapshot_sequence  INTEGER PRIMARY KEY AUTOINCREMENT,
+                snapshot_sha256    TEXT NOT NULL UNIQUE,
+                snapshot_json      TEXT NOT NULL,
+                published_at       TEXT NOT NULL
+            )
+            """
+        )
+        connection.execute("PRAGMA user_version = 1")
+        connection.commit()
+        connection.close()
+
+        with self.assertRaisesRegex(
+            RegimeEvidenceStoreError,
+            "No migration is defined",
+        ):
+            RegimeEvidenceStore(self.db_path)
+
+    def test_newer_schema_version_fails_closed(self):
+        connection = sqlite3.connect(self.db_path)
+        connection.execute(f"PRAGMA user_version = {SCHEMA_VERSION + 1}")
+        connection.close()
+
+        with self.assertRaises(RegimeEvidenceStoreError):
+            RegimeEvidenceStore(self.db_path)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/etrade_python_client/tests/test_regime_market_data.py
+++ b/etrade_python_client/tests/test_regime_market_data.py
@@ -1,0 +1,533 @@
+import dataclasses
+import hashlib
+import json
+import unittest
+from datetime import date
+
+import pandas as pd
+
+import live_trading.regime_market_data as regime_market_data
+from live_trading.regime_market_data import (
+    AVAILABILITY_HISTORICAL_ASSUMPTION,
+    AVAILABILITY_LIVE_RETRIEVAL,
+    AVAILABILITY_PROVIDER_TIMESTAMP,
+    CALENDAR_POLICY_VERSION,
+    PAYLOAD_NORMALIZED_ONLY,
+    PAYLOAD_PROVIDER_RESPONSE,
+    MarketObservation,
+    RegimeMarketDataSnapshot,
+    SourceIdentity,
+    load_snapshot_json,
+    regime_market_schedule,
+)
+from live_trading.regime_detector_v2 import detect_regimes_from_snapshot
+
+
+SPY_IDENTITY = SourceIdentity(
+    provider="yahoo",
+    dataset="daily_prices",
+    provider_symbol="SPY",
+    canonical_instrument="SPY",
+    field="close",
+    adjustment="unadjusted",
+    unit="USD",
+)
+VIX_IDENTITY = SourceIdentity(
+    provider="cboe",
+    dataset="vix_daily",
+    provider_symbol="VIX",
+    canonical_instrument="VIX",
+    field="close",
+    adjustment="none",
+    unit="index_points",
+)
+SESSIONS = (
+    date(2025, 3, 6),
+    date(2025, 3, 7),
+    date(2025, 3, 10),
+)
+
+
+def _event_times(session):
+    schedule = regime_market_schedule(session, session)
+    row = schedule.loc[pd.Timestamp(session)]
+    return pd.Timestamp(row["spy_event_at"]), pd.Timestamp(row["vix_event_at"])
+
+
+def _observation(session, identity, close, **overrides):
+    spy_event_at, vix_event_at = _event_times(session)
+    event_at = (
+        spy_event_at
+        if identity.canonical_instrument == "SPY"
+        else vix_event_at
+    )
+    payload = (
+        f"{identity.provider}|{identity.dataset}|{identity.provider_symbol}|"
+        f"{session.isoformat()}|{close}"
+    ).encode("utf-8")
+    values = {
+        "session": session,
+        "identity": identity,
+        "close": float(close),
+        "event_at": event_at,
+        "available_at": event_at + pd.Timedelta(minutes=1),
+        "ingested_at": event_at + pd.Timedelta(minutes=2),
+        "request_id": f"{identity.provider}:{session.isoformat()}",
+        "raw_payload_sha256": hashlib.sha256(payload).hexdigest(),
+        "payload_kind": PAYLOAD_PROVIDER_RESPONSE,
+        "availability_basis": AVAILABILITY_PROVIDER_TIMESTAMP,
+        "is_final": True,
+    }
+    values.update(overrides)
+    return MarketObservation(**values)
+
+
+def _observations():
+    observations = []
+    for position, session in enumerate(SESSIONS):
+        observations.extend(
+            [
+                _observation(session, SPY_IDENTITY, 500.0 + position),
+                _observation(session, VIX_IDENTITY, 16.0 + position),
+            ]
+        )
+    return observations
+
+
+def _snapshot(observations=None, as_of=None):
+    observations = list(observations if observations is not None else _observations())
+    if as_of is None:
+        as_of = max(item.ingested_at for item in observations) + pd.Timedelta(minutes=1)
+    return RegimeMarketDataSnapshot(
+        as_of=as_of,
+        observations=tuple(observations),
+    )
+
+
+class RegimeMarketDataTests(unittest.TestCase):
+    def test_schedule_has_fixed_dst_and_early_close_boundaries(self):
+        dst_schedule = regime_market_schedule(date(2025, 3, 7), date(2025, 3, 10))
+
+        self.assertEqual(
+            pd.Timestamp(dst_schedule.loc[pd.Timestamp("2025-03-07"), "spy_event_at"]),
+            pd.Timestamp("2025-03-07T21:00:00Z"),
+        )
+        self.assertEqual(
+            pd.Timestamp(dst_schedule.loc[pd.Timestamp("2025-03-07"), "vix_event_at"]),
+            pd.Timestamp("2025-03-07T21:15:00Z"),
+        )
+        self.assertEqual(
+            pd.Timestamp(dst_schedule.loc[pd.Timestamp("2025-03-10"), "spy_event_at"]),
+            pd.Timestamp("2025-03-10T20:00:00Z"),
+        )
+        self.assertEqual(
+            pd.Timestamp(dst_schedule.loc[pd.Timestamp("2025-03-10"), "vix_event_at"]),
+            pd.Timestamp("2025-03-10T20:15:00Z"),
+        )
+
+        early_close = regime_market_schedule(date(2025, 11, 28), date(2025, 11, 28))
+        row = early_close.loc[pd.Timestamp("2025-11-28")]
+        self.assertEqual(
+            pd.Timestamp(row["spy_event_at"]),
+            pd.Timestamp("2025-11-28T18:00:00Z"),
+        )
+        self.assertEqual(
+            pd.Timestamp(row["vix_event_at"]),
+            pd.Timestamp("2025-11-28T18:15:00Z"),
+        )
+        self.assertEqual(
+            pd.Timestamp(row["joint_finalization_at"]),
+            pd.Timestamp("2025-11-28T18:15:00Z"),
+        )
+
+    def test_records_are_frozen_and_session_must_be_a_date(self):
+        observation = _observations()[0]
+        snapshot = _snapshot()
+
+        with self.assertRaises(dataclasses.FrozenInstanceError):
+            observation.close = 999.0
+        with self.assertRaises(dataclasses.FrozenInstanceError):
+            snapshot.as_of = pd.Timestamp("2025-03-11T00:00:00Z")
+        with self.assertRaises((TypeError, ValueError)):
+            dataclasses.replace(
+                observation,
+                session=pd.Timestamp("2025-03-06T16:00:00-05:00"),
+            )
+
+    def test_provider_symbol_swaps_and_vvix_identity_are_rejected(self):
+        invalid_identities = (
+            dataclasses.replace(SPY_IDENTITY, provider_symbol="^VIX"),
+            dataclasses.replace(VIX_IDENTITY, provider_symbol="VVIX"),
+            dataclasses.replace(VIX_IDENTITY, canonical_instrument="SPY"),
+        )
+
+        for identity in invalid_identities:
+            with self.subTest(identity=identity):
+                with self.assertRaises((TypeError, ValueError)):
+                    observations = _observations()
+                    observations[0] = dataclasses.replace(
+                        observations[0],
+                        identity=identity,
+                    )
+                    _snapshot(observations)
+
+    def test_valid_snapshot_returns_exact_detector_inputs(self):
+        snapshot = _snapshot()
+        inputs = snapshot.detector_inputs()
+
+        self.assertTrue(snapshot.schema_version)
+        self.assertEqual(len(snapshot.schedule_sha256), 64)
+        self.assertEqual(len(snapshot.snapshot_sha256), 64)
+        self.assertTrue(snapshot.provenance_evidence_complete)
+        self.assertFalse(snapshot.provenance_verified)
+        self.assertIn(
+            "SNAPSHOT:durable_raw_payload_unverified",
+            snapshot.provenance_failures,
+        )
+        self.assertFalse(inputs["source_provenance_verified"])
+
+        prices = inputs["prices"]
+        self.assertEqual(list(prices.columns), ["SPY_Close", "VIX_Close"])
+        self.assertEqual(
+            list(prices.index),
+            [pd.Timestamp(session) for session in SESSIONS],
+        )
+        self.assertEqual(prices["SPY_Close"].tolist(), [500.0, 501.0, 502.0])
+        self.assertEqual(prices["VIX_Close"].tolist(), [16.0, 17.0, 18.0])
+
+        expected = {
+            (item.identity.canonical_instrument, item.session): max(
+                item.event_at,
+                item.available_at,
+                item.ingested_at,
+            )
+            for item in snapshot.observations
+        }
+        for session in SESSIONS:
+            index = pd.Timestamp(session)
+            self.assertEqual(
+                inputs["spy_available_at"].loc[index],
+                expected[("SPY", session)],
+            )
+            self.assertEqual(
+                inputs["vix_available_at"].loc[index],
+                expected[("VIX", session)],
+            )
+
+    def test_missing_required_leg_is_not_forward_filled(self):
+        observations = [
+            item
+            for item in _observations()
+            if not (
+                item.session == SESSIONS[1]
+                and item.identity.canonical_instrument == "VIX"
+            )
+        ]
+
+        with self.assertRaises((TypeError, ValueError)):
+            _snapshot(observations)
+
+    def test_duplicate_required_leg_is_rejected(self):
+        observations = _observations()
+        observations.append(observations[-1])
+
+        with self.assertRaises((TypeError, ValueError)):
+            _snapshot(observations)
+
+    def test_naive_timestamps_are_rejected(self):
+        valid = _observations()[0]
+        timestamp_fields = ("event_at", "available_at", "ingested_at")
+
+        for field_name in timestamp_fields:
+            with self.subTest(field=field_name):
+                naive = pd.Timestamp(getattr(valid, field_name)).tz_localize(None)
+                with self.assertRaises((TypeError, ValueError)):
+                    dataclasses.replace(valid, **{field_name: naive})
+
+        with self.assertRaises((TypeError, ValueError)):
+            _snapshot(as_of=pd.Timestamp("2025-03-10T21:00:00"))
+
+    def test_timestamp_ordering_and_as_of_are_enforced(self):
+        valid = _observations()[0]
+        invalid_changes = (
+            {"available_at": valid.event_at - pd.Timedelta(seconds=1)},
+            {"ingested_at": valid.available_at - pd.Timedelta(seconds=1)},
+        )
+        for changes in invalid_changes:
+            with self.subTest(changes=changes):
+                with self.assertRaises((TypeError, ValueError)):
+                    dataclasses.replace(valid, **changes)
+
+        observations = _observations()
+        too_early_as_of = max(item.ingested_at for item in observations) - pd.Timedelta(seconds=1)
+        with self.assertRaises((TypeError, ValueError)):
+            _snapshot(observations, as_of=too_early_as_of)
+
+    def test_exchange_event_time_mismatch_is_rejected(self):
+        observations = _observations()
+        valid = observations[0]
+        observations[0] = dataclasses.replace(
+            valid,
+            event_at=valid.event_at + pd.Timedelta(minutes=1),
+        )
+
+        with self.assertRaisesRegex(ValueError, "EVENT_TIME_MISMATCH"):
+            _snapshot(observations)
+
+    def test_delayed_ingestion_controls_effective_availability(self):
+        observations = _observations()
+        target = next(
+            item
+            for item in observations
+            if item.session == SESSIONS[-1]
+            and item.identity.canonical_instrument == "SPY"
+        )
+        delayed_ingestion = pd.Timestamp("2025-03-11T15:00:00Z")
+        replacement = dataclasses.replace(
+            target,
+            availability_basis=AVAILABILITY_LIVE_RETRIEVAL,
+            ingested_at=delayed_ingestion,
+        )
+        observations[observations.index(target)] = replacement
+        snapshot = _snapshot(
+            observations,
+            as_of=delayed_ingestion + pd.Timedelta(minutes=1),
+        )
+
+        inputs = snapshot.detector_inputs()
+        self.assertEqual(
+            inputs["spy_available_at"].loc[pd.Timestamp(SESSIONS[-1])],
+            delayed_ingestion,
+        )
+        self.assertLess(target.available_at, delayed_ingestion)
+
+    def test_snapshot_hash_and_json_are_independent_of_input_order(self):
+        observations = _observations()
+        forward = _snapshot(observations)
+        reversed_snapshot = _snapshot(list(reversed(observations)), as_of=forward.as_of)
+
+        self.assertEqual(forward.schedule_sha256, reversed_snapshot.schedule_sha256)
+        self.assertEqual(forward.snapshot_sha256, reversed_snapshot.snapshot_sha256)
+        self.assertEqual(forward.to_json(), reversed_snapshot.to_json())
+
+    def test_material_observation_change_changes_snapshot_hash(self):
+        observations = _observations()
+        original = _snapshot(observations)
+        observations[0] = dataclasses.replace(
+            observations[0],
+            close=observations[0].close + 0.01,
+        )
+        changed = _snapshot(observations, as_of=original.as_of)
+
+        self.assertNotEqual(original.snapshot_sha256, changed.snapshot_sha256)
+
+    def test_serialization_round_trip_preserves_canonical_snapshot(self):
+        snapshot = _snapshot()
+        restored = load_snapshot_json(snapshot.to_json())
+
+        self.assertEqual(restored.snapshot_sha256, snapshot.snapshot_sha256)
+        self.assertEqual(restored.schedule_sha256, snapshot.schedule_sha256)
+        self.assertEqual(restored.provenance_verified, snapshot.provenance_verified)
+        self.assertEqual(restored.to_json(), snapshot.to_json())
+        self.assertEqual(restored.detector_inputs()["prices"].to_dict(), snapshot.detector_inputs()["prices"].to_dict())
+
+    def test_snapshot_binds_the_source_policy_and_frozen_verdict(self):
+        snapshot = _snapshot()
+        serialized = snapshot.to_json()
+        original_hash = snapshot.snapshot_sha256
+        original_evidence_status = snapshot.provenance_evidence_complete
+        registry_key = SPY_IDENTITY.registry_key
+        original_policy = regime_market_data._SOURCE_IDENTITY_POLICY.pop(
+            registry_key
+        )
+        try:
+            self.assertEqual(snapshot.snapshot_sha256, original_hash)
+            self.assertEqual(
+                snapshot.provenance_evidence_complete,
+                original_evidence_status,
+            )
+            with self.assertRaisesRegex(ValueError, "SOURCE_POLICY_MISMATCH"):
+                load_snapshot_json(serialized)
+        finally:
+            regime_market_data._SOURCE_IDENTITY_POLICY[registry_key] = (
+                original_policy
+            )
+
+    def test_serialized_snapshot_tampering_fails_closed(self):
+        snapshot = _snapshot()
+        payload = json.loads(snapshot.to_json())
+        payload["observations"][0]["close"] += 1.0
+        tampered = json.dumps(payload, sort_keys=True, separators=(",", ":"))
+
+        with self.assertRaises((TypeError, ValueError)):
+            load_snapshot_json(tampered)
+
+    def test_serialized_observation_cannot_omit_finality(self):
+        payload = json.loads(_snapshot().to_json())
+        del payload["observations"][0]["is_final"]
+        missing_finality = json.dumps(
+            payload,
+            sort_keys=True,
+            separators=(",", ":"),
+        )
+
+        with self.assertRaisesRegex(ValueError, "MISSING_IS_FINAL"):
+            load_snapshot_json(missing_finality)
+
+    def test_normalized_and_historical_inputs_are_explicitly_unverified(self):
+        variants = (
+            {
+                "payload_kind": PAYLOAD_NORMALIZED_ONLY,
+                "availability_basis": AVAILABILITY_PROVIDER_TIMESTAMP,
+            },
+            {
+                "payload_kind": PAYLOAD_PROVIDER_RESPONSE,
+                "availability_basis": AVAILABILITY_HISTORICAL_ASSUMPTION,
+            },
+        )
+
+        for changes in variants:
+            with self.subTest(changes=changes):
+                observations = [
+                    dataclasses.replace(item, **changes)
+                    for item in _observations()
+                ]
+                snapshot = _snapshot(observations)
+                inputs = snapshot.detector_inputs()
+
+                self.assertFalse(snapshot.provenance_verified)
+                self.assertTrue(snapshot.provenance_failures)
+                self.assertFalse(inputs["source_provenance_verified"])
+
+    def test_complete_snapshot_stays_unverified_and_execution_ineligible(self):
+        snapshot = _snapshot()
+
+        result = detect_regimes_from_snapshot(snapshot)
+
+        self.assertFalse(result.attrs["source_provenance_verified"])
+        self.assertTrue(result["Input_Provenance_Status"].eq("unverified").all())
+        self.assertTrue(
+            result["Input_Provenance_Evidence"]
+            .eq("complete_but_not_durably_verified")
+            .all()
+        )
+        self.assertTrue(result["Detector_Stage"].eq("shadow").all())
+        self.assertFalse(result["Execution_Eligible"].any())
+        self.assertEqual(result.attrs["detector_stage"], "shadow")
+        self.assertFalse(result.attrs["execution_eligible"])
+        self.assertEqual(
+            result.attrs["calendar_policy_version"],
+            CALENDAR_POLICY_VERSION,
+        )
+        self.assertTrue(
+            result["Source_Policy_SHA256"]
+            .eq(snapshot.source_policy_sha256)
+            .all()
+        )
+        self.assertEqual(
+            result.attrs["exchange_calendars"],
+            ("NYSE", "CBOE_Index_Options"),
+        )
+        self.assertTrue(
+            result.attrs["input_provenance_evidence_complete"]
+        )
+        self.assertIn(
+            "durable_raw_payload_unverified",
+            result.attrs["input_provenance_failure_codes"],
+        )
+        self.assertEqual(
+            result.attrs["input_snapshot_sha256"],
+            snapshot.snapshot_sha256,
+        )
+
+    def test_delayed_snapshot_ingestion_advances_tradable_session(self):
+        baseline = detect_regimes_from_snapshot(_snapshot())
+        observations = _observations()
+        target = next(
+            item
+            for item in observations
+            if item.session == SESSIONS[-1]
+            and item.identity.canonical_instrument == "SPY"
+        )
+        delayed_ingestion = pd.Timestamp("2025-03-11T15:00:00Z")
+        observations[observations.index(target)] = dataclasses.replace(
+            target,
+            availability_basis=AVAILABILITY_LIVE_RETRIEVAL,
+            ingested_at=delayed_ingestion,
+        )
+        delayed_snapshot = _snapshot(
+            observations,
+            as_of=delayed_ingestion + pd.Timedelta(minutes=1),
+        )
+
+        delayed = detect_regimes_from_snapshot(delayed_snapshot)
+        latest_session = pd.Timestamp(SESSIONS[-1])
+
+        self.assertEqual(
+            baseline.loc[latest_session, "Tradable_Session"],
+            pd.Timestamp("2025-03-11"),
+        )
+        self.assertEqual(
+            delayed.loc[latest_session, "Signal_Available_At"],
+            delayed_ingestion,
+        )
+        self.assertEqual(
+            delayed.loc[latest_session, "Tradable_Session"],
+            pd.Timestamp("2025-03-12"),
+        )
+
+    def test_ingestion_at_next_open_rolls_to_following_session(self):
+        observations = _observations()
+        target = next(
+            item
+            for item in observations
+            if item.session == SESSIONS[-1]
+            and item.identity.canonical_instrument == "SPY"
+        )
+        next_open = pd.Timestamp("2025-03-11T13:30:00Z")
+        observations[observations.index(target)] = dataclasses.replace(
+            target,
+            availability_basis=AVAILABILITY_LIVE_RETRIEVAL,
+            ingested_at=next_open,
+        )
+        snapshot = _snapshot(
+            observations,
+            as_of=next_open + pd.Timedelta(minutes=1),
+        )
+
+        result = detect_regimes_from_snapshot(snapshot)
+
+        self.assertEqual(
+            result.loc[pd.Timestamp(SESSIONS[-1]), "Signal_Available_At"],
+            next_open,
+        )
+        self.assertEqual(
+            result.loc[pd.Timestamp(SESSIONS[-1]), "Tradable_Session"],
+            pd.Timestamp("2025-03-12"),
+        )
+
+    def test_normalized_snapshot_provenance_remains_false_in_detector(self):
+        observations = [
+            dataclasses.replace(item, payload_kind=PAYLOAD_NORMALIZED_ONLY)
+            for item in _observations()
+        ]
+        snapshot = _snapshot(observations)
+
+        result = detect_regimes_from_snapshot(snapshot)
+
+        self.assertFalse(result.attrs["source_provenance_verified"])
+        self.assertTrue(result["Input_Provenance_Status"].eq("unverified").all())
+        self.assertTrue(
+            result["Data_Quality"]
+            .str.contains("source_provenance_unverified")
+            .all()
+        )
+        self.assertIn(
+            "raw_provider_payload_unavailable",
+            result.attrs["input_provenance_failure_codes"],
+        )
+        self.assertFalse(result["Execution_Eligible"].any())
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -6,6 +6,7 @@ build-backend = "setuptools.build_meta"
 name = "etrade-quant-trading"
 version = "0.0.0"
 description = "Backtesting and daily trading utilities"
+readme = "README.md"
 requires-python = ">=3.10"
 
 [tool.setuptools.packages.find]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,3 +12,9 @@ requires-python = ">=3.10"
 [tool.setuptools.packages.find]
 where = ["."]
 include = ["polygonio*", "strategies*", "yfinance*", "accounts*"]
+
+[tool.pytest.ini_options]
+testpaths = ["etrade_python_client/tests"]
+markers = [
+    "integration: tests that require live external services",
+]

--- a/requirements.txt
+++ b/requirements.txt
@@ -8,5 +8,5 @@ pandas_market_calendars==5.1.0
 pytest==8.4.2
 Requests==2.32.5
 scipy
-scikit-learn==1.8.0
+scikit-learn==1.7.2
 pyyaml


### PR DESCRIPTION
## Summary

- add an immutable, versioned SPY/VIX observation and snapshot contract with exact NYSE + Cboe Index Options clocks, source-policy binding, deterministic hashes, and strict session coverage
- add a transactional SQLite evidence-manifest store with source attempts, append-only revisions, research/shadow publication channels, rollback on partial or invalid responses, and monotonic as-of selection
- route the V2 shadow detector through evidence snapshots; loose arrays cannot claim verified provenance
- make every current result explicitly execution-ineligible and unverified until a later adapter durably stores raw provider bytes plus parser receipts
- update the read-only audit to quarantine non-session rows and surface the material 2026-06-05 VIX conflict instead of silently selecting a value
- update the architecture map, reliability invariants, and V2 design

## Safety boundary

This PR is stacked on the verified pre-upgrade checkpoint branch. It does **not** connect the detector to E*TRADE orders, live risk decisions, or the served dashboard. `Execution_Eligible` is always false. A payload checksum alone is not called verified provenance.

## Causal record

- calibration: trailing prior-session windows; prototype thresholds remain `research_baseline_unverified`
- evaluation: 2011-05-03 through 2026-07-24 diagnostic replay, not a locked out-of-sample investment test
- inference: prefix-causal transparent score/state machine
- availability: paired SPY/VIX exchange finalization with a cumulative dependency watermark
- entry lag: close-T evidence maps to the first later NYSE open strictly after availability
- return buckets: not used in this detector

## Verification

- `PYTHONPATH=. ../venv/bin/python -m pytest -q tests` — 72 passed
- Python compilation and staged diff checks passed
- read-only causal audit completed
- independent final reviews found no remaining P1 blocker in the R1 scope

Audit result remains diagnostic: Mar 20–Apr 7 is 12/12 persistent stress; Jun 15–Jul 24 is 22 elevated / 6 calm with all five >10% VIX jumps detected. Legacy source problems are explicit: two non-NYSE VIX-only rows, a 16.22 vs 21.51 VIX conflict on June 5, and the quarantined VIX3M/VVIX copy.