### PR TITLE
R4: Add typed Regime V2 backtest/live parity boundary

### DIFF
--- a/etrade_python_client/RELIABILITY.md
+++ b/etrade_python_client/RELIABILITY.md
@@ -329,15 +329,25 @@ decision-time receipts, so it cannot establish production provenance.
     beginning 2026-07-27.
 - `research_reports/regime_v2_calibration_artifact.json`
   - Records the deterministic legacy-data evaluation and selected baseline.
+- `live_trading/regime_signal.py`
+  - Defines an immutable two-axis signal with canonical hashing, exact
+    close-T-to-next-session timing, artifact/evidence lineage, the mandatory
+    causal record, and a hard-coded non-authoritative action boundary.
+- `backtesting/backtest_runner.py`
+  - Accepts V2 only as an exact-date audit annotation and persists it without
+    consulting it for trade behavior.
+  - No longer backfills later HMM probabilities into earlier dates.
+  - Requires empirical forward-return outcomes to resolve strictly before the
+    entry session.
 
 ### Remaining risk
 
 The selected profile is not approved for E*TRADE orders. Its calibration data
 are explicitly `legacy_normalized_unverified`; the provider entitlement gate is
-unresolved; the prospective window has not accumulated; backtest/live taxonomy
-parity is still an R4 task; and no centralized fail-closed risk engine consumes
-the signal. The correct operational result remains `Calibration_Abstain=true`
-and `Execution_Eligible=false`.
+unresolved; the prospective window has not accumulated; the live dashboard has
+not yet published the R4 typed lane; and no centralized fail-closed risk engine
+consumes the signal. The correct operational result remains
+`Calibration_Abstain=true` and `Execution_Eligible=false`.
 
 ### Verification record
 
@@ -354,6 +364,10 @@ and `Execution_Eligible=false`.
 - Unit coverage includes canonical/tamper checks, strict purging, exact
   post-lag outcomes, prefix invariance, stale build/data/pin rejection, and
   binding coverage/chatter/false-persistence guards.
+- R4 coverage verifies closed two-axis types, canonical signal hashes,
+  artifact pins, stripped-attribute rejection, exact Friday-to-Monday mapping,
+  no-fill lookup, numeric-HMM separation, audit serialization, and strictly
+  prior return-bucket resolution.
 
 ### CI portability incident
 

--- a/etrade_python_client/backtesting/backtest_runner.py
+++ b/etrade_python_client/backtesting/backtest_runner.py
@@ -21,7 +21,7 @@ from dataclasses import dataclass, field, asdict
 import uuid
 from concurrent.futures import ProcessPoolExecutor, as_completed
 from datetime import datetime, timedelta, date
-from typing import List, Optional, Tuple, Dict, Any
+from typing import List, Optional, Tuple, Dict, Any, Mapping
 
 import numpy as np
 import pandas as pd
@@ -36,6 +36,10 @@ import pandas_market_calendars as mcal
 from backtesting.option_data_cache import OptionDataCache
 from backtesting.massive_api_client import MassiveAPIClient
 from backtesting.greeks_calculator import compute_chain_deltas, bs_put_delta, implied_volatility
+from live_trading.regime_signal import (
+    RegimeSignal,
+    annotation_for_session,
+)
 
 
 # ANSI Colors for terminal logging
@@ -45,6 +49,34 @@ CLR_RST = "\033[0m"
 
 
 NYSE = mcal.get_calendar("NYSE")
+
+
+def validate_regime_v2_annotations(
+    annotations: Optional[Mapping[str, RegimeSignal]],
+) -> Dict[str, RegimeSignal]:
+    """Validate the exact-date, shadow-only V2 annotation boundary.
+
+    V2 signals deliberately remain separate from legacy integer HMM regimes.
+    This function accepts no numeric states, performs no forward fill, and
+    returns no order-facing projection.
+    """
+
+    if annotations is None:
+        return {}
+    if not isinstance(annotations, Mapping):
+        raise TypeError("regime_v2_annotations must be a mapping")
+
+    validated: Dict[str, RegimeSignal] = {}
+    for key, value in annotations.items():
+        if not isinstance(key, str):
+            raise TypeError("regime_v2_annotations keys must be ISO date strings")
+        signal = annotation_for_session(annotations, key)
+        if signal is None or signal is not value:
+            raise ValueError("regime_v2_annotations contains an invalid entry")
+        if signal.may_authorize_execution:
+            raise ValueError("R4 V2 annotations cannot authorize execution")
+        validated[key] = signal
+    return validated
 
 
 def lag_daily_regime_map(regimes: Dict[str, int], trading_dates: List[str]) -> Dict[str, int]:
@@ -93,11 +125,16 @@ def _forward_return_assignment_strike(
 
     as_of_idx_full = all_date_index.get(as_of_date)
     if as_of_idx_full is None:
-        # Fallback if as_of_date not in full pricing series
-        as_of_idx_full = len(all_dates) - 1
+        return None, {
+            "reason": "as_of_date_missing_from_underlying_prices",
+            "as_of_date": as_of_date,
+        }
 
     trading_horizon = max(1, int(round(float(option_horizon_days) * 252.0 / 365.0)))
-    resolved_cutoff_full = as_of_idx_full - trading_horizon
+    # A sample is eligible only after its terminal close is strictly earlier
+    # than the entry session. A return resolving on the entry date is not
+    # decision-time evidence for that same EOD entry.
+    resolved_cutoff_full = as_of_idx_full - trading_horizon - 1
     if resolved_cutoff_full < 1:
         return None, {"reason": "insufficient_history", "trading_horizon": trading_horizon}
 
@@ -127,6 +164,10 @@ def _forward_return_assignment_strike(
         "reason": "empirical_forward_return_quantile",
         "n": int(len(sample)),
         "trading_horizon": int(trading_horizon),
+        "latest_resolution_session": pd.Timestamp(
+            all_dates[resolved_cutoff_full + trading_horizon]
+        ).date().isoformat(),
+        "outcomes_resolved_strictly_before_entry": True,
         "target_assignment_prob": target_prob,
         "target_return": target_return,
     }
@@ -207,6 +248,7 @@ class SpreadTrade:
     is_roll: bool = False # If opened from rollover
     entry_regime: int = -1
     entry_regime_name: str = ""
+    entry_regime_v2: Optional[Dict[str, Any]] = None
     profit_target: float = 0.70 # Default to early_profit_pct
     short_ticker: str = ""
     long_ticker: str = ""
@@ -274,6 +316,9 @@ class BacktestResult:
     risk_free_rates: pd.Series = field(default_factory=lambda: pd.Series(dtype=float))
     regime_history: List[Tuple[str, int]] = field(default_factory=list)
     regime_labels: Dict[int, str] = field(default_factory=dict)
+    regime_v2_history: List[Tuple[str, Optional[Dict[str, Any]]]] = field(
+        default_factory=list
+    )
     daily_leg_premiums: List[Tuple[str, float, float]] = field(default_factory=list)
     daily_scatter_data: List[dict] = field(default_factory=list)
     daily_opened_dte: List[Tuple[str, int]] = field(default_factory=list)
@@ -307,6 +352,7 @@ class BacktestPathLogger:
         spot: float,
         regime: int,
         regime_name: str,
+        regime_v2: Optional[Dict[str, Any]],
         nlv: float,
         cash: float,
         margin: float,
@@ -321,6 +367,7 @@ class BacktestPathLogger:
             "spot_price": float(spot),
             "regime": int(regime),
             "regime_name": regime_name,
+            "regime_v2": regime_v2,
             "nlv": float(nlv),
             "cash": float(cash),
             "margin": float(margin),
@@ -845,6 +892,7 @@ async def run_put_credit_spread_backtest(
     slippage_model: str = "none",
     max_time_delta_minutes: float = 5.0,
     regime_probabilities: Optional[pd.DataFrame] = None,
+    regime_v2_annotations: Optional[Mapping[str, RegimeSignal]] = None,
     offline_only: bool = False,
 ) -> BacktestResult:
     """
@@ -862,6 +910,9 @@ async def run_put_credit_spread_backtest(
     result.margin_limit_pct = margin_limit_pct
     result.regime_labels = regime_labels if regime_labels else {}
     result.regime_probabilities = regime_probabilities
+    regime_v2_annotations = validate_regime_v2_annotations(
+        regime_v2_annotations
+    )
     
     # Extract strategy-level configurations
     entry_config = (strategy_config or {}).get("entry", {})
@@ -995,7 +1046,11 @@ async def run_put_credit_spread_backtest(
                     # Keep the daily probabilities for plotting
                     prob_cols = [f'prob_state_{i}' for i in range(k)]
                     if all(col in feature_df.columns for col in prob_cols):
-                        result.regime_probabilities = feature_df[prob_cols].reindex(trading_dates).ffill().bfill()
+                        result.regime_probabilities = (
+                            feature_df[prob_cols]
+                            .reindex(trading_dates)
+                            .ffill()
+                        )
                     print("  [Regime Timing] Using one-trading-day-lagged close_T overlay regimes for trade entry.")
                 else:
                     print("  WARNING: Could not build causal regime trace.")
@@ -1559,6 +1614,18 @@ async def run_put_credit_spread_backtest(
             current_regime = regimes.get(td, -1) if regimes else -1
             current_regime_name = result.regime_labels.get(current_regime, "")
             result.regime_history.append((td, current_regime))
+            current_regime_v2 = annotation_for_session(
+                regime_v2_annotations,
+                td,
+            )
+            current_regime_v2_payload = (
+                current_regime_v2.to_envelope()
+                if current_regime_v2 is not None
+                else None
+            )
+            result.regime_v2_history.append(
+                (td, current_regime_v2_payload)
+            )
             td_idx = trading_date_index.get(td, -1)
             prev_regime = regimes.get(trading_dates[td_idx - 1], -1) if regimes and td_idx > 0 else -1
             regime_switched_to_panic = (
@@ -2162,13 +2229,12 @@ async def run_put_credit_spread_backtest(
                     eff_short_delta = target_short_delta
 
             elif regime_dynamic_delta:
-                # Delta is at 0.1 during expansion regimes and cautious decline regime, 
-                # but doubled (0.2) during crisis/panic/turmoil regimes
-                is_crisis = current_regime_name and any(term in current_regime_name for term in ["Panic", "Crisis", "Turmoil"])
-                if is_crisis:
-                    eff_short_delta = -0.20
-                else:
-                    eff_short_delta = -0.10
+                # Legacy compatibility only. V2 never enters this path.
+                is_crisis = current_regime_name and any(
+                    term in current_regime_name
+                    for term in ["Panic", "Crisis", "Turmoil"]
+                )
+                eff_short_delta = -0.20 if is_crisis else -0.10
             eff_spread_width = spread_width
             if (
                 dynamic_delta_method == "vix_double_above_25"
@@ -2801,6 +2867,7 @@ async def run_put_credit_spread_backtest(
                                     status="open",
                                     entry_regime=current_regime,
                                     entry_regime_name=current_regime_name,
+                                    entry_regime_v2=current_regime_v2_payload,
                                     entry_dte=dte_days,
                                     short_entry_mid=short_mid,
                                     long_entry_mid=long_mid,
@@ -3010,6 +3077,7 @@ async def run_put_credit_spread_backtest(
                                                         status="open",
                                                         entry_regime=current_regime,
                                                         entry_regime_name=current_regime_name,
+                                                        entry_regime_v2=current_regime_v2_payload,
                                                         entry_dte=dte_days,
                                                         short_entry_mid=call_short_mid,
                                                         long_entry_mid=call_long_mid,
@@ -3083,6 +3151,7 @@ async def run_put_credit_spread_backtest(
                     spot=spot,
                     regime=current_regime,
                     regime_name="",
+                    regime_v2=current_regime_v2_payload,
                     nlv=current_nlv,
                     cash=current_cash,
                     margin=current_margin_usage,

--- a/etrade_python_client/docs/production_readiness_upgrade_plan.md
+++ b/etrade_python_client/docs/production_readiness_upgrade_plan.md
@@ -163,11 +163,11 @@ the result is marked `VALID`.
 
 | Mandatory field | Current status | Upgrade requirement |
 |---|---|---|
-| Training/calibration end date | **Unverified.** Expanding refits occur in the canonical path but cutoffs are not persisted. Legacy scripts perform global fitting. | Store the cutoff for every model/refit and a calibration-policy hash. |
-| Test date range | **Partial.** Start/end dates are stored, but no OOS/holdout designation or model-selection history exists. | Store calibration, validation, and locked test ranges plus selection lineage. |
-| Inference method | **Mixed and unrecorded.** Canonical auto-training uses expanding inference; other entry points use non-expanding defaults. | Enumerate and store `walk_forward_filter`, prohibit smoothed/Viterbi history for backtest decisions. |
-| Regime lag | **Correct in the canonical helper, not proven per result.** Legacy scripts pass same-day states. | Persist `lag_trading_days >= 1` and assert it at trade-entry construction. |
-| Return-bucket causality | **Partially implemented, invalid end-to-end.** Resolved outcomes are censored, but raw and overlay taxonomies are mixed. | Store `as_of`, horizon convention, resolved cutoff, taxonomy/version, and assert only resolved outcomes enter the matching final-regime bucket. |
+| Training/calibration end date | **Implemented for R4 V2 annotations only.** The typed signal records the last selection-fold session from the pinned artifact. Legacy action paths remain unverified. | Store the cutoff for every model/refit and a calibration-policy hash. |
+| Test date range | **Implemented for R4 V2 annotations only.** The retrospective range is copied from the immutable plan; the prospective holdout is not complete. | Store calibration, validation, and locked test ranges plus selection lineage. |
+| Inference method | **Implemented for R4 V2 annotations only.** Calibrated signals record `causal_prefix_filter`; raw research signals leave it null and abstain. Legacy paths remain mixed. | Enumerate and store `walk_forward_filter`, prohibit smoothed/Viterbi history for backtest decisions. |
+| Regime lag | **Enforced for R4 V2 annotations.** The adapter proves close T maps to the exact next NYSE session and never fills a gap. Legacy scripts can still pass same-day states. | Persist `lag_trading_days >= 1` and assert it at trade-entry construction. |
+| Return-bucket causality | **Explicitly not used in R4.** Typed signals record `not_used_shadow_annotation`; the non-regime empirical helper now requires outcomes resolved strictly before entry. Legacy HMM/overlay buckets remain invalid end-to-end. | Store `as_of`, horizon convention, resolved cutoff, taxonomy/version, and assert only resolved outcomes enter the matching final-regime bucket. |
 
 If any field is absent, the run status is `UNVERIFIED`. If a gate is known to
 fail, the status is `INVALID`. Only `VALID` runs appear in performance

--- a/etrade_python_client/docs/project_overview.md
+++ b/etrade_python_client/docs/project_overview.md
@@ -74,6 +74,7 @@ flowchart TD
         Snap[("backtest_cache/regime_snapshots/*.pkl<br/>(Causal HMM/GMM Cache)")]
         RD2["live_trading/regime_detector_v2.py<br/>(Background + Shock Shadow Detector)"]
         RCAL["live_trading/regime_calibration.py<br/>(Purged Candidate Selection + Immutable Artifact)"]
+        RSIG["live_trading/regime_signal.py<br/>(Typed, Shadow-Only Signal Contract)"]
         RART[("regime_v2_calibration_artifact.json<br/>(Research-only, Content Addressed)")]
     end
 
@@ -81,6 +82,7 @@ flowchart TD
         EP["live_trading/ev_plots.py<br/>(Diagnostic Plotter)"]
         RPA["scratch/regime_probability_audit.py<br/>(SPY vs SPX Statistical Auditor)"]
         RVA["scratch/regime_detector_v2_audit.py<br/>(Unverified Legacy Replay Audit)"]
+        BANN["backtesting/backtest_runner.py<br/>(Exact-Date V2 Audit Annotations)"]
     end
 
     subgraph Generated Frontends & Images
@@ -101,6 +103,9 @@ flowchart TD
     RMD --> RD2
     RD2 --> RCAL
     RCAL --> RART
+    RD2 --> RSIG
+    RART --> RSIG
+    RSIG --> BANN
     RD2 --> RVA
     DI --> PF
     PF --> EE
@@ -122,7 +127,7 @@ flowchart TD
 
 *   **Strategy Specifications** (`backtesting/strategies/*.yaml`): YAML files (e.g., `baseline_put_spread.yaml`, `put_call_credit_spread.yaml`) defining trade structure, short/long delta targets, margin caps, early profit exits, DTEs, and rolling behavior. This is the stable configuration layer.
 *   **Batch Harness** ([`run_comparison.py`](file:///Users/btian/EtradePythonClient/etrade_python_client/backtesting/run_comparison.py)): Orchestrates parameters sweeps. It maps out variants, writes temporary configuration JSONs, and triggers the `backtest_runner.py` for each variant before compiling the leaderboard.
-*   **Historical Simulator** ([`backtest_runner.py`](file:///Users/btian/EtradePythonClient/etrade_python_client/backtesting/backtest_runner.py)): The core execution engine. It simulates daily trade lifecycles, parses the option chain databases, applies margin math, tracks PnL, logs trade events, and generates an interactive, detailed HTML report.
+*   **Historical Simulator** ([`backtest_runner.py`](file:///Users/btian/EtradePythonClient/etrade_python_client/backtesting/backtest_runner.py)): The core execution engine. It simulates daily trade lifecycles, parses the option chain databases, applies margin math, tracks PnL, logs trade events, and generates an interactive, detailed HTML report. V2 regime signals enter through a separate typed, exact-date audit lane and cannot alter the legacy strategy path in R4.
 *   **Dashboard Compiler** ([`generate_experiments_report.py`](file:///Users/btian/EtradePythonClient/etrade_python_client/backtesting/generate_experiments_report.py)): Reads the flat-file JSONL experiments log and compiles a central HTML dashboard leaderboard for comparison.
 *   **Experiment Manager** ([`experiment_manager.py`](file:///Users/btian/EtradePythonClient/etrade_python_client/backtesting/experiment_manager.py)): A utility script providing CLI commands to delete, rebuild, or manage individual runs in the experiments log.
 
@@ -136,6 +141,7 @@ flowchart TD
 *   **V2 Evidence Store** ([`regime_evidence_store.py`](file:///Users/btian/EtradePythonClient/etrade_python_client/live_trading/regime_evidence_store.py)): Persists raw BLOBs, source attempts/health, fetch and parser receipts, append-only corrections, and channel-scoped verified snapshots in SQLite. It replays retained bytes before a `shadow` publication; one-leg failures preserve the previously verified head.
 *   **V2 Shadow Detector** ([`regime_detector_v2.py`](file:///Users/btian/EtradePythonClient/etrade_python_client/live_trading/regime_detector_v2.py)): Produces independent background and shock states from causal daily SPY/VIX inputs. Every current output is execution-ineligible.
 *   **V2 Causal Calibration** ([`regime_calibration.py`](file:///Users/btian/EtradePythonClient/etrade_python_client/live_trading/regime_calibration.py)): Evaluates a predeclared detector grid on purged, resolved-only future-risk outcomes; binds detector/build, data-prefix, calendar, source-policy, plan, and artifact hashes; and keeps the selected profile research-only. The frozen protocol is `docs/regime_v2_calibration_plan.json`.
+*   **V2 Typed Signal Contract** ([`regime_signal.py`](file:///Users/btian/EtradePythonClient/etrade_python_client/live_trading/regime_signal.py)): Converts a structurally valid close-T detector trace into immutable background-plus-shock annotations keyed only to the exact next NYSE session. It preserves artifact, source, evidence, runtime, and causal lineage; never maps into HMM integers; never fills missing sessions; and has no action projection.
 *   **Plotting & Diagnostics** ([`ev_plots.py`](file:///Users/btian/EtradePythonClient/etrade_python_client/live_trading/ev_plots.py)): Orchestrates visualizations of regime timelines, HMM state returns, GMM distribution fits, and Expected Value curves. It is also equipped to trigger out-of-sample calibration backtests.
 *   **Regime Audit** ([`regime_probability_audit.py`](file:///Users/btian/EtradePythonClient/etrade_python_client/scratch/regime_probability_audit.py)): A rigorous statistical audit script that merges SPY/SPX data, fits a causal walk-forward HMM, checks for statistical equivalence via Kolmogorov-Smirnov (KS) tests, audits options assignment frequencies against BS/Skew probabilities, and compiles a comprehensive audit report.
 *   **V2 Legacy Replay Audit** ([`regime_detector_v2_audit.py`](file:///Users/btian/EtradePythonClient/etrade_python_client/scratch/regime_detector_v2_audit.py)): Wraps legacy cache values in an explicitly unverified snapshot, surfaces conflicts/quarantined rows, and compares the two-timescale shadow result with the old overlay.

--- a/etrade_python_client/docs/regime_detection_v2_design.md
+++ b/etrade_python_client/docs/regime_detection_v2_design.md
@@ -2,8 +2,8 @@
 
 **Review date:** 2026-07-26
 
-**Status:** R3 causally calibrated research profile with durable R2 evidence
-boundaries; not connected to order execution
+**Status:** R4 typed shadow contract with causal backtest/live semantics;
+not connected to order execution
 **Related roadmap:** `docs/production_readiness_upgrade_plan.md`
 
 ## Decision
@@ -568,6 +568,49 @@ has no retained raw/provider receipts, and is explicitly
 `promotion_status=research_only`, `Calibration_Abstain=true`, and
 `Execution_Eligible=false`.
 
+### R4 typed shadow parity
+
+`live_trading/regime_signal.py` is the only compatibility boundary for V2
+consumers. It converts detector rows into frozen, content-addressed
+`RegimeSignal` objects without collapsing the two axes into an HMM integer.
+Each object is keyed to its explicit effective session; consumers receive no
+forward fill and no state fallback.
+
+The adapter validates:
+
+- close-T is a real NYSE session and the effective date is exactly T+1;
+- signal availability is no earlier than joint SPY/VIX finalization and
+  strictly before the T+1 market open;
+- detector version, configuration, source-code identity, runtime fingerprint,
+  artifact/plan identity, and any snapshot/evidence hashes remain distinct;
+- calibrated traces retain immutable DataFrame attributes, match an externally
+  pinned artifact hash, explicitly abstain, and remain execution-ineligible;
+- canonical serialization reproduces the signal hash; and
+- all attempted action projections raise.
+
+The embedded causal record makes the mandatory audit fields explicit:
+
+| Field | R4 value |
+|---|---|
+| Training/calibration end | Last selection fold; 2024-12-31 for the committed artifact |
+| Test range | Retrospective 2025 range from the pinned plan |
+| Inference | `causal_prefix_filter` for the artifact; null and abstaining for raw research traces |
+| Regime lag | Exactly one NYSE session |
+| Return buckets | `not_used_shadow_annotation` |
+
+`backtesting/backtest_runner.py` accepts these objects only through
+`regime_v2_annotations`. It records their primitive, hash-verified envelope on
+the daily path and each new trade, but the signal is not consulted by expiration,
+strike, delta, quantity, probability, entry, exit, or roll logic. The legacy
+numeric HMM lane remains a separate compatibility path. R4 also removes
+backward filling of HMM probabilities, requires forward-return outcomes to
+resolve strictly before an EOD entry session.
+
+This is semantic parity, not a trading-policy promotion. A later phase must
+build verified provider history, finish the prospective holdout, define a
+separate monotonic risk policy, and pass paper/canary gates before V2 can veto
+or resize an opening order.
+
 ## Why not another single HMM
 
 A single latent state must choose among three bad behaviors:
@@ -786,6 +829,7 @@ and skipped-trade effects must be included.
 - Provider parser contract: `live_trading/regime_provider_evidence.py`
 - Provider gateway: `live_trading/regime_market_data_gateway.py`
 - Calibration engine: `live_trading/regime_calibration.py`
+- Typed shadow contract: `live_trading/regime_signal.py`
 - Frozen calibration plan: `docs/regime_v2_calibration_plan.json`
 - Research artifact:
   `research_reports/regime_v2_calibration_artifact.json`
@@ -794,7 +838,9 @@ and skipped-trade effects must be included.
   `tests/test_regime_market_data.py`, and
   `tests/test_regime_evidence_store.py`,
   `tests/test_regime_market_data_gateway.py`,
-  `tests/test_regime_calibration.py`
+  `tests/test_regime_calibration.py`,
+  `tests/test_regime_signal.py`, and
+  `tests/test_regime_backtest_parity.py`
 - Read-only replay: `scratch/regime_detector_v2_audit.py`
 - Deterministic calibration runner:
   `scratch/regime_detector_v2_calibrate.py`
@@ -816,6 +862,10 @@ The focused tests verify:
   parser receipts, and store-owned snapshot verification.
 - Stale-attempt rejection and channel-scoped, monotonic snapshot publication.
 - Unavailable first-return shock evidence.
+- Closed-enum, canonical V2 signals with no numeric HMM projection.
+- Exact T-to-T+1 backtest annotations with no fill or action effect.
+- Deployment artifact pins, immutable trace attributes, and strict
+  pre-entry return-outcome resolution.
 
 The read-only replay prints the causal record and reproduces the 2026 comparison
 without downloading or mutating data.

--- a/etrade_python_client/live_trading/regime_signal.py
+++ b/etrade_python_client/live_trading/regime_signal.py
@@ -1,0 +1,1014 @@
+"""Typed, non-authoritative V2 regime signals.
+
+This is the narrow compatibility boundary between the causal V2 detector and
+read-only consumers such as dashboards and backtest annotations.  It has no
+numeric regime state, posterior, return bucket, or order-facing projection.
+In R4 every signal is advisory by construction.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import re
+from dataclasses import dataclass
+from datetime import date, datetime, timezone
+from enum import Enum
+from typing import Any, Mapping
+
+import pandas as pd
+import pandas_market_calendars as mcal
+import numpy as np
+
+from live_trading.regime_detector_v2 import (
+    BACKGROUND_CALM,
+    BACKGROUND_ELEVATED,
+    BACKGROUND_STRESS,
+    BACKGROUND_UNAVAILABLE,
+    DETECTOR_VERSION,
+    SHOCK_ACTIVE,
+    SHOCK_AFTERSHOCK,
+    SHOCK_NONE,
+    SHOCK_UNAVAILABLE,
+    SIGNAL_TIMESTAMP,
+    regime_detector_code_sha256,
+)
+from live_trading.regime_market_data import regime_market_schedule
+
+
+REGIME_SIGNAL_SCHEMA_VERSION = "regime_signal.v1"
+REGIME_SIGNAL_HASH_DOMAIN = b"regime-signal.v1\0"
+R4_SHADOW_ABSTAIN_REASON = "r4_shadow_non_authoritative"
+_SHA256 = re.compile(r"^[0-9a-f]{64}$")
+_REASON = re.compile(r"^[a-z0-9][a-z0-9_-]{0,127}$")
+NYSE = mcal.get_calendar("NYSE")
+
+
+class RegimeSignalError(ValueError):
+    """Raised when a V2 trace cannot become a safe advisory signal."""
+
+
+class RegimeActionProjectionError(RuntimeError):
+    """Raised for any attempted use of a V2 shadow signal in order logic."""
+
+
+class BackgroundState(str, Enum):
+    UNAVAILABLE = BACKGROUND_UNAVAILABLE
+    CALM = BACKGROUND_CALM
+    ELEVATED = BACKGROUND_ELEVATED
+    PERSISTENT_STRESS = BACKGROUND_STRESS
+
+
+class ShockState(str, Enum):
+    UNAVAILABLE = SHOCK_UNAVAILABLE
+    NONE = SHOCK_NONE
+    ACTIVE = SHOCK_ACTIVE
+    AFTERSHOCK = SHOCK_AFTERSHOCK
+
+
+class SignalSourceFamily(str, Enum):
+    V2_SHADOW = "v2_shadow"
+
+
+class SignalAvailability(str, Enum):
+    ADVISORY = "advisory"
+    UNAVAILABLE = "unavailable"
+
+
+class ReturnBucketStatus(str, Enum):
+    """R4 annotation consumers deliberately do not use return buckets."""
+
+    NOT_USED_SHADOW_ANNOTATION = "not_used_shadow_annotation"
+
+
+def _canonical_json(payload: Any) -> str:
+    return json.dumps(
+        payload,
+        sort_keys=True,
+        separators=(",", ":"),
+        ensure_ascii=False,
+        allow_nan=False,
+    )
+
+
+def _hash(payload: Mapping[str, Any]) -> str:
+    return hashlib.sha256(
+        REGIME_SIGNAL_HASH_DOMAIN + _canonical_json(payload).encode("utf-8")
+    ).hexdigest()
+
+
+def _date(value: Any, field_name: str) -> date:
+    if isinstance(value, pd.Timestamp):
+        if value.tzinfo is not None or value != value.normalize():
+            raise RegimeSignalError(f"{field_name} must be a calendar date")
+        value = value.date()
+    elif isinstance(value, datetime):
+        raise RegimeSignalError(f"{field_name} must be a calendar date")
+    if isinstance(value, str):
+        try:
+            value = date.fromisoformat(value)
+        except ValueError as exc:
+            raise RegimeSignalError(f"{field_name} must be an ISO date") from exc
+    if not isinstance(value, date):
+        raise RegimeSignalError(f"{field_name} must be a calendar date")
+    return value
+
+
+def _utc_datetime(value: Any, field_name: str) -> datetime:
+    try:
+        timestamp = pd.Timestamp(value)
+    except Exception as exc:
+        raise RegimeSignalError(f"{field_name} must be a timestamp") from exc
+    if timestamp.tzinfo is None:
+        raise RegimeSignalError(f"{field_name} must be timezone-aware")
+    return timestamp.tz_convert("UTC").to_pydatetime()
+
+
+def _utc_iso(value: datetime) -> str:
+    return value.astimezone(timezone.utc).isoformat().replace("+00:00", "Z")
+
+
+def _sha256(value: Any, field_name: str) -> str | None:
+    if value is None:
+        return None
+    if not isinstance(value, str) or not _SHA256.fullmatch(value):
+        raise RegimeSignalError(f"{field_name} must be a SHA-256 digest")
+    return value
+
+
+def _optional_text(value: Any, field_name: str) -> str | None:
+    if value is None:
+        return None
+    if not isinstance(value, str) or not value:
+        raise RegimeSignalError(f"{field_name} must be a nonempty string or null")
+    return value
+
+
+def _reason_codes(value: Any, field_name: str) -> tuple[str, ...]:
+    if value is None or value == "":
+        return ()
+    if isinstance(value, str):
+        values = value.split("|")
+    elif isinstance(value, (tuple, list)):
+        values = list(value)
+    else:
+        raise RegimeSignalError(f"{field_name} must be pipe-delimited text or a list")
+    normalized = []
+    for item in values:
+        if not isinstance(item, str) or not _REASON.fullmatch(item):
+            raise RegimeSignalError(f"{field_name} contains an invalid reason code")
+        if item not in normalized:
+            normalized.append(item)
+    return tuple(normalized)
+
+
+def _is_nyse_session(session: date) -> bool:
+    return not NYSE.schedule(start_date=session, end_date=session).empty
+
+
+def next_tradable_session(session: date) -> date:
+    """Return the exact next NYSE session after a close-dated signal."""
+
+    session = _date(session, "signal_session")
+    if not _is_nyse_session(session):
+        raise RegimeSignalError("signal_session must be an NYSE session")
+    schedule = NYSE.schedule(
+        start_date=session,
+        end_date=session + pd.Timedelta(days=14),
+    )
+    sessions = pd.DatetimeIndex(schedule.index).tz_localize(None).normalize()
+    following = sessions[sessions > pd.Timestamp(session)]
+    if len(following) < 1:
+        raise RegimeSignalError("could not resolve the next NYSE session")
+    return following[0].date()
+
+
+def _exact_row_value(row: pd.Series, column: str) -> Any:
+    if column not in row.index:
+        raise RegimeSignalError(f"V2 trace is missing required column: {column}")
+    value = row[column]
+    if value is None or pd.isna(value):
+        raise RegimeSignalError(f"V2 trace has no value for required column: {column}")
+    return value
+
+
+def _exact_bool(row: pd.Series, column: str) -> bool:
+    value = _exact_row_value(row, column)
+    if not isinstance(value, (bool, np.bool_)):
+        raise RegimeSignalError(f"V2 trace column must be boolean: {column}")
+    return bool(value)
+
+
+@dataclass(frozen=True)
+class CausalRecord:
+    """Causal facts required to prevent annotation-to-backtest leakage."""
+
+    calibration_end_session: date | None
+    retrospective_test_start: date | None
+    retrospective_test_end: date | None
+    inference_method: str | None
+    signal_lag_sessions: int | None
+    return_bucket_status: ReturnBucketStatus = (
+        ReturnBucketStatus.NOT_USED_SHADOW_ANNOTATION
+    )
+
+    def __post_init__(self) -> None:
+        for field_name in (
+            "calibration_end_session",
+            "retrospective_test_start",
+            "retrospective_test_end",
+        ):
+            value = getattr(self, field_name)
+            if value is not None:
+                value = _date(value, field_name)
+                if not _is_nyse_session(value):
+                    raise RegimeSignalError(f"{field_name} must be an NYSE session")
+            object.__setattr__(self, field_name, value)
+        if (self.retrospective_test_start is None) != (self.retrospective_test_end is None):
+            raise RegimeSignalError("retrospective test range must be complete or absent")
+        if (
+            self.retrospective_test_start is not None
+            and self.retrospective_test_start > self.retrospective_test_end
+        ):
+            raise RegimeSignalError("retrospective test range is inverted")
+        object.__setattr__(
+            self,
+            "inference_method",
+            _optional_text(self.inference_method, "inference_method"),
+        )
+        if self.signal_lag_sessions is not None:
+            if (
+                isinstance(self.signal_lag_sessions, bool)
+                or not isinstance(self.signal_lag_sessions, int)
+                or self.signal_lag_sessions != 1
+            ):
+                raise RegimeSignalError("R4 signals require exactly one lagged session")
+        try:
+            object.__setattr__(
+                self,
+                "return_bucket_status",
+                ReturnBucketStatus(self.return_bucket_status),
+            )
+        except ValueError as exc:
+            raise RegimeSignalError("unsupported return bucket status") from exc
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "calibration_end_session": (
+                None if self.calibration_end_session is None
+                else self.calibration_end_session.isoformat()
+            ),
+            "retrospective_test_start": (
+                None if self.retrospective_test_start is None
+                else self.retrospective_test_start.isoformat()
+            ),
+            "retrospective_test_end": (
+                None if self.retrospective_test_end is None
+                else self.retrospective_test_end.isoformat()
+            ),
+            "inference_method": self.inference_method,
+            "signal_lag_sessions": self.signal_lag_sessions,
+            "return_bucket_status": self.return_bucket_status.value,
+        }
+
+    @classmethod
+    def from_dict(cls, payload: Mapping[str, Any]) -> "CausalRecord":
+        expected = {
+            "calibration_end_session", "retrospective_test_start",
+            "retrospective_test_end", "inference_method", "signal_lag_sessions",
+            "return_bucket_status",
+        }
+        if not isinstance(payload, Mapping) or set(payload) != expected:
+            raise RegimeSignalError("causal record fields do not match the schema")
+        return cls(
+            calibration_end_session=payload["calibration_end_session"],
+            retrospective_test_start=payload["retrospective_test_start"],
+            retrospective_test_end=payload["retrospective_test_end"],
+            inference_method=payload["inference_method"],
+            signal_lag_sessions=payload["signal_lag_sessions"],
+            return_bucket_status=ReturnBucketStatus(payload["return_bucket_status"]),
+        )
+
+
+@dataclass(frozen=True)
+class RegimeLineage:
+    """Immutable identifiers and causal record required to audit one V2 signal."""
+
+    artifact_sha256: str | None
+    plan_sha256: str | None
+    config_sha256: str
+    detector_version: str
+    detector_code_sha256: str | None
+    calibration_code_sha256: str | None
+    calibration_profile: str | None
+    calibration_status: str | None
+    calibration_provenance: str | None
+    snapshot_sha256: str | None
+    source_provenance_status: str | None
+    evidence_manifest_sha256: str | None
+    evidence_verification_kind: str | None
+    evidence_decision_time_eligible: bool
+    calendar_schedule_sha256: str | None
+    source_policy_sha256: str | None
+    runtime_fingerprint_sha256: str | None
+    causal_record: CausalRecord
+
+    def __post_init__(self) -> None:
+        for field_name in (
+            "artifact_sha256",
+            "plan_sha256",
+            "config_sha256",
+            "detector_code_sha256",
+            "calibration_code_sha256",
+            "snapshot_sha256",
+            "evidence_manifest_sha256",
+            "calendar_schedule_sha256",
+            "source_policy_sha256",
+            "runtime_fingerprint_sha256",
+        ):
+            value = _sha256(getattr(self, field_name), field_name)
+            if field_name == "config_sha256" and value is None:
+                raise RegimeSignalError("config_sha256 is required")
+            object.__setattr__(self, field_name, value)
+        for field_name in (
+            "detector_version",
+            "calibration_profile",
+            "calibration_status",
+            "calibration_provenance",
+            "source_provenance_status",
+            "evidence_verification_kind",
+        ):
+            object.__setattr__(
+                self,
+                field_name,
+                _optional_text(getattr(self, field_name), field_name),
+            )
+        if self.detector_version is None:
+            raise RegimeSignalError("detector_version is required")
+        if self.source_provenance_status not in {
+            None,
+            "unverified",
+            "verified",
+        }:
+            raise RegimeSignalError(
+                "source_provenance_status is outside the closed contract"
+            )
+        if self.evidence_verification_kind not in {
+            None,
+            "decision_time",
+            "verified_replay",
+        }:
+            raise RegimeSignalError(
+                "evidence_verification_kind is outside the closed contract"
+            )
+        if not isinstance(self.evidence_decision_time_eligible, bool):
+            raise RegimeSignalError(
+                "evidence_decision_time_eligible must be boolean"
+            )
+        if self.evidence_manifest_sha256 is not None and (
+            self.snapshot_sha256 is None
+            or self.evidence_verification_kind is None
+        ):
+            raise RegimeSignalError(
+                "evidence lineage requires a snapshot and verification kind"
+            )
+        if self.source_provenance_status == "verified" and (
+            self.snapshot_sha256 is None
+            or self.evidence_manifest_sha256 is None
+        ):
+            raise RegimeSignalError(
+                "verified source provenance requires durable evidence"
+            )
+        if self.source_provenance_status == "unverified" and (
+            self.evidence_manifest_sha256 is not None
+            or self.evidence_verification_kind is not None
+            or self.evidence_decision_time_eligible
+        ):
+            raise RegimeSignalError(
+                "unverified source provenance cannot claim evidence"
+            )
+        if self.evidence_decision_time_eligible and (
+            self.evidence_manifest_sha256 is None
+            or self.evidence_verification_kind != "decision_time"
+        ):
+            raise RegimeSignalError(
+                "decision-time eligibility requires decision-time evidence"
+            )
+        if not isinstance(self.causal_record, CausalRecord):
+            raise TypeError("causal_record must be a CausalRecord")
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "artifact_sha256": self.artifact_sha256,
+            "plan_sha256": self.plan_sha256,
+            "config_sha256": self.config_sha256,
+            "detector_version": self.detector_version,
+            "detector_code_sha256": self.detector_code_sha256,
+            "calibration_code_sha256": self.calibration_code_sha256,
+            "calibration_profile": self.calibration_profile,
+            "calibration_status": self.calibration_status,
+            "calibration_provenance": self.calibration_provenance,
+            "snapshot_sha256": self.snapshot_sha256,
+            "source_provenance_status": self.source_provenance_status,
+            "evidence_manifest_sha256": self.evidence_manifest_sha256,
+            "evidence_verification_kind": self.evidence_verification_kind,
+            "evidence_decision_time_eligible": (
+                self.evidence_decision_time_eligible
+            ),
+            "calendar_schedule_sha256": self.calendar_schedule_sha256,
+            "source_policy_sha256": self.source_policy_sha256,
+            "runtime_fingerprint_sha256": self.runtime_fingerprint_sha256,
+            "causal_record": self.causal_record.to_dict(),
+        }
+
+    @classmethod
+    def from_dict(cls, payload: Mapping[str, Any]) -> "RegimeLineage":
+        expected = {
+            "artifact_sha256", "plan_sha256", "config_sha256",
+            "detector_version", "detector_code_sha256", "calibration_code_sha256",
+            "calibration_profile", "calibration_status", "calibration_provenance",
+            "snapshot_sha256", "source_provenance_status",
+            "evidence_manifest_sha256", "evidence_verification_kind",
+            "evidence_decision_time_eligible", "calendar_schedule_sha256",
+            "source_policy_sha256",
+            "runtime_fingerprint_sha256", "causal_record",
+        }
+        if not isinstance(payload, Mapping) or set(payload) != expected:
+            raise RegimeSignalError("regime lineage fields do not match the schema")
+        values = dict(payload)
+        values["causal_record"] = CausalRecord.from_dict(values["causal_record"])
+        return cls(**values)
+
+
+@dataclass(frozen=True)
+class RegimeSignal:
+    """Lossless V2 background-plus-shock signal for advisory consumers only."""
+
+    as_of_session: date
+    available_at: datetime
+    effective_session: date
+    background_state: BackgroundState
+    shock_state: ShockState
+    availability: SignalAvailability
+    signal_timestamp: str
+    reason_codes: tuple[str, ...]
+    abstain_reasons: tuple[str, ...]
+    data_quality: tuple[str, ...]
+    lineage: RegimeLineage
+    schema_version: str = REGIME_SIGNAL_SCHEMA_VERSION
+    source_family: SignalSourceFamily = SignalSourceFamily.V2_SHADOW
+
+    def __post_init__(self) -> None:
+        if self.schema_version != REGIME_SIGNAL_SCHEMA_VERSION:
+            raise RegimeSignalError("unsupported regime signal schema")
+        if self.source_family is not SignalSourceFamily.V2_SHADOW:
+            raise RegimeSignalError("R4 only supports V2 shadow signals")
+        session = _date(self.as_of_session, "as_of_session")
+        effective = _date(self.effective_session, "effective_session")
+        if not _is_nyse_session(session):
+            raise RegimeSignalError("as_of_session must be an NYSE session")
+        expected_effective = next_tradable_session(session)
+        if effective != expected_effective:
+            raise RegimeSignalError(
+                "effective_session must equal the exact next NYSE tradable session"
+            )
+        object.__setattr__(self, "as_of_session", session)
+        object.__setattr__(self, "effective_session", effective)
+        object.__setattr__(self, "available_at", _utc_datetime(self.available_at, "available_at"))
+        try:
+            object.__setattr__(self, "background_state", BackgroundState(self.background_state))
+            object.__setattr__(self, "shock_state", ShockState(self.shock_state))
+            object.__setattr__(self, "availability", SignalAvailability(self.availability))
+        except ValueError as exc:
+            raise RegimeSignalError("regime state is outside the closed V2 taxonomy") from exc
+        if self.signal_timestamp != SIGNAL_TIMESTAMP:
+            raise RegimeSignalError("signal_timestamp does not match the V2 close policy")
+        if not isinstance(self.lineage, RegimeLineage):
+            raise TypeError("lineage must be a RegimeLineage")
+        object.__setattr__(self, "reason_codes", _reason_codes(self.reason_codes, "reason_codes"))
+        abstain = _reason_codes(self.abstain_reasons, "abstain_reasons")
+        quality = _reason_codes(self.data_quality, "data_quality")
+        if R4_SHADOW_ABSTAIN_REASON not in abstain:
+            abstain = (*abstain, R4_SHADOW_ABSTAIN_REASON)
+        object.__setattr__(self, "abstain_reasons", abstain)
+        object.__setattr__(self, "data_quality", quality)
+        expected_availability = (
+            SignalAvailability.UNAVAILABLE
+            if (
+                self.background_state is BackgroundState.UNAVAILABLE
+                or self.shock_state is ShockState.UNAVAILABLE
+            )
+            else SignalAvailability.ADVISORY
+        )
+        if self.availability is not expected_availability:
+            raise RegimeSignalError("availability does not match V2 state availability")
+
+    @property
+    def may_authorize_execution(self) -> bool:
+        """Hard R4 guardrail: advisory signals can never authorize execution."""
+
+        return False
+
+    @property
+    def composite_label(self) -> str:
+        return f"{self.background_state.value} + {self.shock_state.value}"
+
+    def to_dict(self) -> dict[str, Any]:
+        return {
+            "schema_version": self.schema_version,
+            "source_family": self.source_family.value,
+            "as_of_session": self.as_of_session.isoformat(),
+            "available_at": _utc_iso(self.available_at),
+            "effective_session": self.effective_session.isoformat(),
+            "background_state": self.background_state.value,
+            "shock_state": self.shock_state.value,
+            "availability": self.availability.value,
+            "signal_timestamp": self.signal_timestamp,
+            "reason_codes": list(self.reason_codes),
+            "abstain_reasons": list(self.abstain_reasons),
+            "data_quality": list(self.data_quality),
+            "lineage": self.lineage.to_dict(),
+            "may_authorize_execution": False,
+        }
+
+    @property
+    def signal_sha256(self) -> str:
+        return _hash(self.to_dict())
+
+    def to_envelope(self) -> dict[str, Any]:
+        """Return the primitive, tamper-evident persistence envelope."""
+
+        return {
+            "signal": self.to_dict(),
+            "signal_sha256": self.signal_sha256,
+        }
+
+    def to_json(self) -> str:
+        return _canonical_json(self.to_envelope())
+
+    @classmethod
+    def from_dict(cls, payload: Mapping[str, Any]) -> "RegimeSignal":
+        expected = {
+            "schema_version", "source_family", "as_of_session", "available_at",
+            "effective_session", "background_state", "shock_state", "availability",
+            "signal_timestamp", "reason_codes", "abstain_reasons", "data_quality",
+            "lineage", "may_authorize_execution",
+        }
+        if not isinstance(payload, Mapping) or set(payload) != expected:
+            raise RegimeSignalError("regime signal fields do not match the schema")
+        if payload["may_authorize_execution"] is not False:
+            raise RegimeSignalError("R4 regime signals cannot authorize execution")
+        return cls(
+            schema_version=payload["schema_version"],
+            source_family=SignalSourceFamily(payload["source_family"]),
+            as_of_session=payload["as_of_session"],
+            available_at=payload["available_at"],
+            effective_session=payload["effective_session"],
+            background_state=BackgroundState(payload["background_state"]),
+            shock_state=ShockState(payload["shock_state"]),
+            availability=SignalAvailability(payload["availability"]),
+            signal_timestamp=payload["signal_timestamp"],
+            reason_codes=tuple(payload["reason_codes"]),
+            abstain_reasons=tuple(payload["abstain_reasons"]),
+            data_quality=tuple(payload["data_quality"]),
+            lineage=RegimeLineage.from_dict(payload["lineage"]),
+        )
+
+    @classmethod
+    def from_envelope(
+        cls,
+        envelope: Mapping[str, Any],
+    ) -> "RegimeSignal":
+        if not isinstance(envelope, Mapping) or set(envelope) != {"signal", "signal_sha256"}:
+            raise RegimeSignalError("regime signal envelope fields do not match the schema")
+        signal = cls.from_dict(envelope["signal"])
+        if not isinstance(envelope["signal_sha256"], str) or signal.signal_sha256 != envelope["signal_sha256"]:
+            raise RegimeSignalError("regime signal hash does not match")
+        return signal
+
+    @classmethod
+    def from_json(cls, payload: str) -> "RegimeSignal":
+        if not isinstance(payload, str):
+            raise TypeError("regime signal JSON must be a string")
+        try:
+            envelope = json.loads(payload)
+        except json.JSONDecodeError as exc:
+            raise RegimeSignalError("regime signal is not valid JSON") from exc
+        if _canonical_json(envelope) != payload:
+            raise RegimeSignalError("regime signal JSON must be canonical")
+        return cls.from_envelope(envelope)
+
+    def to_dashboard_payload(self) -> dict[str, Any]:
+        """Return an explicit V2-only payload with no action-facing fields."""
+
+        return {
+            "available": self.availability is SignalAvailability.ADVISORY,
+            "source_family": self.source_family.value,
+            "schema_version": self.schema_version,
+            "as_of_session": self.as_of_session.isoformat(),
+            "effective_session": self.effective_session.isoformat(),
+            "available_at": _utc_iso(self.available_at),
+            "background_state": self.background_state.value,
+            "shock_state": self.shock_state.value,
+            "composite_label": self.composite_label,
+            "reason_codes": list(self.reason_codes),
+            "abstain_reasons": list(self.abstain_reasons),
+            "data_quality": list(self.data_quality),
+            "lineage": self.lineage.to_dict(),
+            "may_authorize_execution": False,
+            "signal_sha256": self.signal_sha256,
+        }
+
+    def to_action_projection(self) -> None:
+        raise RegimeActionProjectionError(
+            "V2 shadow signals have no action projection in R4"
+        )
+
+
+def _trace_lineage(trace: pd.DataFrame, row: pd.Series, artifact: Any | None) -> RegimeLineage:
+    def optional_column(name: str) -> Any:
+        if name not in row.index or pd.isna(row[name]):
+            return None
+        return row[name]
+
+    detector_code = trace.attrs.get("detector_code_sha256")
+    runtime_fingerprint = trace.attrs.get("runtime_fingerprint_sha256")
+    lineage = RegimeLineage(
+        artifact_sha256=optional_column("Calibration_Artifact_SHA256"),
+        plan_sha256=optional_column("Calibration_Plan_SHA256"),
+        config_sha256=str(_exact_row_value(row, "Config_Hash")),
+        detector_version=str(_exact_row_value(row, "Detector_Version")),
+        detector_code_sha256=detector_code,
+        calibration_code_sha256=None,
+        calibration_profile=optional_column("Calibration_Profile"),
+        calibration_status=optional_column("Calibration_Status"),
+        calibration_provenance=optional_column("Calibration_Provenance"),
+        snapshot_sha256=optional_column("Input_Snapshot_SHA256"),
+        source_provenance_status=optional_column("Input_Provenance_Status"),
+        evidence_manifest_sha256=optional_column(
+            "Evidence_Manifest_SHA256"
+        ),
+        evidence_verification_kind=optional_column(
+            "Evidence_Verification_Kind"
+        ),
+        evidence_decision_time_eligible=(
+            _exact_bool(row, "Evidence_Decision_Time_Eligible")
+            if "Evidence_Decision_Time_Eligible" in row.index
+            else False
+        ),
+        calendar_schedule_sha256=optional_column(
+            "Calendar_Schedule_SHA256"
+        ),
+        source_policy_sha256=optional_column("Source_Policy_SHA256"),
+        runtime_fingerprint_sha256=runtime_fingerprint,
+        causal_record=CausalRecord(
+            calibration_end_session=None,
+            retrospective_test_start=None,
+            retrospective_test_end=None,
+            inference_method=None,
+            signal_lag_sessions=None,
+        ),
+    )
+    attr_version = trace.attrs.get("detector_version")
+    attr_config = trace.attrs.get("config_hash")
+    if attr_version is not None and attr_version != lineage.detector_version:
+        raise RegimeSignalError("trace detector version does not match its rows")
+    if attr_config is not None and attr_config != lineage.config_sha256:
+        raise RegimeSignalError("trace config hash does not match its rows")
+    for attr_name, expected in (
+        ("input_snapshot_sha256", lineage.snapshot_sha256),
+        (
+            "calendar_schedule_sha256",
+            lineage.calendar_schedule_sha256,
+        ),
+        ("source_policy_sha256", lineage.source_policy_sha256),
+        (
+            "evidence_manifest_sha256",
+            lineage.evidence_manifest_sha256,
+        ),
+        (
+            "evidence_verification_kind",
+            lineage.evidence_verification_kind,
+        ),
+        (
+            "evidence_decision_time_eligible",
+            lineage.evidence_decision_time_eligible,
+        ),
+    ):
+        actual = trace.attrs.get(attr_name)
+        if actual is not None and actual != expected:
+            raise RegimeSignalError(
+                f"trace {attr_name} does not match its rows"
+            )
+    source_verified = trace.attrs.get("source_provenance_verified")
+    if source_verified is not None:
+        if not isinstance(source_verified, (bool, np.bool_)):
+            raise RegimeSignalError(
+                "trace source_provenance_verified must be boolean"
+            )
+        expected_verified = (
+            lineage.source_provenance_status == "verified"
+        )
+        if bool(source_verified) != expected_verified:
+            raise RegimeSignalError(
+                "trace source provenance does not match its rows"
+            )
+    if lineage.detector_version != DETECTOR_VERSION:
+        raise RegimeSignalError("trace detector version is stale")
+    if (
+        lineage.detector_code_sha256 is not None
+        and lineage.detector_code_sha256 != regime_detector_code_sha256()
+    ):
+        raise RegimeSignalError("trace detector code hash is stale")
+
+    if artifact is None:
+        return lineage
+
+    from live_trading.regime_calibration import (
+        RegimeCalibrationArtifact,
+        regime_calibration_code_sha256,
+    )
+
+    if not isinstance(artifact, RegimeCalibrationArtifact):
+        raise TypeError("artifact must be a RegimeCalibrationArtifact")
+    for attr_name, expected in (
+        ("calibration_artifact_sha256", lineage.artifact_sha256),
+        ("calibration_plan_sha256", lineage.plan_sha256),
+        ("calibration_profile", lineage.calibration_profile),
+        ("calibration_status", lineage.calibration_status),
+        ("calibration_provenance", lineage.calibration_provenance),
+    ):
+        actual = trace.attrs.get(attr_name)
+        if actual is not None and actual != expected:
+            raise RegimeSignalError(f"trace {attr_name} does not match its rows")
+    if artifact.execution_eligible is not False:
+        raise RegimeSignalError("calibration artifact cannot authorize execution")
+    if artifact.plan.detector_version != DETECTOR_VERSION:
+        raise RegimeSignalError("calibration artifact detector version is stale")
+    if artifact.plan.detector_code_sha256 != regime_detector_code_sha256():
+        raise RegimeSignalError("calibration artifact detector code hash is stale")
+    if artifact.plan.calibration_code_sha256 != regime_calibration_code_sha256():
+        raise RegimeSignalError("calibration artifact calibration code hash is stale")
+    if lineage.artifact_sha256 != artifact.artifact_sha256:
+        raise RegimeSignalError("trace artifact hash does not match the artifact")
+    if lineage.plan_sha256 != artifact.plan.plan_sha256:
+        raise RegimeSignalError("trace plan hash does not match the artifact")
+    if lineage.config_sha256 != artifact.selected_candidate.config_sha256:
+        raise RegimeSignalError("trace config hash does not match the artifact")
+    if lineage.calibration_profile != artifact.selected_candidate_id:
+        raise RegimeSignalError("trace calibration profile does not match the artifact")
+    if lineage.calibration_status != artifact.promotion_status:
+        raise RegimeSignalError("trace calibration status does not match the artifact")
+    if lineage.calibration_provenance != artifact.data_manifest.provenance_status:
+        raise RegimeSignalError("trace calibration provenance does not match the artifact")
+    if (
+        lineage.detector_code_sha256 is not None
+        and lineage.detector_code_sha256 != artifact.plan.detector_code_sha256
+    ):
+        raise RegimeSignalError("trace detector code hash does not match the artifact")
+    return RegimeLineage(
+        **{
+            **lineage.to_dict(),
+            "detector_code_sha256": artifact.plan.detector_code_sha256,
+            "calibration_code_sha256": artifact.plan.calibration_code_sha256,
+            "causal_record": CausalRecord(
+                calibration_end_session=(
+                    artifact.plan.selection_folds[-1].evaluation_end
+                ),
+                retrospective_test_start=(
+                    artifact.plan.retrospective_test.evaluation_start
+                ),
+                retrospective_test_end=(
+                    artifact.plan.retrospective_test.evaluation_end
+                ),
+                inference_method=artifact.plan.inference_method,
+                signal_lag_sessions=artifact.plan.signal_lag_sessions,
+            ),
+        }
+    )
+
+
+def _trace_signal(trace: pd.DataFrame, session: date, row: pd.Series, artifact: Any | None) -> RegimeSignal:
+    background = BackgroundState(str(_exact_row_value(row, "Background_State")))
+    shock = ShockState(str(_exact_row_value(row, "Shock_State")))
+    if "Composite_Regime" in row.index:
+        expected_composite = f"{background.value}+{shock.value}"
+        if _exact_row_value(row, "Composite_Regime") != expected_composite:
+            raise RegimeSignalError(
+                "trace composite regime does not match its two axes"
+            )
+    if _exact_row_value(row, "Regime_Signal_Timestamp") != SIGNAL_TIMESTAMP:
+        raise RegimeSignalError("trace signal timestamp does not match the V2 close policy")
+    if _exact_bool(row, "Execution_Eligible"):
+        raise RegimeSignalError("V2 trace must remain execution-ineligible")
+    if "Calibration_Execution_Eligible" in row.index:
+        if _exact_bool(row, "Calibration_Execution_Eligible"):
+            raise RegimeSignalError("calibrated V2 trace must remain execution-ineligible")
+    if "Calibration_Abstain" in row.index:
+        if not _exact_bool(row, "Calibration_Abstain"):
+            raise RegimeSignalError("calibrated V2 trace must explicitly abstain")
+    effective = _date(_exact_row_value(row, "Tradable_Session"), "Tradable_Session")
+    expected = next_tradable_session(session)
+    if effective != expected:
+        raise RegimeSignalError("Tradable_Session is not the exact next NYSE session")
+    available_at = _utc_datetime(
+        _exact_row_value(row, "Signal_Available_At"),
+        "Signal_Available_At",
+    )
+    finalization = pd.Timestamp(
+        regime_market_schedule(session, session).iloc[0]["joint_finalization_at"]
+    ).to_pydatetime()
+    if available_at < finalization:
+        raise RegimeSignalError("Signal_Available_At precedes joint close finalization")
+    next_open = pd.Timestamp(
+        NYSE.schedule(start_date=effective, end_date=effective).iloc[0]["market_open"]
+    ).to_pydatetime()
+    if available_at >= next_open:
+        raise RegimeSignalError("Signal_Available_At is too late for the next session")
+    abstain = list(_reason_codes(row.get("Calibration_Abstain_Reasons"), "Calibration_Abstain_Reasons"))
+    if artifact is None:
+        missing_reason = (
+            "calibration_artifact_unverified"
+            if "Calibration_Artifact_SHA256" in row.index
+            else "calibration_lineage_missing"
+        )
+        if missing_reason not in abstain:
+            abstain.append(missing_reason)
+    if "execution_ineligible" not in abstain:
+        abstain.append("execution_ineligible")
+    return RegimeSignal(
+        as_of_session=session,
+        available_at=available_at,
+        effective_session=effective,
+        background_state=background,
+        shock_state=shock,
+        availability=(
+            SignalAvailability.UNAVAILABLE
+            if background is BackgroundState.UNAVAILABLE or shock is ShockState.UNAVAILABLE
+            else SignalAvailability.ADVISORY
+        ),
+        signal_timestamp=SIGNAL_TIMESTAMP,
+        reason_codes=_reason_codes(_exact_row_value(row, "Reason_Codes"), "Reason_Codes"),
+        abstain_reasons=tuple(abstain),
+        data_quality=_reason_codes(_exact_row_value(row, "Data_Quality"), "Data_Quality"),
+        lineage=_trace_lineage(trace, row, artifact),
+    )
+
+
+def from_calibrated_v2_trace(
+    trace: pd.DataFrame,
+    *,
+    artifact: Any | None = None,
+    expected_artifact_sha256: str | None = None,
+) -> dict[str, RegimeSignal]:
+    """Adapt an authentic V2 trace into exact effective-session annotations.
+
+    The returned dictionary is keyed only by the trace's explicit
+    ``Tradable_Session`` values.  It does not forward-fill, infer, or map a
+    V2 state into an HMM integer.  Any schema, lineage, or timing discrepancy
+    raises :class:`RegimeSignalError` rather than producing an action-capable
+    fallback.
+    """
+
+    if not isinstance(trace, pd.DataFrame) or trace.empty:
+        raise RegimeSignalError("V2 trace must be a nonempty pandas DataFrame")
+    if artifact is None and expected_artifact_sha256 is not None:
+        raise RegimeSignalError(
+            "expected_artifact_sha256 requires a calibration artifact"
+        )
+    if artifact is not None:
+        from live_trading.regime_calibration import RegimeCalibrationArtifact
+
+        if not isinstance(artifact, RegimeCalibrationArtifact):
+            raise TypeError("artifact must be a RegimeCalibrationArtifact")
+        expected_hash = _sha256(
+            expected_artifact_sha256,
+            "expected_artifact_sha256",
+        )
+        if expected_hash is None:
+            raise RegimeSignalError(
+                "calibrated V2 traces require a deployment-pinned artifact hash"
+            )
+        if artifact.artifact_sha256 != expected_hash:
+            raise RegimeSignalError(
+                "calibration artifact does not match the deployment pin"
+            )
+        required_calibration_columns = {
+            "Calibration_Artifact_SHA256",
+            "Calibration_Plan_SHA256",
+            "Calibration_Profile",
+            "Calibration_Status",
+            "Calibration_Provenance",
+            "Calibration_Abstain",
+            "Calibration_Abstain_Reasons",
+            "Calibration_Execution_Eligible",
+        }
+        missing = sorted(required_calibration_columns.difference(trace.columns))
+        if missing:
+            raise RegimeSignalError(
+                "calibrated V2 trace is missing lineage columns: "
+                f"{missing}"
+            )
+        required_attrs = {
+            "detector_version",
+            "config_hash",
+            "detector_code_sha256",
+            "runtime_fingerprint_sha256",
+            "calibration_artifact_sha256",
+            "calibration_plan_sha256",
+            "calibration_profile",
+            "calibration_status",
+            "calibration_provenance",
+            "calibration_execution_eligible",
+            "calibration_abstain",
+            "execution_eligible",
+        }
+        missing_attrs = sorted(required_attrs.difference(trace.attrs))
+        if missing_attrs:
+            raise RegimeSignalError(
+                "calibrated V2 trace is missing immutable attributes: "
+                f"{missing_attrs}"
+            )
+        if (
+            trace.attrs["calibration_execution_eligible"] is not False
+            or trace.attrs["calibration_abstain"] is not True
+            or trace.attrs["execution_eligible"] is not False
+        ):
+            raise RegimeSignalError(
+                "calibrated V2 trace must remain abstaining and "
+                "execution-ineligible"
+            )
+    try:
+        index = pd.DatetimeIndex(pd.to_datetime(trace.index, errors="raise"))
+    except Exception as exc:
+        raise RegimeSignalError("V2 trace index must contain session dates") from exc
+    if index.tz is not None:
+        index = index.tz_localize(None)
+    index = index.normalize()
+    if index.has_duplicates or not index.is_monotonic_increasing:
+        raise RegimeSignalError("V2 trace sessions must be unique and sorted")
+    if any(not _is_nyse_session(item.date()) for item in index):
+        raise RegimeSignalError("V2 trace sessions must be NYSE sessions")
+
+    frame = trace.copy()
+    frame.index = index
+    annotations: dict[str, RegimeSignal] = {}
+    for timestamp, row in frame.iterrows():
+        signal = _trace_signal(frame, timestamp.date(), row, artifact)
+        key = signal.effective_session.isoformat()
+        if key in annotations:
+            raise RegimeSignalError("V2 trace produced duplicate effective sessions")
+        annotations[key] = signal
+    return annotations
+
+
+def annotation_for_session(
+    annotations: Mapping[str, RegimeSignal],
+    session: date | str,
+) -> RegimeSignal | None:
+    """Return an annotation only for its exact effective date; never fill."""
+
+    if not isinstance(annotations, Mapping):
+        raise TypeError("annotations must be a mapping")
+    target = _date(session, "session").isoformat()
+    signal = annotations.get(target)
+    if signal is None:
+        return None
+    if not isinstance(signal, RegimeSignal):
+        raise TypeError("annotation mapping contains a non-RegimeSignal value")
+    if signal.effective_session.isoformat() != target:
+        raise RegimeSignalError("annotation key does not match effective_session")
+    return signal
+
+
+def to_dashboard_payload(signal: RegimeSignal) -> dict[str, Any]:
+    if not isinstance(signal, RegimeSignal):
+        raise TypeError("signal must be a RegimeSignal")
+    return signal.to_dashboard_payload()
+
+
+def to_action_projection(signal: RegimeSignal) -> None:
+    if not isinstance(signal, RegimeSignal):
+        raise TypeError("signal must be a RegimeSignal")
+    return signal.to_action_projection()
+
+
+__all__ = [
+    "BackgroundState",
+    "CausalRecord",
+    "R4_SHADOW_ABSTAIN_REASON",
+    "REGIME_SIGNAL_SCHEMA_VERSION",
+    "RegimeActionProjectionError",
+    "RegimeLineage",
+    "RegimeSignal",
+    "RegimeSignalError",
+    "ReturnBucketStatus",
+    "ShockState",
+    "SignalAvailability",
+    "SignalSourceFamily",
+    "annotation_for_session",
+    "from_calibrated_v2_trace",
+    "next_tradable_session",
+    "to_action_projection",
+    "to_dashboard_payload",
+]

--- a/etrade_python_client/tests/test_regime_backtest_parity.py
+++ b/etrade_python_client/tests/test_regime_backtest_parity.py
@@ -1,0 +1,242 @@
+import unittest
+from dataclasses import asdict
+from unittest.mock import patch
+
+import numpy as np
+import pandas as pd
+
+import backtesting.backtest_runner as backtest_module
+from backtesting.backtest_runner import (
+    SpreadTrade,
+    _forward_return_assignment_strike,
+    lag_daily_regime_map,
+    validate_regime_v2_annotations,
+)
+from live_trading.regime_detector_v2 import DETECTOR_VERSION, SIGNAL_TIMESTAMP
+from live_trading.regime_signal import from_calibrated_v2_trace
+
+
+def _annotations():
+    trace = pd.DataFrame(
+        {
+            "Background_State": ["elevated"],
+            "Shock_State": ["active"],
+            "Signal_Available_At": ["2025-04-03T20:15:00Z"],
+            "Tradable_Session": ["2025-04-04"],
+            "Detector_Version": [DETECTOR_VERSION],
+            "Config_Hash": ["a" * 64],
+            "Regime_Signal_Timestamp": [SIGNAL_TIMESTAMP],
+            "Reason_Codes": ["vix_daily_change_extreme"],
+            "Data_Quality": [
+                "exchange_sessions_and_source_times_valid"
+            ],
+            "Execution_Eligible": [False],
+        },
+        index=pd.DatetimeIndex(["2025-04-03"]),
+    )
+    trace.attrs["detector_version"] = DETECTOR_VERSION
+    trace.attrs["config_hash"] = "a" * 64
+    return from_calibrated_v2_trace(trace)
+
+
+class RegimeBacktestParityTests(unittest.TestCase):
+    def test_v2_annotations_are_typed_exact_and_do_not_change_legacy_map(self):
+        legacy = {"2025-04-03": 2}
+        sessions = ["2025-04-03", "2025-04-04", "2025-04-07"]
+        before = lag_daily_regime_map(legacy, sessions)
+
+        annotations = validate_regime_v2_annotations(_annotations())
+
+        self.assertEqual(lag_daily_regime_map(legacy, sessions), before)
+        self.assertEqual(set(annotations), {"2025-04-04"})
+        self.assertEqual(
+            annotations["2025-04-04"].composite_label,
+            "elevated + active",
+        )
+        self.assertFalse(
+            annotations["2025-04-04"].may_authorize_execution
+        )
+        with self.assertRaises(TypeError):
+            validate_regime_v2_annotations({"2025-04-04": 2})
+        with self.assertRaises(ValueError):
+            validate_regime_v2_annotations(
+                {"2025-04-07": annotations["2025-04-04"]}
+            )
+
+    def test_trade_audit_preserves_v2_without_numeric_coercion(self):
+        signal = _annotations()["2025-04-04"]
+        payload = signal.to_envelope()
+        trade = SpreadTrade(
+            entry_date="2025-04-04",
+            entry_regime=2,
+            entry_regime_name="Panic / Crisis",
+            entry_regime_v2=payload,
+        )
+
+        serialized = asdict(trade)
+        self.assertEqual(serialized["entry_regime"], 2)
+        self.assertEqual(
+            serialized["entry_regime_v2"]["signal"]["background_state"],
+            "elevated",
+        )
+        self.assertEqual(
+            serialized["entry_regime_v2"]["signal"]["shock_state"],
+            "active",
+        )
+        self.assertFalse(
+            serialized["entry_regime_v2"]["signal"][
+                "may_authorize_execution"
+            ]
+        )
+        self.assertEqual(
+            serialized["entry_regime_v2"]["signal_sha256"],
+            signal.signal_sha256,
+        )
+
+    def test_forward_bucket_requires_entry_date_and_prior_resolution(self):
+        dates = pd.bdate_range("2025-01-02", periods=40)
+        prices = pd.Series(
+            100.0 * np.exp(np.linspace(0.0, 0.12, len(dates))),
+            index=[item.date().isoformat() for item in dates],
+        )
+        entry = dates[30].date().isoformat()
+
+        strike, diagnostics = _forward_return_assignment_strike(
+            underlying_prices=prices,
+            trading_dates=list(prices.index),
+            trading_date_index={
+                item: position for position, item in enumerate(prices.index)
+            },
+            as_of_date=entry,
+            current_spot=float(prices.loc[entry]),
+            option_horizon_days=7,
+            target_assignment_prob=0.05,
+        )
+
+        self.assertIsNotNone(strike)
+        self.assertTrue(
+            diagnostics["outcomes_resolved_strictly_before_entry"]
+        )
+        self.assertLess(
+            diagnostics["latest_resolution_session"],
+            entry,
+        )
+
+        missing, reason = _forward_return_assignment_strike(
+            underlying_prices=prices,
+            trading_dates=list(prices.index),
+            trading_date_index={},
+            as_of_date="2025-12-31",
+            current_spot=100.0,
+            option_horizon_days=7,
+            target_assignment_prob=0.05,
+        )
+        self.assertIsNone(missing)
+        self.assertEqual(
+            reason["reason"],
+            "as_of_date_missing_from_underlying_prices",
+        )
+
+
+class _NoDataCache:
+    def __init__(self, *_args, **_kwargs):
+        pass
+
+    def clear_daily_memory_cache(self):
+        pass
+
+    def close(self):
+        pass
+
+
+class _NoContractsClient:
+    def __init__(self, *_args, **_kwargs):
+        self.api_calls = 0
+        self.cache_hits = 0
+
+    async def __aenter__(self):
+        return self
+
+    async def __aexit__(self, *_args):
+        return False
+
+    async def fetch_contracts_list(self, *_args, **_kwargs):
+        return []
+
+    async def fetch_chain_ohlcv_batch(self, *_args, **_kwargs):
+        return 0
+
+
+class RegimeBacktestRunnerParityTests(unittest.IsolatedAsyncioTestCase):
+    async def test_runner_actions_are_identical_with_shadow_annotation(self):
+        index = pd.bdate_range("2011-05-03", "2025-04-04")
+        underlying = pd.Series(
+            np.linspace(100.0, 500.0, len(index)),
+            index=index.strftime("%Y-%m-%d"),
+        )
+        vix = pd.Series(
+            [18.0, 18.5],
+            index=["2025-04-03", "2025-04-04"],
+        )
+
+        async def run(regime_v2_annotations=None):
+            with (
+                patch.object(
+                    backtest_module,
+                    "OptionDataCache",
+                    _NoDataCache,
+                ),
+                patch.object(
+                    backtest_module,
+                    "MassiveAPIClient",
+                    _NoContractsClient,
+                ),
+                patch.object(
+                    backtest_module,
+                    "_fetch_underlying_prices",
+                    return_value=pd.Series(
+                        [5.0],
+                        index=["2025-04-04"],
+                    ),
+                ),
+            ):
+                return await backtest_module.run_put_credit_spread_backtest(
+                    start_date="2025-04-04",
+                    end_date="2025-04-04",
+                    underlying_prices=underlying,
+                    vix_prices=vix,
+                    regime_v2_annotations=regime_v2_annotations,
+                    offline_only=True,
+                )
+
+        baseline = await run()
+        annotated = await run(_annotations())
+
+        for field_name in (
+            "trades",
+            "total_pnl",
+            "capital_history",
+            "cash_history",
+            "nvl_history",
+            "margin_history",
+            "regime_history",
+        ):
+            self.assertEqual(
+                getattr(annotated, field_name),
+                getattr(baseline, field_name),
+            )
+        self.assertEqual(baseline.regime_v2_history, [("2025-04-04", None)])
+        envelope = annotated.regime_v2_history[0][1]
+        self.assertEqual(
+            envelope["signal"]["background_state"],
+            "elevated",
+        )
+        self.assertEqual(
+            envelope["signal"]["shock_state"],
+            "active",
+        )
+        self.assertIn("signal_sha256", envelope)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/etrade_python_client/tests/test_regime_signal.py
+++ b/etrade_python_client/tests/test_regime_signal.py
@@ -1,0 +1,359 @@
+import dataclasses
+import json
+import unittest
+from datetime import date
+from types import SimpleNamespace
+from unittest.mock import patch
+
+import pandas as pd
+import pandas_market_calendars as mcal
+import numpy as np
+
+import live_trading.regime_calibration as calibration_module
+from live_trading.regime_calibration import (
+    CalibrationCandidate,
+    CausalValidationFold,
+    RegimeCalibrationPlan,
+    detect_regimes_with_calibration_artifact,
+    regime_calibration_code_sha256,
+    run_research_calibration,
+)
+from live_trading.regime_detector_v2 import (
+    DETECTOR_VERSION,
+    RegimeDetectorConfig,
+    SIGNAL_TIMESTAMP,
+    regime_detector_code_sha256,
+)
+from live_trading.regime_market_data import regime_market_schedule
+from live_trading.regime_signal import (
+    BackgroundState,
+    R4_SHADOW_ABSTAIN_REASON,
+    RegimeActionProjectionError,
+    RegimeSignal,
+    RegimeSignalError,
+    ShockState,
+    annotation_for_session,
+    from_calibrated_v2_trace,
+    next_tradable_session,
+    to_action_projection,
+)
+
+
+CONFIG_HASH = "a" * 64
+NYSE = mcal.get_calendar("NYSE")
+
+
+def _trace(*, tradable_session="2025-04-04", execution_eligible=False):
+    frame = pd.DataFrame(
+        {
+            "Background_State": ["elevated", "persistent_stress"],
+            "Shock_State": ["active", "none"],
+            "Signal_Available_At": [
+                "2025-04-03T20:15:00Z",
+                "2025-04-04T20:15:00Z",
+            ],
+            "Tradable_Session": [tradable_session, "2025-04-07"],
+            "Detector_Version": [DETECTOR_VERSION, DETECTOR_VERSION],
+            "Config_Hash": [CONFIG_HASH, CONFIG_HASH],
+            "Regime_Signal_Timestamp": [SIGNAL_TIMESTAMP, SIGNAL_TIMESTAMP],
+            "Reason_Codes": ["vix_daily_change_extreme", "persistent_score_confirmed"],
+            "Data_Quality": [
+                "exchange_sessions_and_source_times_valid",
+                "exchange_sessions_and_source_times_valid",
+            ],
+            "Execution_Eligible": [execution_eligible, False],
+        },
+        index=pd.DatetimeIndex(["2025-04-03", "2025-04-04"]),
+    )
+    frame.attrs["detector_version"] = DETECTOR_VERSION
+    frame.attrs["config_hash"] = CONFIG_HASH
+    return frame
+
+
+class _FakeArtifact:
+    artifact_sha256 = "1" * 64
+    execution_eligible = False
+    selected_candidate_id = "baseline"
+    promotion_status = "research_only"
+    selected_candidate = SimpleNamespace(config_sha256=CONFIG_HASH)
+    data_manifest = SimpleNamespace(
+        provenance_status="legacy_normalized_unverified",
+    )
+    plan = SimpleNamespace(
+        detector_version=DETECTOR_VERSION,
+        detector_code_sha256=regime_detector_code_sha256(),
+        calibration_code_sha256=regime_calibration_code_sha256(),
+        plan_sha256="2" * 64,
+        selection_folds=(
+            SimpleNamespace(evaluation_end=date(2024, 12, 31)),
+        ),
+        retrospective_test=SimpleNamespace(
+            evaluation_start=date(2025, 1, 2),
+            evaluation_end=date(2025, 12, 31),
+        ),
+        inference_method="causal_prefix_filter",
+        signal_lag_sessions=1,
+    )
+
+
+def _calibrated_trace():
+    frame = _trace()
+    frame["Calibration_Artifact_SHA256"] = _FakeArtifact.artifact_sha256
+    frame["Calibration_Plan_SHA256"] = _FakeArtifact.plan.plan_sha256
+    frame["Calibration_Profile"] = _FakeArtifact.selected_candidate_id
+    frame["Calibration_Status"] = _FakeArtifact.promotion_status
+    frame["Calibration_Provenance"] = (
+        _FakeArtifact.data_manifest.provenance_status
+    )
+    frame["Calibration_Abstain"] = True
+    frame["Calibration_Abstain_Reasons"] = "research_only"
+    frame["Calibration_Execution_Eligible"] = False
+    frame.attrs.update(
+        {
+            "detector_code_sha256": (
+                _FakeArtifact.plan.detector_code_sha256
+            ),
+            "runtime_fingerprint_sha256": "3" * 64,
+            "calibration_artifact_sha256": (
+                _FakeArtifact.artifact_sha256
+            ),
+            "calibration_plan_sha256": _FakeArtifact.plan.plan_sha256,
+            "calibration_profile": _FakeArtifact.selected_candidate_id,
+            "calibration_status": _FakeArtifact.promotion_status,
+            "calibration_provenance": (
+                _FakeArtifact.data_manifest.provenance_status
+            ),
+            "calibration_execution_eligible": False,
+            "calibration_abstain": True,
+            "execution_eligible": False,
+        }
+    )
+    return frame
+
+
+class RegimeSignalTests(unittest.TestCase):
+    def test_v2_adapter_preserves_two_axes_and_exact_lookup(self):
+        annotations = from_calibrated_v2_trace(_trace())
+
+        first = annotation_for_session(annotations, "2025-04-04")
+        second = annotation_for_session(annotations, "2025-04-07")
+        self.assertIsNotNone(first)
+        self.assertEqual(first.background_state, BackgroundState.ELEVATED)
+        self.assertEqual(first.shock_state, ShockState.ACTIVE)
+        self.assertEqual(second.background_state, BackgroundState.PERSISTENT_STRESS)
+        self.assertEqual(second.shock_state, ShockState.NONE)
+        self.assertIsNone(annotation_for_session(annotations, "2025-04-05"))
+        self.assertIsNone(annotation_for_session(annotations, "2025-04-08"))
+        self.assertIn("calibration_lineage_missing", first.abstain_reasons)
+        self.assertIn(R4_SHADOW_ABSTAIN_REASON, first.abstain_reasons)
+        self.assertFalse(first.may_authorize_execution)
+
+    def test_canonical_round_trip_hash_and_dashboard_payload(self):
+        signal = annotation_for_session(from_calibrated_v2_trace(_trace()), "2025-04-04")
+        encoded = signal.to_json()
+        self.assertEqual(RegimeSignal.from_json(encoded), signal)
+        payload = signal.to_dashboard_payload()
+        self.assertTrue(payload["available"])
+        self.assertEqual(payload["background_state"], "elevated")
+        self.assertEqual(payload["shock_state"], "active")
+        self.assertFalse(payload["may_authorize_execution"])
+        self.assertNotIn("state", {key for key in payload if key.startswith("hmm_")})
+        with self.assertRaises(dataclasses.FrozenInstanceError):
+            signal.background_state = BackgroundState.CALM
+        with self.assertRaises(RegimeActionProjectionError):
+            to_action_projection(signal)
+
+    def test_timing_and_execution_mismatches_fail_closed(self):
+        with self.assertRaisesRegex(RegimeSignalError, "exact next NYSE"):
+            from_calibrated_v2_trace(_trace(tradable_session="2025-04-07"))
+        with self.assertRaisesRegex(RegimeSignalError, "execution-ineligible"):
+            from_calibrated_v2_trace(_trace(execution_eligible=True))
+        self.assertEqual(next_tradable_session("2025-04-03").isoformat(), "2025-04-04")
+        self.assertEqual(next_tradable_session("2025-04-04").isoformat(), "2025-04-07")
+
+    def test_hash_or_schema_tampering_fails_closed(self):
+        signal = annotation_for_session(from_calibrated_v2_trace(_trace()), "2025-04-04")
+        envelope = signal.to_json().replace(CONFIG_HASH, "b" * 64)
+        with self.assertRaisesRegex(RegimeSignalError, "hash does not match"):
+            RegimeSignal.from_json(envelope)
+        persisted = json.loads(signal.to_json())
+        persisted["signal"]["background_state"] = "calm"
+        with self.assertRaisesRegex(RegimeSignalError, "hash does not match"):
+            RegimeSignal.from_envelope(persisted)
+        malformed = _trace()
+        malformed.loc[malformed.index[0], "Detector_Version"] = "unexpected"
+        with self.assertRaisesRegex(RegimeSignalError, "detector version"):
+            from_calibrated_v2_trace(malformed)
+
+    def test_calibrated_adapter_requires_pin_and_immutable_attributes(self):
+        artifact = _FakeArtifact()
+        trace = _calibrated_trace()
+
+        with patch.object(
+            calibration_module,
+            "RegimeCalibrationArtifact",
+            _FakeArtifact,
+        ):
+            with self.assertRaisesRegex(
+                RegimeSignalError,
+                "deployment-pinned",
+            ):
+                from_calibrated_v2_trace(trace, artifact=artifact)
+            with self.assertRaisesRegex(
+                RegimeSignalError,
+                "deployment pin",
+            ):
+                from_calibrated_v2_trace(
+                    trace,
+                    artifact=artifact,
+                    expected_artifact_sha256="f" * 64,
+                )
+
+            stripped = trace.copy()
+            stripped.attrs = {}
+            with self.assertRaisesRegex(
+                RegimeSignalError,
+                "immutable attributes",
+            ):
+                from_calibrated_v2_trace(
+                    stripped,
+                    artifact=artifact,
+                    expected_artifact_sha256=artifact.artifact_sha256,
+                )
+
+            signal = annotation_for_session(
+                from_calibrated_v2_trace(
+                    trace,
+                    artifact=artifact,
+                    expected_artifact_sha256=artifact.artifact_sha256,
+                ),
+                "2025-04-04",
+            )
+            causal = signal.lineage.causal_record
+            self.assertEqual(
+                causal.calibration_end_session,
+                date(2024, 12, 31),
+            )
+            self.assertEqual(causal.signal_lag_sessions, 1)
+            self.assertEqual(
+                causal.return_bucket_status.value,
+                "not_used_shadow_annotation",
+            )
+
+    def test_real_calibration_detector_adapter_integration(self):
+        schedule = NYSE.schedule(
+            start_date="2022-01-03",
+            end_date="2025-12-31",
+        )
+        index = (
+            pd.DatetimeIndex(schedule.index)
+            .tz_localize(None)
+            .normalize()[:300]
+        )
+        position = np.arange(len(index))
+        stressed = position % 80 >= 45
+        returns = np.where(
+            stressed,
+            np.where(position % 2 == 0, 0.012, -0.015),
+            np.where(position % 2 == 0, 0.0012, -0.0005),
+        )
+        prices = pd.DataFrame(
+            {
+                "SPY_Close": 400.0 * np.exp(np.cumsum(returns)),
+                "VIX_Close": np.where(
+                    stressed,
+                    27.0 + np.sin(position / 3.0),
+                    16.0 + 0.5 * np.sin(position / 5.0),
+                ),
+            },
+            index=index,
+        )
+        config = RegimeDetectorConfig(
+            calibration_window=60,
+            min_calibration_history=20,
+            vix_slow_window=5,
+            realized_vol_window=5,
+            drawdown_window=10,
+            stress_entry_days=2,
+            stress_exit_days=3,
+            calm_entry_days=2,
+            calm_exit_days=2,
+        )
+
+        def fold(fold_id, ref_end, start, end):
+            return CausalValidationFold(
+                fold_id=fold_id,
+                outcome_reference_start=index[0].date(),
+                outcome_reference_end=index[ref_end].date(),
+                evaluation_start=index[start].date(),
+                evaluation_end=index[end].date(),
+            )
+
+        plan = RegimeCalibrationPlan(
+            protocol_id="signal_integration",
+            candidates=(
+                CalibrationCandidate("baseline", config),
+            ),
+            control_candidate_id="baseline",
+            selection_folds=(
+                fold("selection", 80, 100, 149),
+            ),
+            retrospective_test=fold(
+                "retrospective",
+                170,
+                190,
+                239,
+            ),
+            prospective_holdout_start=index[270].date(),
+            outcome_horizons=(2, 5),
+            min_evaluation_rows=20,
+            max_state_occupancy=0.99,
+            max_switches_per_252=100.0,
+            minimum_isolated_shock_episodes=0,
+            max_false_persistent_isolated_shock_rate=1.0,
+        )
+        artifact = run_research_calibration(prices, plan)
+        market_schedule = regime_market_schedule(
+            prices.index.min().date(),
+            prices.index.max().date(),
+        )
+        sessions = (
+            pd.DatetimeIndex(market_schedule.index)
+            .tz_localize(None)
+            .normalize()
+        )
+        trace = detect_regimes_with_calibration_artifact(
+            prices,
+            artifact,
+            expected_artifact_sha256=artifact.artifact_sha256,
+            as_of=(
+                pd.Timestamp(
+                    market_schedule.iloc[-1]["joint_finalization_at"]
+                )
+                + pd.Timedelta(minutes=1)
+            ),
+            spy_available_at=pd.Series(
+                pd.DatetimeIndex(market_schedule["spy_event_at"]),
+                index=sessions,
+            ),
+            vix_available_at=pd.Series(
+                pd.DatetimeIndex(market_schedule["vix_event_at"]),
+                index=sessions,
+            ),
+        )
+
+        annotations = from_calibrated_v2_trace(
+            trace.tail(1),
+            artifact=artifact,
+            expected_artifact_sha256=artifact.artifact_sha256,
+        )
+        signal = next(iter(annotations.values()))
+        self.assertEqual(
+            signal.lineage.artifact_sha256,
+            artifact.artifact_sha256,
+        )
+        self.assertEqual(
+            signal.lineage.causal_record.calibration_end_session,
+            plan.selection_folds[-1].evaluation_end,
+        )
+        self.assertFalse(signal.may_authorize_execution)

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,6 +5,7 @@ matplotlib==3.6.3
 numpy==1.23.5
 pandas==2.3.2
 pandas_market_calendars==5.1.0
+plotly==6.0.0
 pytest==8.4.2
 Requests==2.32.5
 scipy


### PR DESCRIPTION
Stacked on R3. Adds an immutable, lineage-verified Regime V2 shadow signal shared by backtests and live-facing consumers. Enforces exact T-to-next-NYSE-session timing, sealed audit envelopes, explicit causal metadata, no fill/coercion, and a hard prohibition on execution authorization. Adds runner-level tests proving annotated and unannotated trading actions and P&L are identical. Validation: 119 tests passed; focused causal suite 42 passed; compilation and diff checks passed.