### PR TITLE
R6: make live trading fail closed

### DIFF
--- a/etrade_python_client/RELIABILITY.md
+++ b/etrade_python_client/RELIABILITY.md
@@ -63,6 +63,27 @@ For every reliability incident:
   with the raw executions, the cached daily net flow, and the prior cumulative
   value.
 
+### Live startup and local security
+
+- Every order-capable process must require an explicit `sandbox` or `production`
+  environment. Missing or contradictory mode input must never fall through to
+  production.
+- Production startup requires an exact account ID, account key, and institution
+  type plus an owner-only, signed, short-lived arm document bound to the same
+  identity. The arm and identity must be revalidated after account refresh and
+  immediately before every order API call. R7 must preserve that invariant
+  while replacing the compatibility guard with one durable mutation gateway.
+- An order-capable dashboard binds to loopback by default. Public tunneling is a
+  separately supervised operator action, and wildcard CORS is forbidden.
+- Dashboard credentials must reject defaults and weak values. Settings, arm
+  documents, OAuth state, and touched local logs must be owner-only regular
+  files and must not expose credentials, OAuth verifiers, full account
+  responses, order payloads, or account-bearing URLs.
+- Removing a credential from the current source does not remediate a public Git
+  history. Any published key must be treated as compromised, revoked and
+  rotated at its issuer, then removed from history through a coordinated rewrite
+  and downstream clone/cache cleanup.
+
 ### Delivery and verification
 
 - The live service must be restarted or reloaded after backend changes.
@@ -98,6 +119,7 @@ truth. A source patch is not live until this whole path has been exercised.
 | INC-2026-07-17-03 | Resolved | Mobile view fragmented each SPX position into separate cards, making portfolio-level action thresholds hard to scan. | Layout was organized around individual position cards instead of decision-making by underlying. | One responsive table per ticker, pair-level gain/loss, DTE, strikes, and action emphasis. |
 | INC-2026-07-18-01 | Resolved | A weekend Refresh Data request changed the live portfolio value and margin budget to zero. | The E*TRADE portfolio request returned 401 after OAuth expiry. `portfolio()` silently converted the failed response to an empty list, and the dashboard writer treated it as a confirmed empty portfolio and overwrote the production HTML. | Retry an expired-token portfolio request through the shared auth callback, and require every dashboard-producing portfolio fetch to succeed before replacing the served artifact. |
 | INC-2026-07-24-01 | Resolved | The orange VIX line in the one-month benchmark chart stopped after July 6 while SPY and option-value data continued through July 24. | Market-history refresh checked only SPY and SPX for missing cached dates, so a VIX-only gap never triggered a download. Yahoo also returned malformed responses when the corrected refresh attempted the backfill. | Include VIX in independent missing-date detection and fall back to Cboe's official daily VIX history when Yahoo does not return the requested closes. |
+| INC-2026-07-26-02 | Open | The live process could enter production without an explicit environment, bind a mutable account-list position, and expose an order-capable dashboard beyond loopback; OAuth credentials were also embedded in tracked source. | Environment, arming, account identity, dashboard exposure, local file permissions, and credential sourcing were independent conventions rather than one fail-closed startup boundary. The repository is public, so removing values from the current source cannot revoke copies retained in Git history. | R6 adds explicit environment resolution, exact production identity, a signed short-lived arm, placement-time revalidation, loopback-only dashboard service, strong local credentials, owner-only files, and guarded client logs. Keep this incident open until external keys are revoked/rotated, history is purged, R7 replaces compatibility paths with a durable single mutation owner, and the deployed service is verified. |
 
 ## INC-2026-07-17-01 — Recent cash-flow history regressed
 
@@ -412,6 +434,97 @@ pandas, and calendar versions remain recorded in a separate runtime
 fingerprint. A future promotion gate must validate both a reviewed source hash
 and an approved runtime/lockfile identity, but a patch release cannot rewrite
 the research protocol identity.
+
+## INC-2026-07-26-02 — Live startup could fail open and source exposed OAuth credentials
+
+### Evidence
+
+Before R6, omitted mode input could resolve to the production E*TRADE endpoint,
+the selected brokerage account depended on mutable list position `1`, and there
+was no independently signed, expiring production arm. The same process could
+bind its order-capable dashboard to all interfaces, start ngrok automatically,
+and emit wildcard CORS. Local settings and request logs were not consistently
+created with owner-only protections, and the existing local dashboard
+credentials do not meet the new minimum-strength policy.
+
+Two tracked legacy E*TRADE utilities also contained hardcoded OAuth credentials.
+Those literals have been removed from the current source, but the repository is
+currently public. The affected keys must therefore be treated as compromised;
+their presence in Git history is security evidence, not a resolved source-only
+finding.
+
+### Implementation
+
+- `live_trading/runtime_safety.py`
+  - Requires an explicit `sandbox` or `production` environment before OAuth
+    construction.
+  - Requires production to name the exact account ID, account key, and
+    institution type.
+  - Validates an owner-only, HMAC-signed, versioned arm document bound to that
+    identity, with issued/expiry timestamps and a maximum 15-minute lifetime.
+  - Provides an operator CLI that creates the arm atomically with mode `0600`
+    and reads the signing secret only from
+    `ETRADE_PRODUCTION_ARMING_SECRET`.
+  - Rejects default dashboard usernames, passwords shorter than 16 characters,
+    and action PINs shorter than eight digits.
+- `accounts/accounts_bo.py` and
+  `live_trading/etrade_cover_call_new.py`
+  - Select production accounts by exact identity rather than list position.
+  - Revalidate the account identity and current arm at startup and account
+    refresh.
+  - Bind the dashboard to loopback, do not launch ngrok automatically, and do
+    not return wildcard CORS.
+  - Use owner-only handling for local settings and touched logs and redact
+    dashboard request records.
+- `order/order_bo.py`, `order/order.py`, and
+  `core_api/stock_trade_class.py`
+  - Pass the immutable runtime boundary into the reusable order client.
+  - Revalidate the current arm, environment, and exact account immediately
+    before every order API POST/PUT.
+  - Reject order API access without that boundary and quarantine the older
+    interactive order client.
+- Shared E*TRADE client logging
+  - Uses owner-only files, does not propagate to unfiltered root handlers,
+    redacts authorization-bearing headers, and records only SHA-256/size
+    metadata for order payloads, account/order response bodies, and
+    account-bearing URLs.
+- `live_trading/etrade_check_option.py` and
+  `live_trading/etrade_option_chains.py`
+  - Remove hardcoded OAuth credentials from the current source and require
+    local configuration or environment variables.
+
+### Remaining risk
+
+This is containment in the current source, not production readiness. The
+compatibility order client now rejects calls without the current arm/account
+boundary, but placement has not yet been routed through one durable gateway.
+R7 must make that gateway the sole mutation owner while preserving the
+placement-time check, stable intent identity, capacity reservations, and
+unknown-POST reconciliation.
+
+The exposed OAuth keys still require external revocation and rotation. A later
+coordinated history purge must remove them from all refs and arrange cleanup of
+downstream clones, forks, caches, and build artifacts; making the repository
+private now would not undo prior exposure. The repository remains public.
+
+The current local dashboard settings intentionally fail the new credential
+policy and must be reprovisioned before startup. No live service has been
+restarted, no E*TRADE session or order path has been exercised, and the exact
+deployed dashboard has not been reloaded or visually inspected with R6.
+
+### Verification record
+
+- R5 / PR #28 passed its clean CI job with 134 tests. This establishes the
+  clean dependency/import baseline for the preceding shadow-dashboard change;
+  it is not deployment evidence for R6.
+- R6 includes focused runtime-safety coverage for explicit environments,
+  production-arm schema/signature/lifetime, exact account matching, owner-only
+  files, guarded response/request logging, order calls without a boundary,
+  placement-time arm expiry, dashboard credential rejection, and loopback/CORS
+  behavior.
+- Deployment verification is deliberately recorded as incomplete. This
+  incident remains open until the remaining-risk conditions above are
+  satisfied.
 
 ## Checklist for future dashboard incidents
 

--- a/etrade_python_client/accounts/accounts.py
+++ b/etrade_python_client/accounts/accounts.py
@@ -1,21 +1,15 @@
 import json
 import logging
 import configparser
-from logging.handlers import RotatingFileHandler
 from order.order import Order
+from live_trading.runtime_safety import configure_owner_only_logger, redact_http_headers
 
 # loading configuration file
 config = configparser.ConfigParser()
 config.read('config.ini')
 
 # logger settings
-logger = logging.getLogger('my_logger')
-logger.setLevel(logging.DEBUG)
-handler = RotatingFileHandler("python_client.log", maxBytes=5 * 1024 * 1024, backupCount=3)
-FORMAT = "%(asctime)-15s %(message)s"
-fmt = logging.Formatter(FORMAT, datefmt='%m/%d/%Y %I:%M:%S %p')
-handler.setFormatter(fmt)
-logger.addHandler(handler)
+logger = configure_owner_only_logger('my_logger')
 
 
 class Accounts:
@@ -41,7 +35,7 @@ class Accounts:
 
         # Make API call for GET request
         response = self.session.get(url, header_auth=True)
-        logger.debug("Request Header: %s", response.request.headers)
+        logger.debug("Request Header: %s", redact_http_headers(response.request.headers))
 
         # Handle and parse response
         if response is not None and response.status_code == 200:
@@ -113,7 +107,7 @@ class Accounts:
 
         # Make API call for GET request
         response = self.session.get(url, header_auth=True)
-        logger.debug("Request Header: %s", response.request.headers)
+        logger.debug("Request Header: %s", redact_http_headers(response.request.headers))
 
         print("\nPortfolio:")
 
@@ -187,8 +181,8 @@ class Accounts:
 
         # Make API call for GET request
         response = self.session.get(url, header_auth=True, params=params, headers=headers)
-        logger.debug("Request url: %s", url)
-        logger.debug("Request Header: %s", response.request.headers)
+        logger.debug("Account balance request issued")
+        logger.debug("Request Header: %s", redact_http_headers(response.request.headers))
 
         # Handle and parse response
         if response is not None and response.status_code == 200:

--- a/etrade_python_client/accounts/accounts_bo.py
+++ b/etrade_python_client/accounts/accounts_bo.py
@@ -1,7 +1,6 @@
 import json
 import logging
 import configparser
-from logging.handlers import RotatingFileHandler
 from turtle import position
 # from order.order_bo import Order
 import xml.etree.ElementTree as ET
@@ -24,6 +23,11 @@ from pandas.tseries.offsets import CustomBusinessDay
 import re
 from backtesting import option_limit_backtest
 from data_and_research.polygonio_improvequery import load_stored_option_data  # Ensure this is importable
+from live_trading.runtime_safety import (
+    configure_owner_only_logger,
+    redact_http_headers,
+    resolve_etrade_consumer_key,
+)
 
 ROLL_IN_GL_THRESHOLD = 60
 ROLL_OUT_GL_THRESHOLD = -1
@@ -44,18 +48,17 @@ CORRELATED_STOCKS={
 
 EXEMPTED_STOCKS=['SQQQ','VIX']
 
+
+def _redact_account_identifier(value):
+    text = str(value or "")
+    return f"***{text[-4:]}" if text else "[unavailable]"
+
 # loading configuration file
 config = configparser.ConfigParser()
 config.read('config.ini')
 
 # logger settings
-logger = logging.getLogger('my_logger')
-logger.setLevel(logging.DEBUG)
-handler = RotatingFileHandler("python_client.log", maxBytes=5 * 1024 * 1024, backupCount=3)
-FORMAT = "%(asctime)-15s %(message)s"
-fmt = logging.Formatter(FORMAT, datefmt='%m/%d/%Y %I:%M:%S %p')
-handler.setFormatter(fmt)
-logger.addHandler(handler)
+logger = configure_owner_only_logger('my_logger')
 
 ETRADE_TICKER=["VIXW","VIX","BRKB","BRK.B","SPX"]
 YFINANCE_TICKER=["^VIX","^VIX","BRK-B","BRK-B","^SPX"]
@@ -1089,10 +1092,11 @@ class Accounts:
         self.base_url = base_url
         self.use_sandbox = use_sandbox
         config_key = "SANDBOX_CONSUMER_KEY" if self.use_sandbox else "PROD_CONSUMER_KEY"
-        self.consumer_key = (
-            consumer_key
-            if consumer_key is not None
-            else config["DEFAULT"].get(config_key)
+        self.consumer_key = resolve_etrade_consumer_key(
+            self.use_sandbox,
+            consumer_key=consumer_key,
+            config_value=config["DEFAULT"].get(config_key),
+            required=False,
         )
 
     def _consumer_key_headers(self):
@@ -1115,7 +1119,14 @@ class Accounts:
         self.session, self.base_url = refreshed
         return True
 
-    def account_list(self, selected_account_id=1):
+    def account_list(
+        self,
+        selected_account_id=1,
+        *,
+        expected_account_id_key=None,
+        expected_account_id=None,
+        expected_institution_type=None,
+    ):
         """
         Calls account list API to retrieve a list of the user's E*TRADE accounts
 
@@ -1128,7 +1139,7 @@ class Accounts:
 
         # Make API call for GET request
         response = self.session.get(url, header_auth=True)
-        logger.debug("Request Header: %s", response.request.headers)
+        logger.debug("Request Header: %s", redact_http_headers(response.request.headers))
 
         # List to store account information
         account_info = []
@@ -1137,7 +1148,7 @@ class Accounts:
         # Handle and parse response
         if response is not None and response.status_code == 200:
             parsed = json.loads(response.text)
-            logger.debug("Response Body: %s", json.dumps(parsed, indent=4, sort_keys=True))
+            logger.debug("Account list response received")
 
             data = response.json()
             if data is not None and "AccountListResponse" in data and "Accounts" in data["AccountListResponse"] \
@@ -1150,17 +1161,33 @@ class Accounts:
                 for account in accounts:
                     account_id = account.get("accountId", "")
                     account_id_key = account.get("accountIdKey", "")
-                    account_desc = account.get("accountDesc", "").strip() if account.get("accountDesc") else ""
                     institution_type = account.get("institutionType", "")                    
-                    # Add account details to the list
-                    account_info.append((account_id, account_desc, institution_type, account_id_key))
+                    account_info.append((account_id, "", institution_type, account_id_key))
                     
-                    print_str = f"{count-1})\t{account_id}, {account_desc}, {institution_type}"
+                    print_str = f"{count-1})\t{_redact_account_identifier(account_id)}, {institution_type}"
                     print(print_str)
                     count += 1
-                self.account = accounts[selected_account_id] 
-                # 0: IRA account
-                # 1: Individual brokerage account
+                if expected_account_id_key is not None:
+                    matches = [
+                        account for account in accounts
+                        if account.get("accountIdKey") == expected_account_id_key
+                    ]
+                    if len(matches) != 1:
+                        raise RuntimeError(
+                            "Expected E*TRADE account key did not resolve to exactly one open account"
+                        )
+                    selected = matches[0]
+                    if (
+                        selected.get("accountId") != expected_account_id
+                        or selected.get("institutionType") != expected_institution_type
+                    ):
+                        raise RuntimeError("Expected E*TRADE account identity did not match")
+                    self.account = selected
+                elif selected_account_id is not None:
+                    self.account = accounts[selected_account_id]
+                else:
+                    raise RuntimeError("An exact E*TRADE account identity is required")
+                # Index selection is retained only for legacy sandbox callers.
                 return account_info
             else:
                 # Handle errors
@@ -1901,7 +1928,7 @@ class Accounts:
             if is_etrade_token_expired_response(response) and self._refresh_auth_session_if_possible("portfolio fetch"):
                 url = f"{self.base_url}/v1/accounts/{self.account['accountIdKey']}/portfolio.json"
                 response = self.session.get(url, params=params, header_auth=True)
-            logger.debug("Request Header: %s", response.request.headers)
+            logger.debug("Request Header: %s", redact_http_headers(response.request.headers))
             
             # Check if API call was successful
             if response.status_code != 200:
@@ -4788,8 +4815,8 @@ class Accounts:
         # Make API call for GET request
         # response = self.session.get(url, header_auth=True, params=params, headers=headers)
         response = self.session.get(url, header_auth=True, params=params)
-        logger.debug("Request url: %s", url)
-        logger.debug("Request Header: %s", response.request.headers)
+        logger.debug("Account balance request issued")
+        logger.debug("Request Header: %s", redact_http_headers(response.request.headers))
 
         # Handle and parse response
         if response is not None and response.status_code == 200:
@@ -4799,12 +4826,12 @@ class Accounts:
             if data is not None and "BalanceResponse" in data:
                 balance_data = data["BalanceResponse"]
                 if balance_data is not None and "accountId" in balance_data:
-                    print("\n\nBalance for " + balance_data["accountId"] + ":")
+                    print("\n\nBalance for " + _redact_account_identifier(balance_data["accountId"]) + ":")
                 else:
                     print("\n\nBalance:")
                 # Display balance information
                 if balance_data is not None and "accountDescription" in balance_data:
-                    print("Account Nickname: " + balance_data["accountDescription"])
+                    print("Account description withheld")
                 if balance_data is not None and "Computed" in balance_data \
                         and "RealTimeValues" in balance_data["Computed"] \
                         and "totalAccountValue" in balance_data["Computed"]["RealTimeValues"]:

--- a/etrade_python_client/core_api/stock_trade_class.py
+++ b/etrade_python_client/core_api/stock_trade_class.py
@@ -22,6 +22,7 @@ import pyetrade
 import pyperclip
 import random
 import sys
+import tempfile
 from copy import deepcopy
 import csv
 from selenium.common.exceptions import NoSuchElementException, TimeoutException, SessionNotCreatedException
@@ -29,6 +30,7 @@ from itertools import product
 from accounts.accounts_bo import Accounts
 from market.market_bo import Market
 from order.order_bo import Order
+from live_trading.runtime_safety import RuntimeSafetyBoundary
 from datetime import time
 import pickle
 
@@ -1117,7 +1119,7 @@ def get_token_automated(oauth_url, username=None, password=None, headless=True, 
                 )
                 if js_token and str(js_token).strip() and len(str(js_token).strip()) > 3:
                     token = str(js_token).strip()
-                    print(f"Token obtained via JS: {token}")
+                    print("OAuth verifier obtained via browser automation.")
                     return token
             except:
                 pass
@@ -1142,7 +1144,7 @@ def get_token_automated(oauth_url, username=None, password=None, headless=True, 
                 val = token_element.get_attribute("value") or token_element.text
                 if val and len(val.strip()) > 3:
                     token = val.strip()
-                    print(f"Token obtained via element: {token}")
+                    print("OAuth verifier obtained via browser automation.")
                     return token
 
             # 4. Check for Accept/Authorize Button
@@ -1233,7 +1235,7 @@ def get_token_automated(oauth_url, username=None, password=None, headless=True, 
                 token_candidates = parsed_query.get('oauth_verifier') or parsed_query.get('verifier')
                 if token_candidates:
                     token = unquote(token_candidates[0]).strip()
-                    print(f"Token found in URL fallback: {token}")
+                    print("OAuth verifier obtained from the authorization redirect.")
                     return token
             except:
                 pass
@@ -1243,19 +1245,28 @@ def get_token_automated(oauth_url, username=None, password=None, headless=True, 
                 page_text = driver.execute_script("return document.body ? document.body.innerText : '';")
                 token = _extract_token_from_text(page_text)
                 if token:
-                    print(f"Token found in body text fallback: {token}")
+                    print("OAuth verifier obtained from the authorization page.")
                     return token
             except:
                 pass
 
             # Only now save failure info
-            debug_timestamp = datetime.now().strftime('%Y%m%d_%H%M%S')
-            screenshot_path = os.path.abspath(f"login_failure_{debug_timestamp}.png")
+            descriptor, screenshot_path = tempfile.mkstemp(
+                prefix="login_failure_",
+                suffix=".png",
+                dir=os.getcwd(),
+            )
+            os.close(descriptor)
             try:
                 driver.save_screenshot(screenshot_path)
+                os.chmod(screenshot_path, 0o600)
                 print(f"Extraction failed. Saved failure screenshot to: {screenshot_path}")
-            except:
-                pass
+            except Exception:
+                try:
+                    os.unlink(screenshot_path)
+                except OSError:
+                    pass
+                screenshot_path = None
             
             raise LoginFailureException("Unable to retrieve OAuth verifier token automatically.", screenshot_path=screenshot_path)
 
@@ -1273,8 +1284,13 @@ class LiveTradeAgent:
                 agent_id = None,
                 authenticated_session = None,
                 base_url = None,
-                selected_account = 1,
-                use_sandbox = False,
+                selected_account = None,
+                use_sandbox = None,
+                expected_account_id_key = None,
+                expected_account_id = None,
+                expected_institution_type = None,
+                consumer_key = None,
+                runtime_safety: RuntimeSafetyBoundary | None = None,
                 ):
         if agent_id is None:
             self.agent_id = self.generate_agent_id()
@@ -1282,25 +1298,70 @@ class LiveTradeAgent:
         else:
             self.agent_id = agent_id
 
-        self.use_sandbox = use_sandbox
-        self.selected_account = selected_account
-
         if authenticated_session is not None and base_url is not None:
+            if runtime_safety is None:
+                raise RuntimeError(
+                    "Authenticated LiveTradeAgent construction requires a RuntimeSafetyBoundary"
+                )
+            selected = runtime_safety.account_selection_kwargs["selected_account_id"]
+            expected = (
+                runtime_safety.expected_account_id_key,
+                runtime_safety.expected_account_id,
+                runtime_safety.expected_institution_type,
+            )
+            supplied = (expected_account_id_key, expected_account_id, expected_institution_type)
+            if (
+                use_sandbox is not None and use_sandbox != runtime_safety.use_sandbox
+            ) or (selected_account is not None and selected_account != selected) or any(
+                provided is not None and provided != armed
+                for provided, armed in zip(supplied, expected)
+            ):
+                raise RuntimeError("LiveTradeAgent arguments conflict with the RuntimeSafetyBoundary")
+            self.use_sandbox = runtime_safety.use_sandbox
+            self.selected_account = selected
+            self.expected_account_id_key = runtime_safety.expected_account_id_key
+            self.expected_account_id = runtime_safety.expected_account_id
+            self.expected_institution_type = runtime_safety.expected_institution_type
+            self.runtime_safety = runtime_safety
+            self.consumer_key = consumer_key
             self._initialize_components(authenticated_session, base_url)
+            self.runtime_safety.verify_account(self.account.account)
+        else:
+            self.use_sandbox = bool(use_sandbox)
+            self.selected_account = selected_account
+            self.expected_account_id_key = expected_account_id_key
+            self.expected_account_id = expected_account_id
+            self.expected_institution_type = expected_institution_type
+            self.runtime_safety = None
+            self.consumer_key = consumer_key
         self.today_stock_price = []
         self.today_stock_spread = []
 
     def _initialize_components(self, authenticated_session, base_url):
         """Initialize or refresh dependent services with a new authenticated session."""
-        self.market = Market(authenticated_session, base_url)
-        self.account = Accounts(authenticated_session, base_url)
-        self.account.account_list(self.selected_account)
+        self.market = Market(
+            authenticated_session, base_url, use_sandbox=self.use_sandbox, consumer_key=self.consumer_key
+        )
+        self.account = Accounts(
+            authenticated_session,
+            base_url,
+            use_sandbox=self.use_sandbox,
+            consumer_key=self.consumer_key,
+        )
+        self.account.account_list(
+            self.selected_account,
+            expected_account_id_key=self.expected_account_id_key,
+            expected_account_id=self.expected_account_id,
+            expected_institution_type=self.expected_institution_type,
+        )
         account_selected = self.account.account
         self.order = Order(
             authenticated_session,
             account_selected,
             base_url,
-            use_sandbox=self.use_sandbox
+            use_sandbox=self.use_sandbox,
+            consumer_key=self.consumer_key,
+            runtime_safety=self.runtime_safety,
         )
 
     def refresh_session(self, authenticated_session, base_url):
@@ -1309,6 +1370,9 @@ class LiveTradeAgent:
         Keeps agent/account IDs but rebuilds market/account/order clients.
         """
         self._initialize_components(authenticated_session, base_url)
+        if self.runtime_safety is None:
+            raise RuntimeError("Authenticated LiveTradeAgent refresh requires a RuntimeSafetyBoundary")
+        self.runtime_safety.verify_account(self.account.account)
 
     @staticmethod
     def generate_agent_id():

--- a/etrade_python_client/docs/production_readiness_upgrade_plan.md
+++ b/etrade_python_client/docs/production_readiness_upgrade_plan.md
@@ -37,6 +37,40 @@ Until Phase 0 exits, automatic live execution should remain disabled. Until the
 backtest validity gates exit, regime-aware reports should be labeled
 `UNVERIFIED` rather than ranked beside valid experiments.
 
+## Delivery status as of 2026-07-26
+
+R5 / PR #28 established a clean dependency/import baseline and passed 134 tests
+in clean CI. R6 now implements the first live-startup containment slice in the
+current source:
+
+- `sandbox` or `production` must be selected explicitly; missing or conflicting
+  mode input fails before OAuth construction.
+- Production requires an exact account ID, account key, and institution type
+  plus an owner-only, HMAC-signed, versioned arm document bound to that identity.
+  Its maximum lifetime is 15 minutes.
+- The selected identity and unexpired arm are checked at startup, on account
+  refresh, and immediately before every compatibility-client order API call.
+- The order-capable dashboard binds to loopback, does not launch ngrok
+  automatically, and does not grant wildcard CORS. Startup rejects weak
+  dashboard credentials, and touched settings/log files use owner-only handling.
+- Hardcoded OAuth credentials were removed from the current versions of two
+  legacy utilities in favor of local configuration or environment variables.
+- Shared client logs use owner-only files and retain only redacted headers plus
+  fingerprints for order payloads, account/order bodies, and account-bearing
+  URLs. The older interactive order client and spread executable are
+  quarantined.
+
+These changes do **not** satisfy Phase 0 or make the repository production
+ready. The existing order paths are guarded but not yet centralized, so R7 must
+preserve the arm/account check in a sole mutation owner and add durable
+idempotency, capacity reservations, and reconciliation. The current local dashboard settings
+are intentionally rejected until stronger credentials are provisioned. The
+repository is public, and OAuth keys retained in public Git history must be
+treated as compromised: external revoke/rotate is required, followed by a
+coordinated history purge and downstream cleanup. No live service restart,
+deployment, E*TRADE mutation, or exact served-dashboard verification has been
+performed for R6.
+
 ## What is worth preserving
 
 This is not a rewrite-from-zero recommendation. The following foundations are
@@ -156,6 +190,12 @@ broker timeouts, complete pagination, durable state, web hardening,
 observability, atomic publication, schema validation, dependency locking,
 deployment rollback, and decomposition of the three monoliths.
 
+R6 partially mitigates P0-L1, P0-L2, and P0-L7 in the current source. Their
+release conditions remain open: the placement-time compatibility guard is not
+yet a durable, centralized mutation gateway; affected OAuth keys have not been revoked or rotated;
+public history has not been purged; and no deployed process has been verified.
+P0-L3 through P0-L6 and P0-L8 remain stop-ship issues.
+
 ## Required regime-aware causal record
 
 Every regime-aware run must persist the following fields and pass them before
@@ -244,6 +284,15 @@ flowchart TB
   `0600`, never logged, and validated at startup.
 - Strategy, data, model, execution, and risk policies are separate typed
   sections; unknown keys and invalid ranges are errors.
+
+R6 implements a narrow compatibility boundary around the existing monolith:
+explicit environment selection; exact production account identity; a
+versioned, signed arm document with a maximum 15-minute lifetime; refresh-time
+and order-call revalidation; strong dashboard credential validation; and
+owner-only local files. It does not yet provide the complete typed
+configuration model or an OS secret-store integration. Its compatibility
+order guard does not replace the R7 requirement for a durable single placement
+gateway with stable intent identity and reconciliation.
 
 ### Boundary 2: E*TRADE gateway
 
@@ -412,6 +461,15 @@ Exit gate:
 - Each required dependency failure yields zero submissions.
 - Secret scans of history, working tree, build output, and logs are clean.
 - Existing 11 focused reliability tests remain green.
+
+R6 status: the explicit mode, exact identity, short-lived signed arm,
+refresh-time and order-call revalidation, loopback dashboard, restrictive CORS,
+strong local credential checks, and owner-only/redacted client logging are
+implemented in source. Phase 0 remains open because placement is not centralized or durably
+idempotent, the remaining pre-trade and failure gates are incomplete, exposed
+keys still require external revoke/rotate and coordinated history cleanup, the
+current local settings fail the new policy, and no deployed service has been
+restarted or verified.
 
 ### Phase 1 — reproducible repository baseline (week 1)
 
@@ -582,6 +640,13 @@ The existing monoliths should remain behind compatibility facades while these
 boundaries are extracted. Remove old paths only after golden tests and
 shadow-parity prove equivalent intended behavior.
 
+The current stacked delivery names this first source-level startup containment
+slice R6. It covers part of the planned live-containment and secret/log work,
+not the entire roadmap entries above. R7 is the next safety boundary:
+centralize every placement under one durable owner, preserve the arm/account
+check, persist stable intent identity and capacity reservations, and reconcile
+ambiguous broker outcomes before retry.
+
 ## Test and verification matrix
 
 | Layer | Required tests |
@@ -625,7 +690,15 @@ inspect the deployed Pi; and did not restart the user's deployed dashboard.
 R5 later added an isolated browser verification of the actual dashboard handler
 and source template for both a sealed synthetic advisory and the missing-signal
 failure state. That proves the code/HTML path, not deployment or live provider
-operation. The remaining actions belong to the staged acceptance gates above.
+operation. Its PR #28 clean CI job passed 134 tests.
+
+R6 has not restarted or inspected the deployed dashboard, called E*TRADE, or
+exercised a live/sandbox mutation. Current-source credential removal also does
+not establish secret hygiene while the repository remains public and the old
+keys remain in Git history. External revoke/rotate, coordinated history purge,
+strong local credential reprovisioning, R7 durable gateway enforcement, and
+deployment verification remain required. The remaining actions belong to the
+staged acceptance gates above.
 
 The working tree was already heavily modified and contains important untracked
 runtime sources. This review intentionally adds only this plan and does not

--- a/etrade_python_client/docs/project_overview.md
+++ b/etrade_python_client/docs/project_overview.md
@@ -127,6 +127,48 @@ flowchart TD
     RPA -->|Saves tabular CSV audits| CSVS
 ```
 
+### 3. Live Startup Safety & Dashboard Containment
+
+R6 adds a fail-closed boundary around startup, account refresh, and the
+compatibility order client in the existing live monolith. The environment must
+be explicit. Production
+additionally requires an owner-only, HMAC-signed, short-lived arm document whose
+exact account ID, account key, and institution type match both the command line
+and the broker response. These checks run before broker construction, again
+when the selected account is refreshed, and immediately before every order API
+POST/PUT.
+
+```mermaid
+flowchart LR
+    CLI["Explicit sandbox/production mode<br/>Exact expected account identity"]
+    SECRET["ETRADE_PRODUCTION_ARMING_SECRET<br/>(Environment only)"]
+    ARM[("Owner-only signed arm file<br/>Versioned, maximum 15-minute lifetime")]
+    SAFE["live_trading/runtime_safety.py<br/>(Fail-Closed Startup Boundary)"]
+    OAUTH["E*TRADE OAuth Construction"]
+    ACCOUNT["Exact Account Selection<br/>and Refresh Revalidation"]
+    DASHCFG["Strong Dashboard Credentials<br/>Owner-Only Settings and Logs"]
+    DASH["Loopback-Only Dashboard<br/>No Automatic Tunnel / No Wildcard CORS"]
+    DIRECT["Compatibility Order Client<br/>(Per-Call Arm + Account Guard)"]
+    GATE["R7 Central Order Gateway<br/>(Durable Single Mutation Owner)"]
+    BROKER["E*TRADE"]
+
+    CLI --> SAFE
+    SECRET --> SAFE
+    ARM --> SAFE
+    SAFE --> OAUTH --> ACCOUNT
+    DASHCFG --> DASH
+    ACCOUNT --> DIRECT
+    DIRECT -->|"current, guarded but non-durable"| BROKER
+    DIRECT -.->|"R7 migration"| GATE
+    GATE -.->|"planned replacement"| BROKER
+```
+
+This is source-level containment, not a production-readiness claim. The
+compatibility order client now enforces the arm/account check for every order
+API call, but durable intent identity, reservations, ambiguous-outcome
+reconciliation, and a single broker-mutation owner remain R7 work. The deployed
+service has not been restarted or inspected with R6.
+
 ---
 
 ## 🛠️ Stack Component Descriptions
@@ -164,6 +206,13 @@ finality promise; later provider corrections append a revision and require a
 new verified snapshot. The [provider entitlement gate](regime_data_provider_entitlements.md)
 is unresolved, so retained provider data and all derived V2 outputs remain
 shadow/research-only and cannot affect E*TRADE order eligibility.
+
+### 3. Live Runtime Safety
+
+*   **Runtime Safety Boundary** ([`runtime_safety.py`](file:///Users/btian/EtradePythonClient/etrade_python_client/live_trading/runtime_safety.py)): Resolves an explicit `sandbox` or `production` environment before OAuth construction. Production requires an exact account identity plus a versioned, signed arm file with a bounded lifetime; unsafe, missing, mismatched, future, or expired proof fails closed. The operator CLI writes the arm atomically as an owner-only file without accepting the signing secret as a command-line argument.
+*   **Account Identity Revalidation** ([`accounts_bo.py`](file:///Users/btian/EtradePythonClient/etrade_python_client/accounts/accounts_bo.py), [`order_bo.py`](file:///Users/btian/EtradePythonClient/etrade_python_client/order/order_bo.py)): Selects production accounts by exact account ID, account key, and institution type instead of a mutable list index. The live process revalidates the armed identity after startup and account refresh, and the compatibility order client repeats it immediately before every order API call. R7 must preserve the check inside the durable single mutation gateway.
+*   **Dashboard Containment** ([`etrade_cover_call_new.py`](file:///Users/btian/EtradePythonClient/etrade_python_client/live_trading/etrade_cover_call_new.py)): Serves the order-capable dashboard on loopback only, does not start ngrok automatically, and does not grant wildcard CORS. Startup rejects default or weak dashboard credentials, while local settings and touched logs use owner-only file handling.
+*   **Credential Source Cleanup** ([`etrade_check_option.py`](file:///Users/btian/EtradePythonClient/etrade_python_client/live_trading/etrade_check_option.py), [`etrade_option_chains.py`](file:///Users/btian/EtradePythonClient/etrade_python_client/live_trading/etrade_option_chains.py)): Removes hardcoded OAuth credentials from the current source and requires local configuration or environment variables. Because the repository is currently public and those values remain in Git history, the affected keys must be treated as compromised until they are revoked and rotated externally; a coordinated history purge remains separate follow-up work.
 
 ---
 
@@ -227,7 +276,7 @@ When the user mentions a specific **dashboard**, **HTML**, or **chart**, check t
 | **[`experiments_dashboard.html`](file:///Users/btian/EtradePythonClient/etrade_python_client/backtesting/experiments_dashboard.html)** | `generate_experiments_report.py` | The main leaderboard. Compiles terminal statistics, margin metrics, drawdowns, Sharpe ratios, and links for all simulated variants in the log. |
 | **[`backtesting/reports/report_*.html`](file:///Users/btian/EtradePythonClient/etrade_python_client/backtesting/reports/)** | `backtest_runner.py` | Single backtest interactive report. Contains step-by-step trade logs, equity curves, drawdown curves, trade-by-trade details, and embedded strategy config details. |
 | **[`audit_plots/regime_probability_audit.html`](file:///Users/btian/EtradePythonClient/etrade_python_client/audit_plots/regime_probability_audit.html)** | `regime_probability_audit.py` | Interactive statistical dashboard comparing SPY & SPX. Displays distribution overlays, moments tables, and option assignment edges. |
-| **[`live_trading/dashboard_template.html`](file:///Users/btian/EtradePythonClient/etrade_python_client/live_trading/dashboard_template.html)** | `RefreshHandler` serves the source template; `/api/regime_v2_shadow` reads `live_trading/runtime/regime_v2_shadow.json` | Authenticated operator dashboard. The V2 card displays a redacted background-plus-shock advisory beside the legacy lane and permanently states that it cannot authorize execution. |
+| **[`live_trading/dashboard_template.html`](file:///Users/btian/EtradePythonClient/etrade_python_client/live_trading/dashboard_template.html)** | `RefreshHandler` serves the source template; `/api/regime_v2_shadow` reads `live_trading/runtime/regime_v2_shadow.json` | Authenticated, loopback-only operator dashboard. It requires strong local credentials, does not automatically start a public tunnel, and exposes no wildcard CORS. The V2 card displays a redacted background-plus-shock advisory beside the legacy lane and permanently states that it cannot authorize execution. |
 | **[`research_reports/regime_v2_calibration_artifact.json`](file:///Users/btian/EtradePythonClient/etrade_python_client/research_reports/regime_v2_calibration_artifact.json)** | `regime_detector_v2_calibrate.py` | Canonical R3 candidate metrics, causal folds, selected baseline, provenance limitations, and execution-ineligible promotion status. |
 | **[`s_and_p_data/regime_timeline_2015.png`](file:///Users/btian/EtradePythonClient/etrade_python_client/s_and_p_data/regime_timeline_2015.png)** | `ev_plots.py --timeline` | Visually maps out-of-sample HMM regimes (Expansion, Decline, Panic) as background colors overlaid on SPY Close and VIX. |
 | **[`s_and_p_data/spy_return_distributions_by_hmm.png`](file:///Users/btian/EtradePythonClient/etrade_python_client/s_and_p_data/spy_return_distributions_by_hmm.png)** | `ev_plots.py --distributions` | Multi-panel histogram displaying daily returns bucketed by HMM state and overlaid with fitted fat-tailed Student-t densities. |

--- a/etrade_python_client/live_trading/README.md
+++ b/etrade_python_client/live_trading/README.md
@@ -4,48 +4,50 @@ This module contains the live trading agent and its associated web-based managem
 
 ## 🚀 Quick Start
 
-1. **Start the Trading Bot**:
-   Run the main script with the `--trade` flag. This will automatically start the background HTTP server on port `8765`.
+1. **Provision safety inputs**:
+   Configure client credentials outside Git using local `config.ini` or environment variables, and create an owner-only `live_trading_settings.json` with a non-default dashboard username, a 16+ character password, and an 8+ digit action PIN. Production also requires `ETRADE_PRODUCTION_ARMING_SECRET` and an owner-only, signed, unexpired production-arm document.
+
+2. **Start the trading bot with an explicit environment and account identity**:
+
    ```zsh
-   python3 -m live_trading.etrade_cover_call_new --no-sandbox --trade
+   python3 -m live_trading.etrade_cover_call_new \
+     --environment sandbox \
+     --expected-account-id '<display-id>' \
+     --expected-account-id-key '<account-key>' \
+     --expected-institution-type '<institution-type>' \
+     --trade
    ```
 
-2. **Access the Dashboard**:
-   * **Local**: Open `http://localhost:8765/dashboard` in your browser.
-   * **PIN**: Default PIN is `1234` (configurable in `live_trading_settings.json`).
+   For production, issue a fresh arm document immediately before startup. The secret is read only from the environment; do not put it in the command, settings file, or Git.
+
+   ```zsh
+   export ETRADE_PRODUCTION_ARMING_SECRET='<32+-character secret>'
+   python3 -m live_trading.runtime_safety issue-production-arm \
+     --output .production-arm.json \
+     --expected-account-id '<display-id>' \
+     --expected-account-id-key '<account-key>' \
+     --expected-institution-type '<institution-type>' \
+     --ttl-seconds 300
+
+   python3 -m live_trading.etrade_cover_call_new \
+     --environment production \
+     --production-arm-file .production-arm.json \
+     --expected-account-id '<display-id>' \
+     --expected-account-id-key '<account-key>' \
+     --expected-institution-type '<institution-type>' \
+     --trade
+   ```
+
+   The generated document is owner-only (`0600`), binds the exact account identity, and is valid for at most 15 minutes. A missing or ambiguous environment never defaults to production.
+
+3. **Access the dashboard locally**:
+   Open `http://localhost:8765/dashboard` in your browser. The server binds to loopback only; it does not create a public tunnel.
 
 ---
 
-## 🌐 Public Access Setup (ngrok)
+## 🔒 Remote access
 
-To access your dashboard from your phone while away from home, use **ngrok** to create a secure tunnel.
-
-### 1. Installation
-```zsh
-brew install ngrok/ngrok/ngrok
-```
-
-1. Open `config.ini` in the root directory.
-2. Add your token to the `[NGROK]` section:
-   ```ini
-   [NGROK]
-   AUTH_TOKEN = your_token_here
-   STATIC_DOMAIN = your-name.ngrok-free.app
-   ```
-3. Run the authentication command once:
-   ```zsh
-   ngrok config add-authtoken <YOUR_AUTH_TOKEN>
-   ```
-
-### 3. Claim a Static Domain
-In your ngrok dashboard, go to **Cloud Edge -> Domains** and claim your free static domain (e.g., `your-name.ngrok-free.app`).
-
-### 4. Run the Tunnel
-```zsh
-ngrok http --url=your-name.ngrok-free.app 8765
-```
-
----
+The order-capable dashboard deliberately has no automatic public tunnel. If remote access is later approved, place it behind a separately managed TLS reverse proxy with strong authentication, request-rate controls, and network allowlisting. Do not expose the local HTTP listener directly.
 
 ## 📊 Dashboard Features
 
@@ -59,7 +61,8 @@ ngrok http --url=your-name.ngrok-free.app 8765
 
 ## ⚙️ Configuration
 
-*   **Settings**: `live_trading_settings.json` stores all dynamic parameters.
+*   **Settings**: `live_trading_settings.json` stores dynamic parameters and must be owner-only (`0600`). It is not a place for E*TRADE OAuth credentials.
+*   **E*TRADE credentials**: configure sandbox values through `ETRADE_SANDBOX_CONSUMER_KEY` / `ETRADE_SANDBOX_CONSUMER_SECRET` and production values through `ETRADE_LIVE_CONSUMER_KEY` / `ETRADE_LIVE_CONSUMER_SECRET`, or matching local `config.ini` entries. Never commit values.
 *   **Refresh Frequency**: 
     *   Main Loop Evaluation: Every 60 seconds.
     *   Stale Order Monitoring: Every 120 seconds.

--- a/etrade_python_client/live_trading/etrade_check_option.py
+++ b/etrade_python_client/live_trading/etrade_check_option.py
@@ -30,6 +30,7 @@ from rauth import OAuth1Service
 from logging.handlers import RotatingFileHandler
 from accounts.accounts_bo import Accounts, calculate_std_dev
 from market.market_bo import Market
+from live_trading.runtime_safety import configure_owner_only_logger, read_owner_only_json, write_owner_only_json
 import configparser
 import multiprocessing
 from typing import List
@@ -46,31 +47,31 @@ config = configparser.ConfigParser()
 config.read('config.ini')
 
 # logger settings
-logger = logging.getLogger('my_logger')
-logger.setLevel(logging.DEBUG)
-handler = RotatingFileHandler("python_client.log", maxBytes=5*1024*1024, backupCount=3)
-FORMAT = "%(asctime)-15s %(message)s"
-fmt = logging.Formatter(FORMAT, datefmt='%m/%d/%Y %I:%M:%S %p')
-handler.setFormatter(fmt)
-logger.addHandler(handler)
+logger = configure_owner_only_logger('my_logger')
 '''
     Grab the option expire dates and option chains for the specified symbol.
     Save as a JSON file
 
 '''
 
-# FILL THESE IN WITH YOUR OAUTH KEYS AND SECRETS
-# See https://developer.etrade.com/getting-started
+# OAuth credentials are supplied by local config.ini or environment variables.
 OAUTH_KEYS = {
     "sandbox": {
-        "consumer_key": "79a22325849d55ab995c67d9b5df9684",
-        "consumer_secret": "b9711c32ff7e1ec28a609317e0bdcf149fa6f944e59f3c89348e5aa85fd1b32f",
+        "consumer_key": os.getenv("ETRADE_SANDBOX_CONSUMER_KEY") or config['DEFAULT'].get('SANDBOX_CONSUMER_KEY'),
+        "consumer_secret": os.getenv("ETRADE_SANDBOX_CONSUMER_SECRET") or config['DEFAULT'].get('SANDBOX_CONSUMER_SECRET'),
     },
     "live": {
-        "consumer_key": "73ae73ac0315a6520f31b9d081d7849a",
-        "consumer_secret": "3058031dfb6e2a44b5d0ef0055ed46c74f333c08fafdfb6ead39d6637249b34f",
+        "consumer_key": os.getenv("ETRADE_LIVE_CONSUMER_KEY") or config['DEFAULT'].get('PROD_CONSUMER_KEY'),
+        "consumer_secret": os.getenv("ETRADE_LIVE_CONSUMER_SECRET") or config['DEFAULT'].get('PROD_CONSUMER_SECRET'),
     }
 }
+
+
+def configured_oauth_keys(use_sandbox):
+    keys = OAUTH_KEYS[environment_key(use_sandbox)]
+    if not all(isinstance(keys.get(name), str) and keys[name].strip() for name in ("consumer_key", "consumer_secret")):
+        raise RuntimeError("E*TRADE client credentials are not configured")
+    return {name: keys[name].strip() for name in ("consumer_key", "consumer_secret")}
 
 # File to cache OAuth tokens so you don't have to re-authenticate each time
 ETRADE_OAUTH_FILE = ".etrade_oauth"
@@ -95,31 +96,25 @@ def environment_key(use_sandbox) -> str:
 
 def get_etrade_oauth(use_sandbox) -> dict:
     try:
-        with open(ETRADE_OAUTH_FILE) as f:
-            tokens = json.load(f)
-            return tokens[environment_key(use_sandbox)]
-    except (KeyError, TypeError, FileNotFoundError, JSONDecodeError) as err:
-        print("Couldn't find/parse cached OAuth in {} ({}: {})".format(ETRADE_OAUTH_FILE, err))
+        return read_owner_only_json(ETRADE_OAUTH_FILE, label="OAuth cache")[environment_key(use_sandbox)]
+    except (KeyError, TypeError, RuntimeError):
+        print("Couldn't load cached OAuth safely.")
         return None
 
 # Save the token, merging in with existing tokens
 def save_etrade_oauth(token, use_sandbox) -> bool:
     try:
-        try:
-            with open(ETRADE_OAUTH_FILE) as f:
-                tokens = json.load(f)
-        except FileNotFoundError:
-            tokens = {}
+        tokens = read_owner_only_json(ETRADE_OAUTH_FILE, label="OAuth cache") if os.path.lexists(ETRADE_OAUTH_FILE) else {}
         tokens[environment_key(use_sandbox)] = token
-        with open(os.open(ETRADE_OAUTH_FILE, os.O_CREAT | os.O_WRONLY, 0o600), "w") as f:
-            f.write(json.dumps(tokens))
-    except (KeyError, JSONDecodeError) as err:
-        print("Couldn't write cached OAuth in {} ({})".format(ETRADE_OAUTH_FILE, err))
-        sys.exit(1)
+        write_owner_only_json(ETRADE_OAUTH_FILE, tokens)
+        return True
+    except (KeyError, TypeError, RuntimeError):
+        print("Couldn't save cached OAuth safely.")
+        return False
 
 def oauth(use_sandbox, auto_login = True):
     """Allows user authorization for the sample application with OAuth 1"""
-    keys = OAUTH_KEYS[environment_key(use_sandbox)]
+    keys = configured_oauth_keys(use_sandbox)
     consumer_key = keys["consumer_key"]
     consumer_secret = keys["consumer_secret"]
     if use_sandbox:
@@ -137,12 +132,8 @@ def oauth(use_sandbox, auto_login = True):
         base_url=base_url
     )
 
-    token_file = ".etrade_oauth"
-
-    if os.path.exists(token_file):
-        with open(token_file, 'r') as f:
-            tokens = json.load(f)
-        
+    tokens = get_etrade_oauth(use_sandbox)
+    if isinstance(tokens, dict) and {"access_token", "access_token_secret"} <= set(tokens):
         session = etrade.get_session((tokens['access_token'], tokens['access_token_secret']))
         
         renew_url = f"{base_url}/oauth/renew_access_token"
@@ -183,8 +174,8 @@ def oauth(use_sandbox, auto_login = True):
         'access_token': session.access_token,
         'access_token_secret': session.access_token_secret
     }
-    with open(token_file, 'w') as f:
-        json.dump(tokens, f)
+    if not save_etrade_oauth(tokens, use_sandbox):
+        raise RuntimeError("could not persist OAuth cache safely")
 
     print("New session created and tokens saved.")
     return session, base_url
@@ -300,7 +291,7 @@ if __name__ == "__main__":
     
     if start_trade:
         if not bypass_etrade: 
-            etrade_instance = LiveTradeAgent(None,session,base_url)
+            raise RuntimeError("Legacy live execution is disabled; use etrade_cover_call_new with a RuntimeSafetyBoundary")
         else:
             etrade_instance = LiveTradeAgent()
         print('Live trade agent id: ', etrade_instance.agent_id)
@@ -338,4 +329,3 @@ if __name__ == "__main__":
             else:
                 print("Trading hours are over.")
                 t.sleep(60)
-  

--- a/etrade_python_client/live_trading/etrade_cover_call_new.py
+++ b/etrade_python_client/live_trading/etrade_cover_call_new.py
@@ -12,9 +12,11 @@ import json
 import ast
 import os
 import sys
+import stat
 import traceback
 import random
 import secrets
+import tempfile
 import hmac
 import hashlib
 import smtplib
@@ -25,7 +27,6 @@ from email.mime.text import MIMEText
 from datetime import timedelta
 from datetime import datetime, date
 from pathlib import Path
-from logging.handlers import RotatingFileHandler
 import logging
 import pandas as pd
 from live_trading.ev_engine import (
@@ -43,7 +44,6 @@ from accounts.accounts_bo import StockPosition
 from core_api.stock_trade_class import *
 import webbrowser
 from rauth import OAuth1Service
-from logging.handlers import RotatingFileHandler
 from accounts.accounts_bo import Accounts, calculate_std_dev, calculate_margin, print_margin_report, find_highest_margin_ratios, _select_nearest_expiration, is_etrade_token_expired_response
 from market.market_bo import Market
 import configparser
@@ -61,11 +61,22 @@ from live_trading.regime_shadow_store import (
     RegimeShadowStore,
     unavailable_dashboard_payload,
 )
+from live_trading.runtime_safety import (
+    RuntimeSafetyError,
+    build_runtime_safety_boundary,
+    configure_owner_only_logger,
+    read_owner_only_json,
+    secure_append_text,
+    secure_lock_file,
+    validate_dashboard_credentials,
+    write_owner_only_json,
+)
 from live_trading.spy_position_tracker import update_spy_daily_snapshot, record_closed_spy_gain
 import threading
 from http.server import ThreadingHTTPServer, BaseHTTPRequestHandler
 
 import base64
+import io
 TRADE_STATUS_FILE = "trade_status.json"
 DASHBOARD_LOG_FILE = "dashboard_requests.log"
 AUDIT_LOG_FILE = "order_audit_log.csv"
@@ -98,17 +109,17 @@ def log_order_execution(order_info, reason, status="PLACED"):
     try:
         file_exists = os.path.exists(AUDIT_LOG_FILE)
         timestamp = datetime.now().strftime("%Y-%m-%d %H:%M:%S")
-        with open(AUDIT_LOG_FILE, "a") as f:
-            if not file_exists:
-                f.write("timestamp,ticker,type,strikes,qty,reason,order_id,status\n")
-            
-            ticker = order_info.get('ticker', 'N/A')
-            order_type = "CLOSE" if order_info.get('is_close') else "OPEN"
-            strikes = f"{order_info.get('sell_strike', 'N/A')}/{order_info.get('long_strike', 'N/A')}"
-            qty = order_info.get('pair_quantity', order_info.get('qty', 1))
-            order_id = order_info.get('order_id', 'N/A')
-            
-            f.write(f"{timestamp},{ticker},{order_type},{strikes},{qty},{reason},{order_id},{status}\n")
+        ticker = order_info.get('ticker', 'N/A')
+        order_type = "CLOSE" if order_info.get('is_close') else "OPEN"
+        strikes = f"{order_info.get('sell_strike', 'N/A')}/{order_info.get('long_strike', 'N/A')}"
+        qty = order_info.get('pair_quantity', order_info.get('qty', 1))
+        order_id = order_info.get('order_id', 'N/A')
+        buffer = io.StringIO()
+        writer = csv.writer(buffer)
+        if not file_exists:
+            writer.writerow(("timestamp", "ticker", "type", "strikes", "qty", "reason", "order_id", "status"))
+        writer.writerow((timestamp, ticker, order_type, strikes, qty, reason, order_id, status))
+        secure_append_text(AUDIT_LOG_FILE, buffer.getvalue())
     except Exception as e:
         print(f"⚠️ Error writing to audit log: {e}")
 
@@ -157,22 +168,39 @@ def send_trade_notification_email(order_info, reason):
     except Exception as e:
         print(f"⚠️ Failed to send notification email: {e}")
 
+_DASHBOARD_LOG_SECRET_MARKERS = (
+    "pin", "pass", "password", "secret", "token", "credential", "oauth",
+    "consumer", "authorization", "auth",
+)
+
+
+def _redact_dashboard_log_data(value):
+    if isinstance(value, dict):
+        return {
+            key: (
+                "[REDACTED]"
+                if any(marker in str(key).lower() for marker in _DASHBOARD_LOG_SECRET_MARKERS)
+                else _redact_dashboard_log_data(item)
+            )
+            for key, item in value.items()
+        }
+    if isinstance(value, list):
+        return [_redact_dashboard_log_data(item) for item in value]
+    return value
+
+
 def log_dashboard_request(path, data):
-    """Log all dashboard API requests to a persistent file."""
+    """Log request metadata without persisting credentials or action secrets."""
     try:
         timestamp = datetime.now().strftime("%Y-%m-%d %H:%M:%S")
-        # Strip PIN for security in logs
-        log_data = data.copy() if isinstance(data, dict) else data
-        if isinstance(log_data, dict) and 'pin' in log_data:
-            log_data['pin'] = "****"
+        log_data = _redact_dashboard_log_data(data)
             
         entry = {
             "timestamp": timestamp,
             "path": path,
             "data": log_data
         }
-        with open(DASHBOARD_LOG_FILE, "a") as f:
-            f.write(json.dumps(entry) + "\n")
+        secure_append_text(DASHBOARD_LOG_FILE, json.dumps(entry) + "\n")
     except Exception as e:
         print(f"⚠️ Error logging dashboard request: {e}")
 
@@ -912,11 +940,53 @@ LIVE_SETTINGS_FILE = "live_trading_settings.json"
 DASHBOARD_SESSION_COOKIE = "etrade_dashboard_session"
 DASHBOARD_SESSION_DAYS = 7
 
+
+def _validate_live_settings_parent():
+    parent = Path(LIVE_SETTINGS_FILE).parent
+    try:
+        parent_metadata = os.lstat(parent)
+        if (
+            stat.S_ISLNK(parent_metadata.st_mode)
+            or not stat.S_ISDIR(parent_metadata.st_mode)
+            or parent_metadata.st_uid != os.geteuid()
+            or stat.S_IMODE(parent_metadata.st_mode) & 0o022
+        ):
+            raise RuntimeSafetyError("live settings parent is unsafe")
+        parent_descriptor = os.open(
+            parent,
+            os.O_RDONLY | getattr(os, "O_DIRECTORY", 0) | getattr(os, "O_NOFOLLOW", 0),
+        )
+    except OSError as exc:
+        raise RuntimeSafetyError("live settings parent is unsafe") from exc
+    try:
+        opened_parent = os.fstat(parent_descriptor)
+        if (
+            opened_parent.st_dev != parent_metadata.st_dev
+            or opened_parent.st_ino != parent_metadata.st_ino
+        ):
+            raise RuntimeSafetyError("live settings parent is unsafe")
+    finally:
+        os.close(parent_descriptor)
+    return parent
+
+
 def load_live_settings():
     """Load trading settings from JSON file."""
     try:
-        if os.path.exists(LIVE_SETTINGS_FILE):
-            with open(LIVE_SETTINGS_FILE, "r") as f:
+        if os.path.lexists(LIVE_SETTINGS_FILE):
+            _validate_live_settings_parent()
+            metadata = os.stat(LIVE_SETTINGS_FILE, follow_symlinks=False)
+            if (
+                not stat.S_ISREG(metadata.st_mode)
+                or metadata.st_uid != os.geteuid()
+                or stat.S_IMODE(metadata.st_mode) & 0o077
+            ):
+                raise RuntimeSafetyError("live settings must be an owner-only regular file")
+            descriptor = os.open(
+                LIVE_SETTINGS_FILE,
+                os.O_RDONLY | getattr(os, "O_CLOEXEC", 0) | getattr(os, "O_NOFOLLOW", 0),
+            )
+            with os.fdopen(descriptor, "r", encoding="utf-8") as f:
                 settings = json.load(f)
                 # Dynamic self-healing migration for SPY & SPX spread width and pair quantity settings
                 modified = False
@@ -944,6 +1014,8 @@ def load_live_settings():
                 if modified:
                     save_live_settings(settings)
                 return settings
+    except RuntimeSafetyError:
+        raise
     except Exception as e:
         print(f"⚠️ Error loading settings: {e}")
     
@@ -965,17 +1037,48 @@ def load_live_settings():
         "spy_target_expiration": None,
         "spx_target_expiration": None,
         "auto_open_enabled": False,
-        "pin": "1234",
+        "pin": "",
         "dashboard_user": "",
         "dashboard_pass": "",
         "dashboard_auth_secret": secrets.token_hex(32)
     }
 
 def save_live_settings(settings):
-    """Save trading settings to JSON file."""
+    """Atomically save validated dashboard settings as an owner-only file."""
     try:
-        with open(LIVE_SETTINGS_FILE, "w") as f:
-            json.dump(settings, f, indent=4)
+        validate_dashboard_credentials(settings)
+        target = Path(LIVE_SETTINGS_FILE)
+        parent = _validate_live_settings_parent()
+        if os.path.lexists(target) and stat.S_ISLNK(os.lstat(target).st_mode):
+            raise RuntimeSafetyError("live settings path must not be a symlink")
+        descriptor, temporary_name = tempfile.mkstemp(
+            prefix=f".{target.name}.",
+            suffix=".tmp",
+            dir=parent,
+            text=True,
+        )
+        try:
+            os.fchmod(descriptor, 0o600)
+            with os.fdopen(descriptor, "w", encoding="utf-8") as handle:
+                descriptor = -1
+                json.dump(settings, handle, indent=4)
+                handle.flush()
+                os.fsync(handle.fileno())
+            os.replace(temporary_name, target)
+            temporary_name = None
+            parent_descriptor = os.open(parent, os.O_RDONLY)
+            try:
+                os.fsync(parent_descriptor)
+            finally:
+                os.close(parent_descriptor)
+        finally:
+            if descriptor >= 0:
+                os.close(descriptor)
+            if temporary_name is not None:
+                try:
+                    os.unlink(temporary_name)
+                except OSError:
+                    pass
         return True
     except Exception as e:
         print(f"⚠️ Error saving settings: {e}")
@@ -2147,11 +2250,14 @@ class RefreshHandler(BaseHTTPRequestHandler):
         try:
             self.send_response(code)
             self.send_header('Content-Type', content_type)
-            self.send_header('Access-Control-Allow-Origin', '*')
             response_headers = {
                 'Cache-Control': 'no-store, max-age=0',
                 'Pragma': 'no-cache',
                 'Expires': '0',
+                'X-Content-Type-Options': 'nosniff',
+                'X-Frame-Options': 'DENY',
+                'Referrer-Policy': 'no-referrer',
+                'Cross-Origin-Resource-Policy': 'same-origin',
             }
             response_headers.update(headers or {})
             for key, value in response_headers.items():
@@ -2200,19 +2306,9 @@ class RefreshHandler(BaseHTTPRequestHandler):
             print("⚠️ Error sending private dashboard response.")
 
     def do_OPTIONS(self):
-        """Handle CORS preflight requests."""
+        """Reject cross-origin preflight for this same-origin dashboard."""
         try:
-            if self.path.split("?", 1)[0] == "/api/regime_v2_shadow":
-                self._send_private_json_response(
-                    405,
-                    {"error": "Method not allowed"},
-                )
-                return
-            self.send_response(200)
-            self.send_header('Access-Control-Allow-Origin', '*')
-            self.send_header('Access-Control-Allow-Methods', 'GET, POST, OPTIONS')
-            self.send_header('Access-Control-Allow-Headers', 'Content-Type')
-            self.end_headers()
+            self._send_private_json_response(405, {"error": "Method not allowed"})
         except (BrokenPipeError, ConnectionResetError):
             pass
     
@@ -2841,15 +2937,14 @@ def start_ngrok_tunnel(config, port):
     except Exception as e:
         print(f"⚠️ Error starting ngrok tunnel: {e}")
 
-def start_refresh_server(port=8765):
-    """Start the HTTP refresh server in a background thread."""
-    server = ThreadingHTTPServer(('0.0.0.0', port), RefreshHandler)
+def start_refresh_server(port=8765, host="127.0.0.1"):
+    """Start the order-capable dashboard on loopback only."""
+    if host not in {"127.0.0.1", "::1", "localhost"}:
+        raise RuntimeSafetyError("dashboard host must be loopback")
+    server = ThreadingHTTPServer((host, port), RefreshHandler)
     server_thread = threading.Thread(target=server.serve_forever, daemon=True)
     server_thread.start()
     print(f"🌐 [Refresh Server] Started on http://localhost:{port}")
-    
-    # Start ngrok tunnel if configured
-    start_ngrok_tunnel(config, port)
     
     return server
 
@@ -2877,13 +2972,7 @@ config = configparser.ConfigParser()
 config.read('config.ini')
 
 # logger settings
-logger = logging.getLogger('my_logger')
-logger.setLevel(logging.DEBUG)
-handler = RotatingFileHandler("python_client.log", maxBytes=5*1024*1024, backupCount=3)
-FORMAT = "%(asctime)-15s %(message)s"
-fmt = logging.Formatter(FORMAT, datefmt='%m/%d/%Y %I:%M:%S %p')
-handler.setFormatter(fmt)
-logger.addHandler(handler)
+logger = configure_owner_only_logger('my_logger')
 '''
     Grab the option expire dates and option chains for the specified symbol.
     Save as a JSON file
@@ -2891,17 +2980,35 @@ logger.addHandler(handler)
 '''
 OAUTH_KEYS = {
     "sandbox": {
-        "consumer_key": config['DEFAULT'].get('SANDBOX_CONSUMER_KEY', os.getenv("ETRADE_SANDBOX_CONSUMER_KEY", "default_sandbox_key")),
-        "consumer_secret": config['DEFAULT'].get('SANDBOX_CONSUMER_SECRET', os.getenv("ETRADE_SANDBOX_CONSUMER_SECRET", "default_sandbox_secret")),
+        "consumer_key": config['DEFAULT'].get('SANDBOX_CONSUMER_KEY', os.getenv("ETRADE_SANDBOX_CONSUMER_KEY")),
+        "consumer_secret": config['DEFAULT'].get('SANDBOX_CONSUMER_SECRET', os.getenv("ETRADE_SANDBOX_CONSUMER_SECRET")),
     },
     "live": {
-        "consumer_key": config['DEFAULT'].get('PROD_CONSUMER_KEY', os.getenv("ETRADE_LIVE_CONSUMER_KEY", "default_live_key")),
-        "consumer_secret": config['DEFAULT'].get('PROD_CONSUMER_SECRET', os.getenv("ETRADE_LIVE_CONSUMER_SECRET", "default_live_secret")),
+        "consumer_key": config['DEFAULT'].get('PROD_CONSUMER_KEY', os.getenv("ETRADE_LIVE_CONSUMER_KEY")),
+        "consumer_secret": config['DEFAULT'].get('PROD_CONSUMER_SECRET', os.getenv("ETRADE_LIVE_CONSUMER_SECRET")),
     }
 }
 
 # File to cache OAuth tokens so you don't have to re-authenticate each time
 ETRADE_OAUTH_FILE = ".etrade_oauth"
+
+
+def configured_oauth_keys(use_sandbox):
+    """Return non-placeholder client credentials or fail before broker I/O."""
+
+    prefix = "SANDBOX" if use_sandbox else "LIVE"
+    config_key = "SANDBOX" if use_sandbox else "PROD"
+    consumer_key = os.getenv(f"ETRADE_{prefix}_CONSUMER_KEY") or config["DEFAULT"].get(f"{config_key}_CONSUMER_KEY")
+    consumer_secret = os.getenv(f"ETRADE_{prefix}_CONSUMER_SECRET") or config["DEFAULT"].get(f"{config_key}_CONSUMER_SECRET")
+    placeholders = {"", "default_live_key", "default_live_secret", "default_sandbox_key", "default_sandbox_secret"}
+    if (
+        not isinstance(consumer_key, str)
+        or not isinstance(consumer_secret, str)
+        or consumer_key.strip() in placeholders
+        or consumer_secret.strip() in placeholders
+    ):
+        raise RuntimeSafetyError("E*TRADE client credentials are not configured")
+    return {"consumer_key": consumer_key.strip(), "consumer_secret": consumer_secret.strip()}
 
 def is_trading_day(check_date):
     """
@@ -3261,7 +3368,7 @@ def release_margin(all_positions, cover_call_list=None, etrade_instance=None, ma
 
     # Process each order generated for the selected candidates
     for order in orders:
-        print(f"Processing order: {order}")
+        print("Processing generated close order; payload withheld.")
         if etrade_instance:
             preview_response = etrade_instance.order.place_order(order, preview_only=True)
             print(f"Preview response: {preview_response}")
@@ -4109,39 +4216,38 @@ def environment_key(use_sandbox) -> str:
 
 def get_etrade_oauth(use_sandbox) -> dict:
     try:
-        with open(ETRADE_OAUTH_FILE) as f:
-            tokens = json.load(f)
-            return tokens[environment_key(use_sandbox)]
-    except (KeyError, TypeError, FileNotFoundError, JSONDecodeError) as err:
-        print("Couldn't find/parse cached OAuth in {} ({}: {})".format(ETRADE_OAUTH_FILE, err))
+        tokens = read_owner_only_json(ETRADE_OAUTH_FILE, label="OAuth cache")
+        return tokens[environment_key(use_sandbox)]
+    except (KeyError, TypeError, RuntimeSafetyError):
+        print("Couldn't load cached OAuth safely.")
         return None
 
 # Save the token, merging in with existing tokens
 def save_etrade_oauth(token, use_sandbox) -> bool:
     try:
-        try:
-            with open(ETRADE_OAUTH_FILE) as f:
-                tokens = json.load(f)
-        except FileNotFoundError:
+        if os.path.lexists(ETRADE_OAUTH_FILE):
+            tokens = read_owner_only_json(ETRADE_OAUTH_FILE, label="OAuth cache")
+        else:
             tokens = {}
         tokens[environment_key(use_sandbox)] = token
-        with open(os.open(ETRADE_OAUTH_FILE, os.O_CREAT | os.O_WRONLY, 0o600), "w") as f:
-            f.write(json.dumps(tokens))
-    except (KeyError, JSONDecodeError) as err:
-        print("Couldn't write cached OAuth in {} ({})".format(ETRADE_OAUTH_FILE, err))
-        sys.exit(1)
+        write_owner_only_json(ETRADE_OAUTH_FILE, tokens)
+        return True
+    except (KeyError, TypeError, RuntimeSafetyError):
+        print("Couldn't save cached OAuth safely.")
+        return False
 
 from urllib.parse import parse_qsl
 
 def oauth(use_sandbox, auto_login=True, username=None, password=None, headless=None):
     """Allows user authorization for the sample application with OAuth 1"""
-    keys = OAUTH_KEYS[environment_key(use_sandbox)]
+    if use_sandbox not in {True, False}:
+        raise RuntimeSafetyError("E*TRADE environment must be explicit")
+    keys = configured_oauth_keys(use_sandbox)
     consumer_key = keys["consumer_key"]
     consumer_secret = keys["consumer_secret"]
     
     print(f"Environment: {'Sandbox' if use_sandbox else 'Live'}")
     print(f"Base URL: {'https://apisb.etrade.com' if use_sandbox else 'https://api.etrade.com'}")
-    print(f"Consumer Key used: {consumer_key[:4]}...{consumer_key[-4:]}")
     sys.stdout.flush()
 
     if use_sandbox:
@@ -4165,11 +4271,14 @@ def oauth(use_sandbox, auto_login=True, username=None, password=None, headless=N
         base_url=base_url
     )
 
-    token_file = ".etrade_oauth"
+    token_file = ETRADE_OAUTH_FILE
 
-    if os.path.exists(token_file):
-        with open(token_file, 'r') as f:
-            tokens = json.load(f)
+    tokens = (
+        read_owner_only_json(token_file, label="OAuth cache")
+        if os.path.lexists(token_file)
+        else None
+    )
+    if isinstance(tokens, dict) and {"access_token", "access_token_secret"} <= set(tokens):
         
         session = etrade.get_session((tokens['access_token'], tokens['access_token_secret']))
         
@@ -4263,8 +4372,7 @@ def oauth(use_sandbox, auto_login=True, username=None, password=None, headless=N
         'access_token': session.access_token,
         'access_token_secret': session.access_token_secret
     }
-    with open(token_file, 'w') as f:
-        json.dump(tokens, f)
+    write_owner_only_json(token_file, tokens)
 
     print("New session created and tokens saved.")
     return session, base_url
@@ -4285,6 +4393,18 @@ def _attach_etrade_auth_refresh_callbacks():
             setattr(client, "auth_refresh_callback", callback)
 
 
+def _select_runtime_account(account_client):
+    """Resolve the selected account through the immutable runtime boundary."""
+
+    safety = globals().get("runtime_safety")
+    if safety is None:
+        # Importable helpers retain legacy sandbox behavior outside the main process.
+        return account_client.account_list(1)
+    account_client.account_list(**safety.account_selection_kwargs)
+    safety.verify_account(account_client.account)
+    return account_client.account
+
+
 def _refresh_etrade_session(reason="E*TRADE request"):
     with ETRADE_SESSION_REFRESH_LOCK:
         use_sandbox_value = globals().get("use_sandbox", False)
@@ -4296,15 +4416,25 @@ def _refresh_etrade_session(reason="E*TRADE request"):
         globals()["last_renewal_time"] = datetime.now()
 
         if globals().get("accounts") is not None:
-            refreshed_accounts = Accounts(new_session, new_base_url, use_sandbox=use_sandbox_value)
-            refreshed_accounts.account_list(1)
+            refreshed_accounts = Accounts(
+                new_session, new_base_url, use_sandbox=use_sandbox_value,
+                consumer_key=globals().get("runtime_consumer_key"),
+            )
+            _select_runtime_account(refreshed_accounts)
             globals()["accounts"] = refreshed_accounts
         if globals().get("market") is not None:
-            globals()["market"] = Market(new_session, new_base_url, use_sandbox=use_sandbox_value)
+            globals()["market"] = Market(
+                new_session, new_base_url, use_sandbox=use_sandbox_value,
+                consumer_key=globals().get("runtime_consumer_key"),
+            )
 
         etrade = globals().get("etrade_instance")
         if etrade is not None:
             etrade.refresh_session(new_session, new_base_url)
+            safety = globals().get("runtime_safety")
+            if safety is None:
+                raise RuntimeSafetyError("runtime account safety is unavailable during refresh")
+            safety.verify_account(etrade.account.account)
 
         _attach_etrade_auth_refresh_callbacks()
         return new_session, new_base_url
@@ -4313,26 +4443,44 @@ def _refresh_etrade_session(reason="E*TRADE request"):
 if __name__ == "__main__":
     parser = argparse.ArgumentParser(description='Grab all the option chains for the specified symbol',
                                      formatter_class=argparse.ArgumentDefaultsHelpFormatter)
-    parser.add_argument('--sandbox', help='use sandbox?', action=argparse.BooleanOptionalAction)
+    parser.add_argument('--environment', choices=('sandbox', 'production'))
+    parser.add_argument('--sandbox', help='legacy explicit sandbox mode', action=argparse.BooleanOptionalAction, default=None)
     parser.add_argument('--trade', help='start live trade?', action=argparse.BooleanOptionalAction)
     parser.add_argument('--use_existing_file', help='re-use the backtest results?', action=argparse.BooleanOptionalAction)
     parser.add_argument('--no-regime', help='skip heavy market regime detection?', action='store_true')
+    parser.add_argument('--expected-account-id')
+    parser.add_argument('--expected-account-id-key')
+    parser.add_argument('--expected-institution-type')
+    parser.add_argument('--production-arm-file', type=Path)
 
     parser.add_argument('--username', help='username for login', type=str, required=False)
     parser.add_argument('--password', help='password for login', type=str, required=False)
     parser.add_argument('--no-headless', help='disable headless mode for login', action='store_true')
     args = parser.parse_args()
 
-    # --- SINGLETON LOCK ---
-    import fcntl
-    lock_file_path = '/tmp/etrade_trader.lock'
-    lock_file = open(lock_file_path, 'w')
+    if args.trade is not True:
+        parser.error("--trade is required for this order-capable process")
+
     try:
-        fcntl.lockf(lock_file, fcntl.LOCK_EX | fcntl.LOCK_NB)
-    except IOError:
-        print(f"❌ Error: Another instance of etrade_cover_call_new is already running.")
-        sys.exit(1)
-    use_sandbox = args.sandbox
+        runtime_safety = build_runtime_safety_boundary(
+            environment=args.environment,
+            legacy_sandbox=args.sandbox,
+            expected_account_id=args.expected_account_id,
+            expected_account_id_key=args.expected_account_id_key,
+            expected_institution_type=args.expected_institution_type,
+            production_arm_file=args.production_arm_file,
+            production_arm_secret=os.getenv("ETRADE_PRODUCTION_ARMING_SECRET"),
+        )
+    except RuntimeSafetyError as exc:
+        parser.error(str(exc))
+
+    # --- SINGLETON LOCK ---
+    try:
+        lock_file = secure_lock_file(Path.cwd() / "etrade_trader.lock")
+    except RuntimeSafetyError as exc:
+        parser.error(str(exc))
+    use_sandbox = runtime_safety.use_sandbox
+    runtime_consumer_key = configured_oauth_keys(use_sandbox)["consumer_key"]
     start_trade = args.trade
     use_existing_file = args.use_existing_file
     no_regime = args.no_regime
@@ -4367,9 +4515,12 @@ if __name__ == "__main__":
     start_log = False
     end_log = False
 
-    keys = OAUTH_KEYS[environment_key(use_sandbox)]
-    consumer_key = keys["consumer_key"]
-    consumer_secret = keys["consumer_secret"]
+    try:
+        live_settings = load_live_settings()
+        validate_dashboard_credentials(live_settings)
+        configured_oauth_keys(use_sandbox)
+    except RuntimeSafetyError as exc:
+        parser.error(str(exc))
 
     trade_executed_flag = False # flag to be reset every ticks, indicating the trade strategy had been exeucted for the current tick
     # Add these lines
@@ -4390,8 +4541,7 @@ if __name__ == "__main__":
 
     authenticated = 0
     
-    # Load dynamic settings
-    live_settings = load_live_settings()
+    # Load dynamic settings only after the safety boundary has accepted them.
     trade_start_time = datetime.strptime(live_settings.get('trade_start_time', '07:15:00'), '%H:%M:%S').time()
     trade_end_time = datetime.strptime(live_settings.get('trade_end_time', '13:30:00'), '%H:%M:%S').time()
 
@@ -4404,14 +4554,27 @@ if __name__ == "__main__":
 
     if start_trade:
         if not bypass_etrade: 
-            etrade_instance = LiveTradeAgent(None,session,base_url, use_sandbox=use_sandbox)
+            selection = runtime_safety.account_selection_kwargs
+            etrade_instance = LiveTradeAgent(
+                None,
+                session,
+                base_url,
+                selected_account=selection["selected_account_id"],
+                use_sandbox=use_sandbox,
+                expected_account_id_key=runtime_safety.expected_account_id_key,
+                expected_account_id=runtime_safety.expected_account_id,
+                expected_institution_type=runtime_safety.expected_institution_type,
+                runtime_safety=runtime_safety,
+                consumer_key=runtime_consumer_key,
+            )
+            runtime_safety.verify_account(etrade_instance.account.account)
         else:
             etrade_instance = LiveTradeAgent()
         print('Live trade agent id: ', etrade_instance.agent_id)
 
-        accounts = Accounts(session, base_url)
-        accounts.account_list(1) # Select the Individual Brokerage account ending in 8703
-        market = Market(session, base_url)
+        accounts = Accounts(session, base_url, use_sandbox=use_sandbox, consumer_key=runtime_consumer_key)
+        _select_runtime_account(accounts)
+        market = Market(session, base_url, use_sandbox=use_sandbox, consumer_key=runtime_consumer_key)
         _attach_etrade_auth_refresh_callbacks()
 
 
@@ -4484,7 +4647,7 @@ if __name__ == "__main__":
     # Guard: Ensure --trade flag was passed, otherwise accounts/etrade_instance are undefined
     if not start_trade:
         print("❌ Error: You must run with --trade flag for the refresh functionality to work.")
-        print("   Example: python3 etrade_cover_call_new.py --no-sandbox --trade --username <user> --password <pass>")
+        print("   See live_trading/README.md for explicit environment and production-arm usage.")
         sys.exit(1)
     
     while True:
@@ -4526,11 +4689,12 @@ if __name__ == "__main__":
                 try:
                     session, base_url = oauth(use_sandbox)
                     last_renewal_time = datetime.now()
-                    accounts = Accounts(session, base_url)
-                    market = Market(session, base_url)
-                    accounts.account_list(1)
+                    accounts = Accounts(session, base_url, use_sandbox=use_sandbox, consumer_key=runtime_consumer_key)
+                    market = Market(session, base_url, use_sandbox=use_sandbox, consumer_key=runtime_consumer_key)
+                    _select_runtime_account(accounts)
                     if start_trade and not bypass_etrade:
                         etrade_instance.refresh_session(session, base_url)
+                        runtime_safety.verify_account(etrade_instance.account.account)
                     _attach_etrade_auth_refresh_callbacks()
                 except LoginFailureException as e:
                     logging.error(f"Failed to renew session (LoginFailure): {e}")
@@ -4577,7 +4741,7 @@ if __name__ == "__main__":
             if is_manual_refresh and not is_manual_trade:
                 print(f"🔄 [Manual Refresh] Regenerating portfolio HTML ({market_status})...")
                 try:
-                    accounts.account_list(1)
+                    _select_runtime_account(accounts)
                     refresh_positions = accounts.portfolio(print_enable=False, require_success=True)
                     from copy import deepcopy
                     refresh_screened = accounts.screen_option(deepcopy(refresh_positions))
@@ -4729,7 +4893,7 @@ if __name__ == "__main__":
                 if is_manual_refresh:
                     print("🔄 [Manual Refresh] Fetching portfolio and updating HTML (market closed)...")
                     try:
-                        accounts.account_list(1)
+                        _select_runtime_account(accounts)
                         all_positions = accounts.portfolio(print_enable=False, require_success=True)
                         screened = accounts.screen_option(all_positions)
                         html_path = accounts.render_screened_option_pairs_html(screened, out_path="screened_option_pairs.html", order_instance=etrade_instance.order, show_refresh=False)
@@ -4762,7 +4926,7 @@ if __name__ == "__main__":
 
             # ── Market is a trading day (PRE_MARKET, OPEN, or AFTER_HOURS) ──
             # Run read-only account/portfolio operations
-            accounts.account_list(1)
+            _select_runtime_account(accounts)
             today = datetime.now()
             passed_monday = today - timedelta(days=((today.weekday()) % 7))
             etrade_instance.order.option_gain_new(passed_monday.strftime("%Y-%m-%d"))

--- a/etrade_python_client/live_trading/etrade_option_chains.py
+++ b/etrade_python_client/live_trading/etrade_option_chains.py
@@ -10,6 +10,7 @@ import json
 import ast
 import os
 import sys
+import webbrowser
 from datetime import timedelta
 from datetime import datetime
 from logging.handlers import RotatingFileHandler
@@ -23,37 +24,42 @@ from itertools import product
 from data_and_research import option_price
 import time
 import csv
+import configparser
+from live_trading.runtime_safety import configure_owner_only_logger, read_owner_only_json, write_owner_only_json
 
 # from backtesting.test import SMA
 
 LOOKBACK_DAY = 180
 
+config = configparser.ConfigParser()
+config.read('config.ini')
+
 # logger settings
-logger = logging.getLogger('my_logger')
-logger.setLevel(logging.DEBUG)
-handler = RotatingFileHandler("python_client.log", maxBytes=5*1024*1024, backupCount=3)
-FORMAT = "%(asctime)-15s %(message)s"
-fmt = logging.Formatter(FORMAT, datefmt='%m/%d/%Y %I:%M:%S %p')
-handler.setFormatter(fmt)
-logger.addHandler(handler)
+logger = configure_owner_only_logger('my_logger')
 '''
     Grab the option expire dates and option chains for the specified symbol.
     Save as a JSON file
 
 '''
 
-# FILL THESE IN WITH YOUR OAUTH KEYS AND SECRETS
-# See https://developer.etrade.com/getting-started
+# OAuth credentials are supplied by local config.ini or environment variables.
 OAUTH_KEYS = {
     "sandbox": {
-        "consumer_key": "79a22325849d55ab995c67d9b5df9684",
-        "consumer_secret": "b9711c32ff7e1ec28a609317e0bdcf149fa6f944e59f3c89348e5aa85fd1b32f",
+        "consumer_key": os.getenv("ETRADE_SANDBOX_CONSUMER_KEY") or config['DEFAULT'].get('SANDBOX_CONSUMER_KEY'),
+        "consumer_secret": os.getenv("ETRADE_SANDBOX_CONSUMER_SECRET") or config['DEFAULT'].get('SANDBOX_CONSUMER_SECRET'),
     },
     "live": {
-        "consumer_key": "73ae73ac0315a6520f31b9d081d7849a",
-        "consumer_secret": "3058031dfb6e2a44b5d0ef0055ed46c74f333c08fafdfb6ead39d6637249b34f",
+        "consumer_key": os.getenv("ETRADE_LIVE_CONSUMER_KEY") or config['DEFAULT'].get('PROD_CONSUMER_KEY'),
+        "consumer_secret": os.getenv("ETRADE_LIVE_CONSUMER_SECRET") or config['DEFAULT'].get('PROD_CONSUMER_SECRET'),
     }
 }
+
+
+def configured_oauth_keys(use_sandbox):
+    keys = OAUTH_KEYS[environment_key(use_sandbox)]
+    if not all(isinstance(keys.get(name), str) and keys[name].strip() for name in ("consumer_key", "consumer_secret")):
+        raise RuntimeError("E*TRADE client credentials are not configured")
+    return {name: keys[name].strip() for name in ("consumer_key", "consumer_secret")}
 
 # File to cache OAuth tokens so you don't have to re-authenticate each time
 ETRADE_OAUTH_FILE = ".etrade_oauth"
@@ -238,27 +244,21 @@ def environment_key(use_sandbox) -> str:
 
 def get_etrade_oauth(use_sandbox) -> dict:
     try:
-        with open(ETRADE_OAUTH_FILE) as f:
-            tokens = json.load(f)
-            return tokens[environment_key(use_sandbox)]
-    except (KeyError, TypeError, FileNotFoundError, JSONDecodeError) as err:
-        print("Couldn't find/parse cached OAuth in {} ({}: {})".format(ETRADE_OAUTH_FILE, err))
+        return read_owner_only_json(ETRADE_OAUTH_FILE, label="OAuth cache")[environment_key(use_sandbox)]
+    except (KeyError, TypeError, RuntimeError):
+        print("Couldn't load cached OAuth safely.")
         return None
 
 # Save the token, merging in with existing tokens
 def save_etrade_oauth(token, use_sandbox) -> bool:
     try:
-        try:
-            with open(ETRADE_OAUTH_FILE) as f:
-                tokens = json.load(f)
-        except FileNotFoundError:
-            tokens = {}
+        tokens = read_owner_only_json(ETRADE_OAUTH_FILE, label="OAuth cache") if os.path.lexists(ETRADE_OAUTH_FILE) else {}
         tokens[environment_key(use_sandbox)] = token
-        with open(os.open(ETRADE_OAUTH_FILE, os.O_CREAT | os.O_WRONLY, 0o600), "w") as f:
-            f.write(json.dumps(tokens))
-    except (KeyError, JSONDecodeError) as err:
-        print("Couldn't write cached OAuth in {} ({})".format(ETRADE_OAUTH_FILE, err))
-        sys.exit(1)
+        write_owner_only_json(ETRADE_OAUTH_FILE, tokens)
+        return True
+    except (KeyError, TypeError, RuntimeError):
+        print("Couldn't save cached OAuth safely.")
+        return False
 
 if __name__ == "__main__":
     parser = argparse.ArgumentParser(description='Grab all the option chains for the specified symbol',
@@ -271,7 +271,7 @@ if __name__ == "__main__":
     args = parser.parse_args()
     use_sandbox = args.sandbox
 
-    keys = OAUTH_KEYS[environment_key(use_sandbox)]
+    keys = configured_oauth_keys(use_sandbox)
     consumer_key = keys["consumer_key"]
     consumer_secret = keys["consumer_secret"]
 
@@ -288,8 +288,8 @@ if __name__ == "__main__":
     except Exception as err:
         # print("Got {} when trying to get & renew cached OAuth tokens; getting new ones".format(err))
         oauth = pyetrade.ETradeOAuth(consumer_key, consumer_secret)
-        print("Visit this URL and copy the five character token")
-        print(oauth.get_request_token())
+        print("Opening E*TRADE authorization; copy the five-character verifier.")
+        webbrowser.open(oauth.get_request_token())
         API_token = input('E*TRADE token: ')
         oauth.get_access_token(API_token)
         token = oauth.access_token

--- a/etrade_python_client/live_trading/etrade_put_credit_spread.py
+++ b/etrade_python_client/live_trading/etrade_put_credit_spread.py
@@ -34,7 +34,6 @@ import os
 import sys
 import time
 from datetime import datetime, timedelta
-from logging.handlers import RotatingFileHandler
 from typing import Dict, List, Optional, Tuple
 from urllib.parse import parse_qsl
 
@@ -50,6 +49,12 @@ from data_and_research.option_assign_probability import calculate_probability
 from backtesting.polygonio_dailytrade import fetch_yfinance_data
 from data_and_research.polygonio_improvequery import get_earnings_dates
 from backtesting.polygon_multi import load_latest_parameters
+from live_trading.runtime_safety import (
+    RuntimeSafetyError,
+    configure_owner_only_logger,
+    read_owner_only_json,
+    write_owner_only_json,
+)
 
 # Constants
 ETRADE_OAUTH_FILE = ".etrade_oauth"
@@ -60,25 +65,17 @@ config.read('config.ini')
 
 OAUTH_KEYS = {
     "sandbox": {
-        "consumer_key": config.get('DEFAULT', 'SANDBOX_CONSUMER_KEY', fallback=os.getenv("ETRADE_SANDBOX_CONSUMER_KEY", "default_sandbox_key")),
-        "consumer_secret": config.get('DEFAULT', 'SANDBOX_CONSUMER_SECRET', fallback=os.getenv("ETRADE_SANDBOX_CONSUMER_SECRET", "default_sandbox_secret")),
+        "consumer_key": os.getenv("ETRADE_SANDBOX_CONSUMER_KEY") or config.get('DEFAULT', 'SANDBOX_CONSUMER_KEY', fallback=None),
+        "consumer_secret": os.getenv("ETRADE_SANDBOX_CONSUMER_SECRET") or config.get('DEFAULT', 'SANDBOX_CONSUMER_SECRET', fallback=None),
     },
     "live": {
-        "consumer_key": config.get('DEFAULT', 'PROD_CONSUMER_KEY', fallback=os.getenv("ETRADE_LIVE_CONSUMER_KEY", "default_live_key")),
-        "consumer_secret": config.get('DEFAULT', 'PROD_CONSUMER_SECRET', fallback=os.getenv("ETRADE_LIVE_CONSUMER_SECRET", "default_live_secret")),
+        "consumer_key": os.getenv("ETRADE_LIVE_CONSUMER_KEY") or config.get('DEFAULT', 'PROD_CONSUMER_KEY', fallback=None),
+        "consumer_secret": os.getenv("ETRADE_LIVE_CONSUMER_SECRET") or config.get('DEFAULT', 'PROD_CONSUMER_SECRET', fallback=None),
     }
 }
 
 # Setup logging
-logger = logging.getLogger('etrade_trader')
-logger.setLevel(logging.DEBUG)
-handler = RotatingFileHandler("etrade_trader.log", maxBytes=5*1024*1024, backupCount=3)
-formatter = logging.Formatter("%(asctime)s - %(levelname)s - %(message)s", datefmt='%Y-%m-%d %H:%M:%S')
-handler.setFormatter(formatter)
-logger.addHandler(handler)
-console_handler = logging.StreamHandler()
-console_handler.setFormatter(formatter)
-logger.addHandler(console_handler)
+logger = configure_owner_only_logger('etrade_trader', "etrade_trader.log")
 
 def environment_key(use_sandbox: bool) -> str:
     """Determine the environment key based on sandbox flag."""
@@ -87,31 +84,33 @@ def environment_key(use_sandbox: bool) -> str:
 def load_oauth_tokens(use_sandbox: bool) -> Optional[Dict[str, str]]:
     """Load cached OAuth tokens from file."""
     try:
-        with open(ETRADE_OAUTH_FILE, 'r') as f:
-            tokens = json.load(f)
+        tokens = read_owner_only_json(ETRADE_OAUTH_FILE, label="OAuth cache")
         return tokens.get(environment_key(use_sandbox))
-    except (FileNotFoundError, json.JSONDecodeError, KeyError) as e:
+    except (RuntimeSafetyError, KeyError, TypeError) as e:
         logger.warning(f"Failed to load OAuth tokens: {e}")
         return None
 
 def save_oauth_tokens(tokens: Dict[str, str], use_sandbox: bool) -> None:
     """Save OAuth tokens to file securely."""
     try:
-        existing_tokens = {}
-        if os.path.exists(ETRADE_OAUTH_FILE):
-            with open(ETRADE_OAUTH_FILE, 'r') as f:
-                existing_tokens = json.load(f)
+        existing_tokens = (
+            read_owner_only_json(ETRADE_OAUTH_FILE, label="OAuth cache")
+            if os.path.lexists(ETRADE_OAUTH_FILE)
+            else {}
+        )
         existing_tokens[environment_key(use_sandbox)] = tokens
-        with open(ETRADE_OAUTH_FILE, 'w', encoding='utf-8') as f:
-            json.dump(existing_tokens, f, ensure_ascii=False, indent=4)
-        os.chmod(ETRADE_OAUTH_FILE, 0o600)
+        write_owner_only_json(ETRADE_OAUTH_FILE, existing_tokens)
         logger.info("OAuth tokens saved successfully.")
-    except (IOError, json.JSONDecodeError) as e:
+    except (RuntimeSafetyError, KeyError, TypeError) as e:
         logger.error(f"Failed to save OAuth tokens: {e}")
-        sys.exit(1)
+        raise RuntimeSafetyError("could not persist OAuth cache safely") from e
 
 def get_etrade_session(use_sandbox: bool, auto_login: bool = True, username: Optional[str] = None, password: Optional[str] = None) -> Tuple[Optional[OAuth1Service], str]:
     """Authenticate and get E*TRADE OAuth session with renewal support."""
+    raise RuntimeSafetyError(
+        "etrade_put_credit_spread is quarantined; use etrade_cover_call_new "
+        "with an explicit RuntimeSafetyBoundary"
+    )
     keys = OAUTH_KEYS[environment_key(use_sandbox)]
     base_url = config.get('DEFAULT', 'SANDBOX_BASE_URL') if use_sandbox else config.get('DEFAULT', 'PROD_BASE_URL')
 
@@ -253,6 +252,7 @@ def release_margin(
 
 def main():
     parser = argparse.ArgumentParser(description="E*TRADE Options Trading Application")
+    parser.error("etrade_put_credit_spread is quarantined; use etrade_cover_call_new with explicit runtime safety")
     parser.add_argument('--sandbox', action='store_true', help='Use sandbox environment')
     parser.add_argument('--trade', action='store_true', help='Enable live trading')
     parser.add_argument('--use_existing_file', action='store_true', help='Reuse backtest results')

--- a/etrade_python_client/live_trading/runtime_safety.py
+++ b/etrade_python_client/live_trading/runtime_safety.py
@@ -1,0 +1,649 @@
+"""Fail-closed runtime controls for the order-capable E*TRADE process."""
+
+from __future__ import annotations
+
+import argparse
+import hashlib
+import hmac
+import json
+import logging
+import os
+import secrets
+import stat
+import fcntl
+from dataclasses import dataclass
+from datetime import datetime, timedelta, timezone
+from logging.handlers import RotatingFileHandler
+from pathlib import Path
+from typing import Any
+
+
+class RuntimeSafetyError(RuntimeError):
+    """Raised before broker construction when a runtime safety invariant fails."""
+
+
+ARM_SCHEMA_VERSION = 1
+MAX_PRODUCTION_ARM_LIFETIME = timedelta(minutes=15)
+MAX_PRODUCTION_ARM_FUTURE_SKEW = timedelta(seconds=60)
+_ARM_SIGNED_FIELDS = (
+    "version",
+    "environment",
+    "expected_account_id",
+    "expected_account_id_key",
+    "expected_institution_type",
+    "issued_at",
+    "expires_at",
+)
+_ARM_FIELDS = frozenset((*_ARM_SIGNED_FIELDS, "signature"))
+
+
+def _required_text(value: str | None, name: str) -> str:
+    if not isinstance(value, str) or not value.strip():
+        raise RuntimeSafetyError(f"{name} is required")
+    return value.strip()
+
+
+def _parse_timestamp(value: Any, label: str) -> datetime:
+    if not isinstance(value, str):
+        raise RuntimeSafetyError(f"production arm {label} is invalid")
+    try:
+        parsed = datetime.fromisoformat(value.replace("Z", "+00:00"))
+    except ValueError as exc:
+        raise RuntimeSafetyError(f"production arm {label} is invalid") from exc
+    if parsed.tzinfo is None:
+        raise RuntimeSafetyError(f"production arm {label} must include a timezone")
+    return parsed.astimezone(timezone.utc)
+
+
+def _arm_payload(document: dict[str, Any]) -> bytes:
+    if not isinstance(document, dict) or set(document) - {"signature"} != set(_ARM_SIGNED_FIELDS):
+        raise RuntimeSafetyError("production arm schema is invalid")
+    return json.dumps(
+        {field: document[field] for field in _ARM_SIGNED_FIELDS},
+        sort_keys=True,
+        separators=(",", ":"),
+    ).encode("utf-8")
+
+
+def production_arm_signature(document: dict[str, Any], secret: str) -> str:
+    """Return the signature required in an offline production arm document."""
+
+    return hmac.new(secret.encode("utf-8"), _arm_payload(document), hashlib.sha256).hexdigest()
+
+
+def _require_arm_secret(secret: str | None) -> str:
+    result = _required_text(secret, "ETRADE_PRODUCTION_ARMING_SECRET")
+    if len(result) < 32:
+        raise RuntimeSafetyError("ETRADE_PRODUCTION_ARMING_SECRET is too short")
+    return result
+
+
+def _validate_arm_schema(document: Any) -> dict[str, Any]:
+    if not isinstance(document, dict) or set(document) != _ARM_FIELDS:
+        raise RuntimeSafetyError("production arm schema is invalid")
+    if type(document["version"]) is not int or document["version"] != ARM_SCHEMA_VERSION:
+        raise RuntimeSafetyError("production arm version is invalid")
+    if document["environment"] != "production":
+        raise RuntimeSafetyError("production arm environment is invalid")
+    for field in _ARM_SIGNED_FIELDS:
+        if field in {"version", "environment", "issued_at", "expires_at"}:
+            continue
+        _required_text(document[field], field)
+    if not isinstance(document["signature"], str):
+        raise RuntimeSafetyError("production arm proof is invalid")
+    return document
+
+
+def _trusted_parent_descriptor(path: Path) -> int:
+    parent = path.parent
+    try:
+        before = os.lstat(parent)
+        if (
+            stat.S_ISLNK(before.st_mode)
+            or not stat.S_ISDIR(before.st_mode)
+            or before.st_uid != os.geteuid()
+            or stat.S_IMODE(before.st_mode) & 0o022
+        ):
+            raise RuntimeSafetyError("runtime file parent is unsafe")
+        descriptor = os.open(
+            parent,
+            os.O_RDONLY | getattr(os, "O_DIRECTORY", 0) | getattr(os, "O_NOFOLLOW", 0),
+        )
+    except OSError as exc:
+        raise RuntimeSafetyError("runtime file parent is unsafe") from exc
+    after = os.fstat(descriptor)
+    if after.st_dev != before.st_dev or after.st_ino != before.st_ino:
+        os.close(descriptor)
+        raise RuntimeSafetyError("runtime file parent is unsafe")
+    return descriptor
+
+
+def _write_owner_only_atomic(path: str | Path, payload: bytes) -> None:
+    target = Path(path)
+    parent_descriptor = _trusted_parent_descriptor(target)
+    temporary_name = None
+    descriptor = -1
+    try:
+        for _ in range(16):
+            candidate = f".{target.name}.{secrets.token_hex(16)}.tmp"
+            try:
+                descriptor = os.open(
+                    candidate,
+                    os.O_WRONLY | os.O_CREAT | os.O_EXCL | getattr(os, "O_NOFOLLOW", 0),
+                    0o600,
+                    dir_fd=parent_descriptor,
+                )
+                temporary_name = candidate
+                break
+            except FileExistsError:
+                continue
+        if descriptor < 0 or temporary_name is None:
+            raise RuntimeSafetyError("could not create runtime file")
+        os.fchmod(descriptor, 0o600)
+        payload_offset = 0
+        while payload_offset < len(payload):
+            written = os.write(descriptor, payload[payload_offset:])
+            if written <= 0:
+                raise RuntimeSafetyError("could not write runtime file")
+            payload_offset += written
+        os.fsync(descriptor)
+        os.close(descriptor)
+        descriptor = -1
+        os.replace(temporary_name, target.name, src_dir_fd=parent_descriptor, dst_dir_fd=parent_descriptor)
+        temporary_name = None
+        os.fsync(parent_descriptor)
+    finally:
+        if descriptor >= 0:
+            os.close(descriptor)
+        if temporary_name is not None:
+            try:
+                os.unlink(temporary_name, dir_fd=parent_descriptor)
+            except OSError:
+                pass
+        os.close(parent_descriptor)
+
+
+def write_owner_only_json(path: str | Path, value: Any) -> None:
+    """Atomically replace a sensitive JSON document without following links."""
+
+    _write_owner_only_atomic(path, json.dumps(value, sort_keys=True, separators=(",", ":")).encode("utf-8"))
+
+
+def read_owner_only_json(path: str | Path, *, label: str = "runtime file") -> Any:
+    """Read JSON only from an owner-only regular file under a trusted parent."""
+
+    target = Path(path)
+    parent_descriptor = _trusted_parent_descriptor(target)
+    descriptor = -1
+    try:
+        descriptor = os.open(
+            target.name,
+            os.O_RDONLY | getattr(os, "O_CLOEXEC", 0) | getattr(os, "O_NOFOLLOW", 0),
+            dir_fd=parent_descriptor,
+        )
+        metadata = os.fstat(descriptor)
+        if (
+            not stat.S_ISREG(metadata.st_mode)
+            or metadata.st_uid != os.geteuid()
+            or stat.S_IMODE(metadata.st_mode) & 0o077
+            or metadata.st_size > 64 * 1024
+        ):
+            raise RuntimeSafetyError(f"{label} must be an owner-only regular file")
+        with os.fdopen(descriptor, "r", encoding="utf-8") as handle:
+            descriptor = -1
+            return json.load(handle)
+    except (OSError, UnicodeDecodeError, json.JSONDecodeError) as exc:
+        raise RuntimeSafetyError(f"{label} is invalid") from exc
+    finally:
+        if descriptor >= 0:
+            os.close(descriptor)
+        os.close(parent_descriptor)
+
+
+def secure_lock_file(path: str | Path):
+    """Open and non-blockingly lock an owner-only runtime lock file."""
+
+    target = Path(path)
+    parent_descriptor = _trusted_parent_descriptor(target)
+    descriptor = -1
+    try:
+        descriptor = os.open(
+            target.name,
+            os.O_RDWR | os.O_CREAT | getattr(os, "O_CLOEXEC", 0) | getattr(os, "O_NOFOLLOW", 0),
+            0o600,
+            dir_fd=parent_descriptor,
+        )
+        metadata = os.fstat(descriptor)
+        if (
+            not stat.S_ISREG(metadata.st_mode)
+            or metadata.st_uid != os.geteuid()
+            or stat.S_IMODE(metadata.st_mode) & 0o077
+        ):
+            raise RuntimeSafetyError("runtime lock file is unsafe")
+        try:
+            fcntl.lockf(descriptor, fcntl.LOCK_EX | fcntl.LOCK_NB)
+        except OSError as exc:
+            raise RuntimeSafetyError("another trading instance is already running") from exc
+        handle = os.fdopen(descriptor, "r+")
+        descriptor = -1
+        return handle
+    except OSError as exc:
+        raise RuntimeSafetyError("runtime lock file is unsafe") from exc
+    finally:
+        if descriptor >= 0:
+            os.close(descriptor)
+        os.close(parent_descriptor)
+
+
+def _open_owner_only_log(path: str | Path) -> int:
+    """Open a regular owner-only log through a verified parent descriptor."""
+
+    target = Path(path)
+    parent_descriptor = _trusted_parent_descriptor(target)
+    try:
+        descriptor = os.open(
+            target.name,
+            os.O_WRONLY | os.O_APPEND | os.O_CREAT | getattr(os, "O_CLOEXEC", 0) | getattr(os, "O_NOFOLLOW", 0),
+            0o600,
+            dir_fd=parent_descriptor,
+        )
+    except OSError as exc:
+        raise RuntimeSafetyError("log file is unsafe") from exc
+    finally:
+        os.close(parent_descriptor)
+    metadata = os.fstat(descriptor)
+    if (
+        not stat.S_ISREG(metadata.st_mode)
+        or metadata.st_uid != os.geteuid()
+        or stat.S_IMODE(metadata.st_mode) & 0o077
+    ):
+        os.close(descriptor)
+        raise RuntimeSafetyError("log file is unsafe")
+    return descriptor
+
+
+def issue_production_arm(
+    *,
+    output: str | Path,
+    expected_account_id: str,
+    expected_account_id_key: str,
+    expected_institution_type: str,
+    ttl_seconds: int,
+    secret: str | None,
+    now: datetime | None = None,
+) -> dict[str, Any]:
+    """Create a bounded, signed, owner-only production arm document."""
+
+    signing_secret = _require_arm_secret(secret)
+    if type(ttl_seconds) is not int or not 0 < ttl_seconds <= int(MAX_PRODUCTION_ARM_LIFETIME.total_seconds()):
+        raise RuntimeSafetyError("production arm lifetime is invalid")
+    issued_at = (now or datetime.now(timezone.utc)).astimezone(timezone.utc)
+    document = {
+        "version": ARM_SCHEMA_VERSION,
+        "environment": "production",
+        "expected_account_id": _required_text(expected_account_id, "expected account id"),
+        "expected_account_id_key": _required_text(expected_account_id_key, "expected account key"),
+        "expected_institution_type": _required_text(expected_institution_type, "expected institution type"),
+        "issued_at": issued_at.isoformat(),
+        "expires_at": (issued_at + timedelta(seconds=ttl_seconds)).isoformat(),
+    }
+    document["signature"] = production_arm_signature(document, signing_secret)
+    _write_owner_only_atomic(output, json.dumps(document, sort_keys=True, separators=(",", ":")).encode("utf-8"))
+    return document
+
+
+def secure_append_text(path: str | Path, text: str) -> None:
+    """Append a log record without following links or accepting unsafe files."""
+
+    descriptor = _open_owner_only_log(path)
+    try:
+        payload = text.encode("utf-8")
+        payload_offset = 0
+        while payload_offset < len(payload):
+            written = os.write(descriptor, payload[payload_offset:])
+            if written <= 0:
+                raise RuntimeSafetyError("could not append dashboard log")
+            payload_offset += written
+    finally:
+        os.close(descriptor)
+
+
+class OwnerOnlyRotatingFileHandler(RotatingFileHandler):
+    """A rotating handler that only opens owner-only regular log files."""
+
+    def _open(self):
+        descriptor = _open_owner_only_log(self.baseFilename)
+        return os.fdopen(descriptor, self.mode, encoding=self.encoding, errors=self.errors)
+
+
+def configure_owner_only_logger(name: str, filename: str = "python_client.log") -> logging.Logger:
+    """Attach one owner-only rotating file handler to a shared client logger."""
+
+    logger = logging.getLogger(name)
+    logger.setLevel(logging.DEBUG)
+    logger.propagate = False
+    expected_filename = os.path.abspath(filename)
+    for existing in logger.handlers:
+        if isinstance(existing, OwnerOnlyRotatingFileHandler) and existing.baseFilename == expected_filename:
+            return logger
+    handler = OwnerOnlyRotatingFileHandler(filename, maxBytes=5 * 1024 * 1024, backupCount=3)
+    handler.setFormatter(logging.Formatter("%(asctime)-15s %(message)s", datefmt="%m/%d/%Y %I:%M:%S %p"))
+    handler.addFilter(_SafeClientLogFilter())
+    logger.addHandler(handler)
+    return logger
+
+
+class _SafeClientLogFilter(logging.Filter):
+    """Defence in depth for older client call sites that log request objects."""
+
+    def filter(self, record: logging.LogRecord) -> bool:
+        raw_message = str(record.msg)
+        message = raw_message.lower()
+        if "request header" in message or "response headers" in message:
+            if record.args:
+                values = record.args if isinstance(record.args, tuple) else (record.args,)
+                record.args = tuple(redact_http_headers(value) for value in values)
+        elif (
+            "request payload" in message
+            or "response" in message
+            or "request url" in message
+            or "order placed" in message
+        ) and record.args:
+            values = record.args if isinstance(record.args, tuple) else (record.args,)
+            record.args = tuple(content_fingerprint(value) for value in values)
+        elif raw_message.lstrip().startswith(("{", "[", "<")):
+            record.msg = "Structured client detail withheld: %s"
+            record.args = (content_fingerprint(raw_message),)
+        return True
+
+
+def redact_http_headers(headers: Any) -> dict[str, str]:
+    """Return only header names; no HTTP header values are retained in logs."""
+
+    try:
+        items = headers.items()
+    except AttributeError:
+        return {}
+    return {str(name): "[REDACTED]" for name, _value in items}
+
+
+def payload_fingerprint(payload: str | bytes) -> dict[str, int | str]:
+    """Provide audit-safe payload metadata without retaining order XML."""
+
+    encoded = payload.encode("utf-8") if isinstance(payload, str) else payload
+    return {"bytes": len(encoded), "sha256": hashlib.sha256(encoded).hexdigest()}
+
+
+def content_fingerprint(value: Any) -> dict[str, int | str]:
+    """Fingerprint arbitrary client detail without retaining account or order data."""
+
+    if isinstance(value, bytes):
+        encoded = value
+    elif isinstance(value, str):
+        encoded = value.encode("utf-8")
+    else:
+        try:
+            encoded = json.dumps(
+                value,
+                sort_keys=True,
+                separators=(",", ":"),
+                default=str,
+            ).encode("utf-8")
+        except (TypeError, ValueError):
+            encoded = type(value).__name__.encode("utf-8")
+    return {"bytes": len(encoded), "sha256": hashlib.sha256(encoded).hexdigest()}
+
+
+def resolve_etrade_consumer_key(
+    use_sandbox: bool,
+    *,
+    consumer_key: str | None = None,
+    config_value: str | None = None,
+    required: bool = True,
+) -> str | None:
+    """Resolve one consumer key from an explicit value, env, then local config."""
+
+    if consumer_key is not None:
+        return consumer_key
+    environment_name = "ETRADE_SANDBOX_CONSUMER_KEY" if use_sandbox else "ETRADE_LIVE_CONSUMER_KEY"
+    value = os.getenv(environment_name) or config_value
+    if isinstance(value, str) and value.strip():
+        return value.strip()
+    if required:
+        environment = "sandbox" if use_sandbox else "production"
+        raise RuntimeSafetyError(f"Missing E*TRADE {environment} consumer key; set {environment_name} or local config.ini")
+    return None
+
+
+@dataclass(frozen=True)
+class RuntimeSafetyBoundary:
+    environment: str
+    expected_account_id: str | None
+    expected_account_id_key: str | None
+    expected_institution_type: str | None
+    arm_issued_at: datetime | None = None
+    arm_expires_at: datetime | None = None
+
+    @property
+    def use_sandbox(self) -> bool:
+        return self.environment == "sandbox"
+
+    @property
+    def account_selection_kwargs(self) -> dict[str, str | int | None]:
+        if self.use_sandbox and self.expected_account_id_key is None:
+            return {"selected_account_id": 1}
+        return {
+            "selected_account_id": None,
+            "expected_account_id_key": self.expected_account_id_key,
+            "expected_account_id": self.expected_account_id,
+            "expected_institution_type": self.expected_institution_type,
+        }
+
+    def assert_current(self, now: datetime | None = None) -> None:
+        if self.environment != "production":
+            return
+        current_time = (now or datetime.now(timezone.utc)).astimezone(timezone.utc)
+        if self.arm_issued_at is None or self.arm_expires_at is None:
+            raise RuntimeSafetyError("production arm proof is unavailable")
+        if current_time < self.arm_issued_at - MAX_PRODUCTION_ARM_FUTURE_SKEW:
+            raise RuntimeSafetyError("production arm proof is not yet valid")
+        if current_time >= self.arm_expires_at:
+            raise RuntimeSafetyError("production arm proof is expired")
+
+    def verify_account(self, account: Any, *, now: datetime | None = None) -> None:
+        self.assert_current(now)
+        if self.use_sandbox and self.expected_account_id_key is None:
+            return
+        if not isinstance(account, dict):
+            raise RuntimeSafetyError("broker did not return a selected account")
+        checks = {
+            "accountIdKey": self.expected_account_id_key,
+            "accountId": self.expected_account_id,
+            "institutionType": self.expected_institution_type,
+        }
+        for field, expected in checks.items():
+            if account.get(field) != expected:
+                raise RuntimeSafetyError(f"broker account {field} does not match the armed identity")
+
+
+def _read_production_arm(
+    path: str | Path,
+    secret: str,
+    now: datetime,
+) -> tuple[dict[str, Any], datetime, datetime]:
+    arm_path = Path(path)
+    try:
+        descriptor = os.open(
+            arm_path,
+            os.O_RDONLY | getattr(os, "O_CLOEXEC", 0) | getattr(os, "O_NOFOLLOW", 0),
+        )
+    except OSError as exc:
+        raise RuntimeSafetyError("production arm document is unavailable") from exc
+    try:
+        metadata = os.fstat(descriptor)
+        if (
+            not stat.S_ISREG(metadata.st_mode)
+            or metadata.st_uid != os.geteuid()
+            or stat.S_IMODE(metadata.st_mode) & 0o077
+            or metadata.st_size > 64 * 1024
+        ):
+            raise RuntimeSafetyError("production arm document must be an owner-only regular file")
+        with os.fdopen(descriptor, "r", encoding="utf-8") as handle:
+            descriptor = -1
+            document = json.load(handle)
+    except (OSError, json.JSONDecodeError) as exc:
+        raise RuntimeSafetyError("production arm document is invalid") from exc
+    finally:
+        if descriptor >= 0:
+            os.close(descriptor)
+    document = _validate_arm_schema(document)
+    signature = document["signature"]
+    expected_signature = production_arm_signature(document, secret)
+    if not hmac.compare_digest(signature, expected_signature):
+        raise RuntimeSafetyError("production arm proof is invalid")
+    issued_at = _parse_timestamp(document["issued_at"], "issued_at")
+    expiry = _parse_timestamp(document["expires_at"], "expires_at")
+    if issued_at > now + MAX_PRODUCTION_ARM_FUTURE_SKEW:
+        raise RuntimeSafetyError("production arm issued_at is too far in the future")
+    if expiry <= issued_at:
+        raise RuntimeSafetyError("production arm lifetime is invalid")
+    if expiry - issued_at > MAX_PRODUCTION_ARM_LIFETIME:
+        raise RuntimeSafetyError("production arm lifetime is invalid")
+    if expiry <= now:
+        raise RuntimeSafetyError("production arm proof is expired")
+    return document, issued_at, expiry
+
+
+def build_runtime_safety_boundary(
+    *,
+    environment: str | None,
+    legacy_sandbox: bool | None,
+    expected_account_id: str | None,
+    expected_account_id_key: str | None,
+    expected_institution_type: str | None,
+    production_arm_file: str | Path | None = None,
+    production_arm_secret: str | None = None,
+    now: datetime | None = None,
+) -> RuntimeSafetyBoundary:
+    """Resolve one explicit mode and verify production's independent arm proof.
+
+    The legacy ``--sandbox`` flag remains an explicit sandbox-only compatibility
+    path. Missing or conflicting mode input never falls through to production.
+    """
+
+    if environment not in {None, "sandbox", "production"}:
+        raise RuntimeSafetyError("environment must be sandbox or production")
+    if environment is None:
+        if legacy_sandbox is True:
+            resolved = "sandbox"
+        elif legacy_sandbox is False:
+            resolved = "production"
+        else:
+            raise RuntimeSafetyError("an explicit --environment or --sandbox/--no-sandbox is required")
+    else:
+        resolved = environment
+        if legacy_sandbox is not None and legacy_sandbox != (resolved == "sandbox"):
+            raise RuntimeSafetyError("--environment conflicts with --sandbox/--no-sandbox")
+
+    supplied_identity = (expected_account_id, expected_account_id_key, expected_institution_type)
+    if resolved == "sandbox" and not any(supplied_identity):
+        return RuntimeSafetyBoundary("sandbox", None, None, None)
+    account_id = _required_text(expected_account_id, "expected account id")
+    account_key = _required_text(expected_account_id_key, "expected account key")
+    institution_type = _required_text(expected_institution_type, "expected institution type")
+
+    if resolved == "sandbox":
+        return RuntimeSafetyBoundary("sandbox", account_id, account_key, institution_type)
+
+    secret = _require_arm_secret(production_arm_secret)
+    if production_arm_file is None:
+        raise RuntimeSafetyError("--production-arm-file is required for production")
+    current_time = (now or datetime.now(timezone.utc)).astimezone(timezone.utc)
+    document, issued_at, expiry = _read_production_arm(production_arm_file, secret, current_time)
+    required = {
+        "environment": "production",
+        "expected_account_id": account_id,
+        "expected_account_id_key": account_key,
+        "expected_institution_type": institution_type,
+    }
+    if any(document.get(field) != value for field, value in required.items()):
+        raise RuntimeSafetyError("production arm identity does not match runtime identity")
+    return RuntimeSafetyBoundary(
+        "production",
+        account_id,
+        account_key,
+        institution_type,
+        issued_at,
+        expiry,
+    )
+
+
+def validate_dashboard_credentials(settings: dict[str, Any]) -> None:
+    """Reject credentials that make an order-capable dashboard unsafe to start."""
+
+    if not isinstance(settings, dict):
+        raise RuntimeSafetyError("live settings are invalid")
+    username = _required_text(settings.get("dashboard_user"), "dashboard username")
+    password = _required_text(settings.get("dashboard_pass"), "dashboard password")
+    pin = _required_text(settings.get("pin"), "dashboard action PIN")
+    if username.lower() in {"admin", "user", "etrade"}:
+        raise RuntimeSafetyError("dashboard username is a reserved default")
+    if len(password) < 16 or password.lower() in {"password", "changeme", "default"}:
+        raise RuntimeSafetyError("dashboard password is weak")
+    if len(pin) < 8 or not pin.isdigit() or pin in {"00000000", "12345678", "1234"}:
+        raise RuntimeSafetyError("dashboard action PIN is weak")
+
+
+def main(argv: list[str] | None = None) -> int:
+    """Issue a short-lived production arm without accepting a CLI secret."""
+
+    parser = argparse.ArgumentParser(description="Runtime safety operator commands")
+    commands = parser.add_subparsers(dest="command", required=True)
+    issue = commands.add_parser("issue-production-arm")
+    issue.add_argument("--output", required=True, type=Path)
+    issue.add_argument("--expected-account-id", required=True)
+    issue.add_argument("--expected-account-id-key", required=True)
+    issue.add_argument("--expected-institution-type", required=True)
+    issue.add_argument("--ttl-seconds", type=int, default=300)
+    args = parser.parse_args(argv)
+    try:
+        if args.command == "issue-production-arm":
+            issue_production_arm(
+                output=args.output,
+                expected_account_id=args.expected_account_id,
+                expected_account_id_key=args.expected_account_id_key,
+                expected_institution_type=args.expected_institution_type,
+                ttl_seconds=args.ttl_seconds,
+                secret=os.getenv("ETRADE_PRODUCTION_ARMING_SECRET"),
+            )
+            return 0
+    except RuntimeSafetyError as exc:
+        parser.error(str(exc))
+    raise AssertionError("unreachable")
+
+
+__all__ = [
+    "RuntimeSafetyBoundary",
+    "RuntimeSafetyError",
+    "ARM_SCHEMA_VERSION",
+    "MAX_PRODUCTION_ARM_LIFETIME",
+    "OwnerOnlyRotatingFileHandler",
+    "build_runtime_safety_boundary",
+    "configure_owner_only_logger",
+    "content_fingerprint",
+    "issue_production_arm",
+    "main",
+    "production_arm_signature",
+    "payload_fingerprint",
+    "redact_http_headers",
+    "read_owner_only_json",
+    "resolve_etrade_consumer_key",
+    "secure_lock_file",
+    "secure_append_text",
+    "validate_dashboard_credentials",
+    "write_owner_only_json",
+]
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/etrade_python_client/market/market.py
+++ b/etrade_python_client/market/market.py
@@ -1,15 +1,9 @@
 import json
 import logging
-from logging.handlers import RotatingFileHandler
+from live_trading.runtime_safety import configure_owner_only_logger, redact_http_headers
 
 # logger settings
-logger = logging.getLogger('my_logger')
-logger.setLevel(logging.DEBUG)
-handler = RotatingFileHandler("python_client.log", maxBytes=5 * 1024 * 1024, backupCount=3)
-FORMAT = "%(asctime)-15s %(message)s"
-fmt = logging.Formatter(FORMAT, datefmt='%m/%d/%Y %I:%M:%S %p')
-handler.setFormatter(fmt)
-logger.addHandler(handler)
+logger = configure_owner_only_logger('my_logger')
 
 
 class Market:
@@ -30,7 +24,7 @@ class Market:
 
         # Make API call for GET request
         response = self.session.get(url)
-        logger.debug("Request Header: %s", response.request.headers)
+        logger.debug("Request Header: %s", redact_http_headers(response.request.headers))
 
         if response is not None and response.status_code == 200:
 

--- a/etrade_python_client/market/market_bo.py
+++ b/etrade_python_client/market/market_bo.py
@@ -1,32 +1,28 @@
 import json
 import logging
-from logging.handlers import RotatingFileHandler
 import xmltodict
 import xml.etree.ElementTree as ET
 import configparser
+from live_trading.runtime_safety import configure_owner_only_logger, redact_http_headers, resolve_etrade_consumer_key
 
 # logger settings
-logger = logging.getLogger('my_logger')
-logger.setLevel(logging.DEBUG)
-handler = RotatingFileHandler("python_client.log", maxBytes=5 * 1024 * 1024, backupCount=3)
-FORMAT = "%(asctime)-15s %(message)s"
-fmt = logging.Formatter(FORMAT, datefmt='%m/%d/%Y %I:%M:%S %p')
-handler.setFormatter(fmt)
-logger.addHandler(handler)
+logger = configure_owner_only_logger('my_logger')
 
 # loading configuration file
 config = configparser.ConfigParser()
 config.read('config.ini')
 
 class Market:
-    def __init__(self, session, base_url,use_sandbox=False):
+    def __init__(self, session, base_url,use_sandbox=False, consumer_key=None):
         self.session = session
         self.base_url = base_url
         self.use_sandbox = use_sandbox
-        if self.use_sandbox:
-            self.consumer_key = config["DEFAULT"]["SANDBOX_CONSUMER_KEY"]
-        else: 
-            self.consumer_key = config["DEFAULT"]["PROD_CONSUMER_KEY"]
+        config_key = "SANDBOX_CONSUMER_KEY" if self.use_sandbox else "PROD_CONSUMER_KEY"
+        self.consumer_key = resolve_etrade_consumer_key(
+            self.use_sandbox,
+            consumer_key=consumer_key,
+            config_value=config["DEFAULT"].get(config_key),
+        )
 
     def lookup(self, symbol):
         """
@@ -44,7 +40,7 @@ class Market:
         # Parameters for the API call
         # params = {"search": symbol}
         response = self.session.get(url, auth=self.session.auth)
-        logger.debug("Request Header: %s", response.request.headers)
+        logger.debug("Request Header: %s", redact_http_headers(response.request.headers))
 
         # Make the API call
         # response = self.session.get(url, params=params)
@@ -103,7 +99,7 @@ class Market:
         # Make API call for GET request
         response = self.session.get(url)
 
-        logger.debug("Request Header: %s", response.request.headers)
+        logger.debug("Request Header: %s", redact_http_headers(response.request.headers))
 
         if response is not None and response.status_code == 200:
 
@@ -230,10 +226,10 @@ class Market:
             api_url += ".json"
         if len(args):
             api_url += "?" + "&".join(args)
-        logger.debug(api_url)
+        logger.debug("Market request issued")
 
         req = self.session.get(api_url)
         req.raise_for_status()
-        logger.debug(req.text)
+        logger.debug("Response Body: %s", req.text)
 
         return xmltodict.parse(req.text) if resp_format.lower() == "xml" else req.json()

--- a/etrade_python_client/order/order.py
+++ b/etrade_python_client/order/order.py
@@ -1,30 +1,30 @@
 import json
 import logging
-from logging.handlers import RotatingFileHandler
 import configparser
 import random
 import re
+from live_trading.runtime_safety import (
+    RuntimeSafetyError,
+    configure_owner_only_logger,
+    payload_fingerprint,
+    redact_http_headers,
+)
 
 # loading configuration file
 config = configparser.ConfigParser()
 config.read('config.ini')
 
 # logger settings
-logger = logging.getLogger('my_logger')
-logger.setLevel(logging.DEBUG)
-handler = RotatingFileHandler("python_client.log", maxBytes=5 * 1024 * 1024, backupCount=3)
-FORMAT = "%(asctime)-15s %(message)s"
-fmt = logging.Formatter(FORMAT, datefmt='%m/%d/%Y %I:%M:%S %p')
-handler.setFormatter(fmt)
-logger.addHandler(handler)
+logger = configure_owner_only_logger('my_logger')
 
 
 class Order:
 
     def __init__(self, session, account, base_url):
-        self.session = session
-        self.account = account
-        self.base_url = base_url
+        raise RuntimeSafetyError(
+            "legacy interactive Order client is quarantined; use order.order_bo.Order "
+            "with a RuntimeSafetyBoundary"
+        )
 
     def preview_order(self):
         """
@@ -70,8 +70,8 @@ class Order:
 
         # Make API call for POST request
         response = self.session.post(url, header_auth=True, headers=headers, data=payload)
-        logger.debug("Request Header: %s", response.request.headers)
-        logger.debug("Request payload: %s", payload)
+        logger.debug("Request Header: %s", redact_http_headers(response.request.headers))
+        logger.debug("Request payload: %s", payload_fingerprint(payload))
 
         # Handle and parse response
         if response is not None and response.status_code == 200:
@@ -205,8 +205,8 @@ class Order:
 
                     # Make API call for POST request
                     response = session.post(url, header_auth=True, headers=headers, data=payload)
-                    logger.debug("Request Header: %s", response.request.headers)
-                    logger.debug("Request payload: %s", payload)
+                    logger.debug("Request Header: %s", redact_http_headers(response.request.headers))
+                    logger.debug("Request payload: %s", payload_fingerprint(payload))
 
                     # Handle and parse response
                     if response is not None and response.status_code == 200:
@@ -472,7 +472,7 @@ class Order:
             # Make API call for GET request
             response_open = self.session.get(url, header_auth=True, params=params_open, headers=headers)
 
-            logger.debug("Request Header: %s", response_open.request.headers)
+            logger.debug("Request Header: %s", redact_http_headers(response_open.request.headers))
             logger.debug("Response Body: %s", response_open.text)
 
             print("\nOpen Orders: ")
@@ -586,8 +586,8 @@ class Order:
 
                         # Add payload for PUT Request
                         response = self.session.put(url, header_auth=True, headers=headers, data=payload)
-                        logger.debug("Request Header: %s", response.request.headers)
-                        logger.debug("Request payload: %s", payload)
+                        logger.debug("Request Header: %s", redact_http_headers(response.request.headers))
+                        logger.debug("Request payload: %s", payload_fingerprint(payload))
 
                         # Handle and parse response
                         if response is not None and response.status_code == 200:
@@ -600,7 +600,7 @@ class Order:
                                     data["CancelOrderResponse"]["orderId"]) + " successfully Cancelled.")
                             else:
                                 # Handle errors
-                                logger.debug("Response Headers: %s", response.headers)
+                                logger.debug("Response Headers: %s", redact_http_headers(response.headers))
                                 logger.debug("Response Body: %s", response.text)
                                 data = response.json()
                                 if 'Error' in data and 'message' in data["Error"] \
@@ -610,7 +610,7 @@ class Order:
                                     print("Error: Cancel Order API service error")
                         else:
                             # Handle errors
-                            logger.debug("Response Headers: %s", response.headers)
+                            logger.debug("Response Headers: %s", redact_http_headers(response.headers))
                             logger.debug("Response Body: %s", response.text)
                             data = response.json()
                             if 'Error' in data and 'message' in data["Error"] and data["Error"]["message"] is not None:
@@ -674,7 +674,7 @@ class Order:
             prev_orders = []
 
             # Open orders
-            logger.debug("Request Header: %s", response_open.request.headers)
+            logger.debug("Request Header: %s", redact_http_headers(response_open.request.headers))
             logger.debug("Response Body: %s", response_open.text)
 
             print("\nOpen Orders:")
@@ -691,9 +691,9 @@ class Order:
                 prev_orders.extend(self.print_orders(data, "open"))
 
             # Executed orders
-            logger.debug("Request Header: %s", response_executed.request.headers)
+            logger.debug("Request Header: %s", redact_http_headers(response_executed.request.headers))
             logger.debug("Response Body: %s", response_executed.text)
-            logger.debug(response_executed.text)
+            logger.debug("Response Body: %s", response_executed.text)
 
             print("\nExecuted Orders:")
             # Handle and parse response
@@ -709,7 +709,7 @@ class Order:
                 prev_orders.extend(self.print_orders(data, "executed"))
 
             # Individual fills orders
-            logger.debug("Request Header: %s", response_indiv_fills.request.headers)
+            logger.debug("Request Header: %s", redact_http_headers(response_indiv_fills.request.headers))
             logger.debug("Response Body: %s", response_indiv_fills.text)
 
             print("\nIndividual Fills Orders:")
@@ -726,7 +726,7 @@ class Order:
                 prev_orders.extend(self.print_orders(data, "indiv_fills"))
 
             # Cancelled orders
-            logger.debug("Request Header: %s", response_cancelled.request.headers)
+            logger.debug("Request Header: %s", redact_http_headers(response_cancelled.request.headers))
             logger.debug("Response Body: %s", response_cancelled.text)
 
             print("\nCancelled Orders:")
@@ -743,7 +743,7 @@ class Order:
                 prev_orders.extend(self.print_orders(data, "cancelled"))
 
             # Rejected orders
-            logger.debug("Request Header: %s", response_rejected.request.headers)
+            logger.debug("Request Header: %s", redact_http_headers(response_rejected.request.headers))
             logger.debug("Response Body: %s", response_rejected.text)
 
             print("\nRejected Orders:")

--- a/etrade_python_client/order/order_bo.py
+++ b/etrade_python_client/order/order_bo.py
@@ -1,7 +1,6 @@
 from __future__ import annotations
 import json
 import logging
-from logging.handlers import RotatingFileHandler
 import configparser
 import random
 import re
@@ -16,19 +15,21 @@ import logging
 import requests
 from xml.etree import ElementTree as ET
 from decimal import Decimal, ROUND_CEILING, ROUND_FLOOR, ROUND_HALF_UP
+from live_trading.runtime_safety import (
+    RuntimeSafetyBoundary,
+    RuntimeSafetyError,
+    configure_owner_only_logger,
+    payload_fingerprint,
+    redact_http_headers,
+    resolve_etrade_consumer_key,
+)
 
 # loading configuration file
 config = configparser.ConfigParser()
 config.read('config.ini')
 
 # logger settings
-logger = logging.getLogger('my_logger')
-logger.setLevel(logging.DEBUG)
-handler = RotatingFileHandler("python_client.log", maxBytes=5 * 1024 * 1024, backupCount=3)
-FORMAT = "%(asctime)-15s %(message)s"
-fmt = logging.Formatter(FORMAT, datefmt='%m/%d/%Y %I:%M:%S %p')
-handler.setFormatter(fmt)
-logger.addHandler(handler)
+logger = configure_owner_only_logger('my_logger')
 
 
 class Order:
@@ -62,15 +63,41 @@ class Order:
 
         return float(max(tick_dec, snapped))
 
-    def __init__(self, session, account, base_url, use_sandbox):
+    def __init__(
+        self,
+        session,
+        account,
+        base_url,
+        use_sandbox,
+        consumer_key=None,
+        runtime_safety: RuntimeSafetyBoundary | None = None,
+    ):
         self.session = session
         self.account = account
         self.base_url = base_url
         self.use_sandbox = use_sandbox
-        if self.use_sandbox:
-            self.consumer_key = config["DEFAULT"]["SANDBOX_CONSUMER_KEY"]
-        else: 
-            self.consumer_key = config["DEFAULT"]["PROD_CONSUMER_KEY"]
+        self.runtime_safety = runtime_safety
+        if runtime_safety is not None:
+            if runtime_safety.use_sandbox != use_sandbox:
+                raise RuntimeSafetyError("order client environment conflicts with runtime safety boundary")
+            runtime_safety.verify_account(account)
+        config_key = "SANDBOX_CONSUMER_KEY" if self.use_sandbox else "PROD_CONSUMER_KEY"
+        self.consumer_key = resolve_etrade_consumer_key(
+            self.use_sandbox,
+            consumer_key=consumer_key,
+            config_value=config["DEFAULT"].get(config_key),
+        )
+
+    def _assert_order_api_access(self) -> None:
+        """Revalidate the arm and exact account at every order API boundary."""
+
+        if self.runtime_safety is None:
+            raise RuntimeSafetyError(
+                "order API access requires an authenticated RuntimeSafetyBoundary"
+            )
+        if self.runtime_safety.use_sandbox != self.use_sandbox:
+            raise RuntimeSafetyError("order client environment conflicts with runtime safety boundary")
+        self.runtime_safety.verify_account(self.account)
 
     def _refresh_auth_session_if_possible(self, reason):
         callback = getattr(self, "auth_refresh_callback", None)
@@ -205,9 +232,10 @@ class Order:
             </PreviewOrderRequest>
             """
         # Make the API call for POST request
+        self._assert_order_api_access()
         response = self.session.post(url, headers=headers, data=payload)
-        logger.debug("Request Header: %s", response.request.headers)
-        logger.debug("Request payload: %s", payload)
+        logger.debug("Request Header: %s", redact_http_headers(response.request.headers))
+        logger.debug("Request payload: %s", payload_fingerprint(payload))
 
         # Print the status code and response text for debugging
         if response.status_code != 200:
@@ -221,7 +249,7 @@ class Order:
             else:
                 print(order)
                 print(response.text)
-                print(payload)
+                print("Order request payload withheld; metadata:", payload_fingerprint(payload))
 
         # Handle and parse response
         if response and response.status_code == 200:
@@ -295,10 +323,11 @@ class Order:
                                  order["limitPrice"], order["symbol"], order["orderAction"], order["quantity"])
 
         # Make API call for POST request
-        print(payload)
+        print("Order request payload withheld; metadata:", payload_fingerprint(payload))
+        self._assert_order_api_access()
         response = self.session.post(url, header_auth=True, headers=headers, data=payload)
-        logger.debug("Request Header: %s", response.request.headers)
-        logger.debug("Request payload: %s", payload)
+        logger.debug("Request Header: %s", redact_http_headers(response.request.headers))
+        logger.debug("Request payload: %s", payload_fingerprint(payload))
         print(response)
 
         # Handle and parse response
@@ -514,9 +543,10 @@ class Order:
             """
 
         # Make API call for POST request
+        self._assert_order_api_access()
         response = self.session.post(url, headers=headers, data=payload)
-        logger.debug("Request Header: %s", response.request.headers)
-        logger.debug("Request payload: %s", payload)
+        logger.debug("Request Header: %s", redact_http_headers(response.request.headers))
+        logger.debug("Request payload: %s", payload_fingerprint(payload))
 
         if response.status_code != 200:
             print("Preview order Status Code:", response.status_code)
@@ -529,7 +559,7 @@ class Order:
             else:
                 print(order)
                 print(response.text)
-                print(payload)
+                print("Order request payload withheld; metadata:", payload_fingerprint(payload))
 
         # Handle and parse response
         if response and response.status_code == 200:
@@ -600,9 +630,10 @@ class Order:
                                  order["orderTerm"], order["limitPrice"], order["symbol"], order["orderAction"], order["quantity"])
 
         # Make API call for POST request
+        self._assert_order_api_access()
         response = self.session.post(url, header_auth=True, headers=headers, data=payload)
-        logger.debug("Request Header: %s", response.request.headers)
-        logger.debug("Request payload: %s", payload)
+        logger.debug("Request Header: %s", redact_http_headers(response.request.headers))
+        logger.debug("Request payload: %s", payload_fingerprint(payload))
 
         # Handle and parse response
         if response is not None and response.status_code == 200:
@@ -742,6 +773,7 @@ class Order:
 
         preview_url = f"{self.base_url}/v1/accounts/{self.account['accountIdKey']}/orders/preview"
         preview_headers = {"Content-Type": "application/xml", "Accept": "application/json", "consumerKey": self.consumer_key}
+        self._assert_order_api_access()
         pr = self.session.post(preview_url, headers=preview_headers, data=preview_payload)
         if pr.status_code != 200:
             print(f"Failed to preview change for order {order_id}: {pr.text}")
@@ -790,6 +822,7 @@ class Order:
 
         place_url = f"{self.base_url}/v1/accounts/{self.account['accountIdKey']}/orders/{order_id}/change/place"
         place_headers = {"Content-Type": "application/xml", "Accept": "application/json", "consumerKey": self.consumer_key}
+        self._assert_order_api_access()
         pl = self.session.put(place_url, headers=place_headers, data=place_payload)
         if pl.status_code == 200:
             new_id = None
@@ -929,9 +962,16 @@ class Order:
                 options_select = input("Please select an option: ")
 
                 if options_select.isdigit() and 0 < int(options_select) < len(prev_orders) + 1:
+                    if (
+                        not isinstance(account, dict)
+                        or account.get("accountIdKey") != self.account.get("accountIdKey")
+                    ):
+                        raise RuntimeSafetyError(
+                            "preview account conflicts with the runtime-bound order account"
+                        )
 
                     # URL for the API endpoint
-                    url = self.base_url + "/v1/accounts/" + account["accountIdKey"] + "/orders/preview.json"
+                    url = self.base_url + "/v1/accounts/" + self.account["accountIdKey"] + "/orders/preview.json"
 
                     # Add parameters and header information
                     headers = {"Content-Type": "application/xml", "consumerKey": self.consumer_key}
@@ -972,9 +1012,10 @@ class Order:
                                              prev_orders[options_select - 1]["quantity"])
 
                     # Make API call for POST request
-                    response = session.post(url, header_auth=True, headers=headers, data=payload)
-                    logger.debug("Request Header: %s", response.request.headers)
-                    logger.debug("Request payload: %s", payload)
+                    self._assert_order_api_access()
+                    response = self.session.post(url, header_auth=True, headers=headers, data=payload)
+                    logger.debug("Request Header: %s", redact_http_headers(response.request.headers))
+                    logger.debug("Request payload: %s", payload_fingerprint(payload))
 
                     # Handle and parse response
                     if response is not None and response.status_code == 200:
@@ -1333,7 +1374,7 @@ class Order:
             # Make API call for GET request
             response_open = self.session.get(url, header_auth=True, params=params_open, headers=headers)
 
-            logger.debug("Request Header: %s", response_open.request.headers)
+            logger.debug("Request Header: %s", redact_http_headers(response_open.request.headers))
             logger.debug("Response Body: %s", response_open.text)
 
             print("\nOpen Orders: ")
@@ -1447,9 +1488,10 @@ class Order:
                         payload = payload.format(order_list[int(selection) - 1])
 
                         # Add payload for PUT Request
+                        self._assert_order_api_access()
                         response = self.session.put(url, header_auth=True, headers=headers, data=payload)
-                        logger.debug("Request Header: %s", response.request.headers)
-                        logger.debug("Request payload: %s", payload)
+                        logger.debug("Request Header: %s", redact_http_headers(response.request.headers))
+                        logger.debug("Request payload: %s", payload_fingerprint(payload))
 
                         # Handle and parse response
                         if response is not None and response.status_code == 200:
@@ -1462,7 +1504,7 @@ class Order:
                                     data["CancelOrderResponse"]["orderId"]) + " successfully Cancelled.")
                             else:
                                 # Handle errors
-                                logger.debug("Response Headers: %s", response.headers)
+                                logger.debug("Response Headers: %s", redact_http_headers(response.headers))
                                 logger.debug("Response Body: %s", response.text)
                                 data = response.json()
                                 if 'Error' in data and 'message' in data["Error"] \
@@ -1472,7 +1514,7 @@ class Order:
                                     print("Error: Cancel Order API service error")
                         else:
                             # Handle errors
-                            logger.debug("Response Headers: %s", response.headers)
+                            logger.debug("Response Headers: %s", redact_http_headers(response.headers))
                             logger.debug("Response Body: %s", response.text)
                             data = response.json()
                             if 'Error' in data and 'message' in data["Error"] and data["Error"]["message"] is not None:
@@ -1537,7 +1579,7 @@ class Order:
             prev_orders = []
 
             # Open orders
-            logger.debug("Request Header: %s", response_open.request.headers)
+            logger.debug("Request Header: %s", redact_http_headers(response_open.request.headers))
             logger.debug("Response Body: %s", response_open.text)
 
             print("\nOpen Orders:")
@@ -1554,9 +1596,9 @@ class Order:
                 prev_orders.extend(self.print_orders(data, "open"))
 
             # Executed orders
-            logger.debug("Request Header: %s", response_executed.request.headers)
+            logger.debug("Request Header: %s", redact_http_headers(response_executed.request.headers))
             logger.debug("Response Body: %s", response_executed.text)
-            logger.debug(response_executed.text)
+            logger.debug("Response Body: %s", response_executed.text)
 
             print("\nExecuted Orders:")
             # Handle and parse response
@@ -1574,7 +1616,7 @@ class Order:
                 prev_orders.extend(self.print_orders(data, "executed"))
 
             # Individual fills orders
-            logger.debug("Request Header: %s", response_indiv_fills.request.headers)
+            logger.debug("Request Header: %s", redact_http_headers(response_indiv_fills.request.headers))
             logger.debug("Response Body: %s", response_indiv_fills.text)
 
             print("\nIndividual Fills Orders:")
@@ -1591,7 +1633,7 @@ class Order:
                 prev_orders.extend(self.print_orders(data, "indiv_fills"))
 
             # Cancelled orders
-            logger.debug("Request Header: %s", response_cancelled.request.headers)
+            logger.debug("Request Header: %s", redact_http_headers(response_cancelled.request.headers))
             logger.debug("Response Body: %s", response_cancelled.text)
 
             print("\nCancelled Orders:")
@@ -1608,7 +1650,7 @@ class Order:
                 prev_orders.extend(self.print_orders(data, "cancelled"))
 
             # Rejected orders
-            logger.debug("Request Header: %s", response_rejected.request.headers)
+            logger.debug("Request Header: %s", redact_http_headers(response_rejected.request.headers))
             logger.debug("Response Body: %s", response_rejected.text)
 
             print("\nRejected Orders:")
@@ -1689,9 +1731,9 @@ class Order:
             prev_orders = []
 
             # Executed orders
-            logger.debug("Request Header: %s", response_filter.request.headers)
+            logger.debug("Request Header: %s", redact_http_headers(response_filter.request.headers))
             logger.debug("Response Body: %s", response_filter.text)
-            logger.debug(response_filter.text)
+            logger.debug("Response Body: %s", response_filter.text)
 
             print("\nExecuted Orders:")
             # Handle and parse response
@@ -1742,7 +1784,7 @@ class Order:
         response = self.session.get(url, header_auth=True, params=params, headers=headers)
         if is_etrade_token_expired_response(response) and self._refresh_auth_session_if_possible("open orders fetch"):
             response = self.session.get(url, header_auth=True, params=params, headers=headers)
-        logger.debug("Request Header: %s", response.request.headers)
+        logger.debug("Request Header: %s", redact_http_headers(response.request.headers))
         logger.debug("Response Body: %s", response.text)
 
         open_orders_list = []
@@ -1800,7 +1842,7 @@ class Order:
         params = {"status": "CANCELLED"}
 
         response = self.session.get(url, header_auth=True, params=params, headers=headers)
-        logger.debug("Request Header: %s", response.request.headers)
+        logger.debug("Request Header: %s", redact_http_headers(response.request.headers))
         logger.debug("Response Body: %s", response.text)
 
         cancelled_orders_list = []
@@ -1865,7 +1907,7 @@ class Order:
 
         # Make API call for GET request
         response = self.session.get(url, header_auth=True, params=params, headers=headers)
-        logger.debug("Request Header: %s", response.request.headers)
+        logger.debug("Request Header: %s", redact_http_headers(response.request.headers))
         logger.debug("Response Body: %s", response.text)
 
         executed_orders_list = []
@@ -1931,7 +1973,7 @@ class Order:
 
         # Make API call for GET request
         response = self.session.get(url, header_auth=True, params=params, headers=headers)
-        logger.debug("Request Header: %s", response.request.headers)
+        logger.debug("Request Header: %s", redact_http_headers(response.request.headers))
         logger.debug("Response Body: %s", response.text)
 
         opened_orders_list = []
@@ -2019,6 +2061,7 @@ class Order:
             }
 
             # Make the API request to place the order
+            self._assert_order_api_access()
             response = self.session.post(url, json=order_payload)
 
             # Check if the request was successful
@@ -2640,7 +2683,7 @@ class Order:
         
         # Make API call for GET request
         response_open = self.session.get(url, header_auth=True, params=params_open, headers=headers)
-        logger.debug("Request Header: %s", response_open.request.headers)
+        logger.debug("Request Header: %s", redact_http_headers(response_open.request.headers))
         logger.debug("Response Body: %s", response_open.text)
         
         print("\nOpen Orders:")
@@ -2718,9 +2761,10 @@ class Order:
                             payload = payload.format(order_id)
                             
                             # Make API call for PUT request
+                            self._assert_order_api_access()
                             response = self.session.put(cancel_url, header_auth=True, headers=cancel_headers, data=payload)
-                            logger.debug("Request Header: %s", response.request.headers)
-                            logger.debug("Request payload: %s", payload)
+                            logger.debug("Request Header: %s", redact_http_headers(response.request.headers))
+                            logger.debug("Request payload: %s", payload_fingerprint(payload))
                             
                             # Handle and parse response
                             if response is not None and response.status_code == 200:
@@ -2874,6 +2918,7 @@ class Order:
                         "consumerKey": self.consumer_key,
                     }
                     
+                    self._assert_order_api_access()
                     change_response = self.session.put(change_url, headers=change_headers, data=payload)
                     
                     if change_response.status_code == 200:
@@ -2883,7 +2928,7 @@ class Order:
                         print("Failed to update order %s: Status Code: %s, Response: %s", 
                                     order_id, change_response.status_code, change_response.text)
                         print(change_url)
-                        print(payload)
+                        print("Order request payload withheld; metadata:", payload_fingerprint(payload))
             # Wait 10 seconds before next iteration
             time.sleep(10)
 
@@ -2975,6 +3020,7 @@ class Order:
                         "consumerKey": self.consumer_key,
                     }
 
+                    self._assert_order_api_access()
                     preview_response = self.session.post(preview_url, headers=preview_headers, data=preview_payload)
                     if preview_response.status_code != 200:
                         print("Failed to preview change for order %s: %s", order_id, preview_response.text)
@@ -3022,6 +3068,7 @@ class Order:
                         "consumerKey": self.consumer_key,
                     }
 
+                    self._assert_order_api_access()
                     place_response = self.session.put(place_url, headers=place_headers, data=place_payload)
                     if place_response.status_code == 200:
                         print("Successfully updated order %s to new limit price %.2f", order_id, new_limit_price)

--- a/etrade_python_client/tests/test_runtime_safety.py
+++ b/etrade_python_client/tests/test_runtime_safety.py
@@ -1,0 +1,728 @@
+"""Focused fail-closed coverage for the live runtime boundary."""
+
+from __future__ import annotations
+
+import io
+import json
+import os
+import subprocess
+import sys
+import tempfile
+import unittest
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+from types import SimpleNamespace
+from unittest import mock
+
+from accounts.accounts_bo import Accounts
+from live_trading.runtime_safety import (
+    ARM_SCHEMA_VERSION,
+    MAX_PRODUCTION_ARM_LIFETIME,
+    OwnerOnlyRotatingFileHandler,
+    RuntimeSafetyBoundary,
+    RuntimeSafetyError,
+    build_runtime_safety_boundary,
+    configure_owner_only_logger,
+    issue_production_arm,
+    main as runtime_safety_main,
+    production_arm_signature,
+    read_owner_only_json,
+    secure_lock_file,
+    secure_append_text,
+    validate_dashboard_credentials,
+    write_owner_only_json,
+)
+
+
+class _Response:
+    status_code = 200
+    headers = {"Content-Type": "application/json"}
+
+    def __init__(self, payload):
+        self._payload = payload
+        self.text = json.dumps(payload)
+        self.request = SimpleNamespace(headers={})
+
+    def json(self):
+        return self._payload
+
+
+class _Session:
+    def __init__(self, payload):
+        self.payload = payload
+
+    def get(self, *args, **kwargs):
+        return _Response(self.payload)
+
+
+def _account(key="account-key", display="display-id", institution="BROKERAGE"):
+    return {
+        "accountIdKey": key,
+        "accountId": display,
+        "institutionType": institution,
+        "accountStatus": "OPEN",
+    }
+
+
+def _arm_document(*, issued_at=None, expires_at=None, extra=None):
+    issued_at = issued_at or datetime.now(timezone.utc)
+    document = {
+        "version": ARM_SCHEMA_VERSION,
+        "environment": "production",
+        "expected_account_id": "display-id",
+        "expected_account_id_key": "account-key",
+        "expected_institution_type": "BROKERAGE",
+        "issued_at": issued_at.isoformat(),
+        "expires_at": (expires_at or issued_at + timedelta(minutes=5)).isoformat(),
+    }
+    if extra:
+        document.update(extra)
+    return document
+
+
+class RuntimeSafetyTests(unittest.TestCase):
+    def test_missing_environment_never_defaults_to_production(self):
+        with self.assertRaisesRegex(RuntimeSafetyError, "explicit"):
+            build_runtime_safety_boundary(
+                environment=None,
+                legacy_sandbox=None,
+                expected_account_id=None,
+                expected_account_id_key=None,
+                expected_institution_type=None,
+            )
+
+    def test_explicit_legacy_sandbox_is_the_only_identity_free_compatibility_path(self):
+        boundary = build_runtime_safety_boundary(
+            environment=None,
+            legacy_sandbox=True,
+            expected_account_id=None,
+            expected_account_id_key=None,
+            expected_institution_type=None,
+        )
+        self.assertTrue(boundary.use_sandbox)
+        self.assertEqual(boundary.account_selection_kwargs, {"selected_account_id": 1})
+
+    def test_production_requires_matching_unexpired_independent_arm_document(self):
+        with tempfile.TemporaryDirectory() as directory:
+            arm_path = Path(directory) / "production-arm.json"
+            secret = "s" * 32
+            document = _arm_document()
+            document["signature"] = production_arm_signature(document, secret)
+            arm_path.write_text(json.dumps(document), encoding="utf-8")
+            os.chmod(arm_path, 0o600)
+
+            boundary = build_runtime_safety_boundary(
+                environment="production",
+                legacy_sandbox=None,
+                expected_account_id="display-id",
+                expected_account_id_key="account-key",
+                expected_institution_type="BROKERAGE",
+                production_arm_file=arm_path,
+                production_arm_secret=secret,
+            )
+
+        self.assertFalse(boundary.use_sandbox)
+        self.assertEqual(boundary.account_selection_kwargs["selected_account_id"], None)
+        boundary.verify_account(_account())
+        with self.assertRaisesRegex(RuntimeSafetyError, "armed identity"):
+            boundary.verify_account(_account(display="wrong"))
+
+    def test_production_rejects_a_missing_or_weak_arm_proof(self):
+        with self.assertRaisesRegex(RuntimeSafetyError, "arm"):
+            build_runtime_safety_boundary(
+                environment="production",
+                legacy_sandbox=None,
+                expected_account_id="display-id",
+                expected_account_id_key="account-key",
+                expected_institution_type="BROKERAGE",
+                production_arm_file=None,
+                production_arm_secret="s" * 32,
+            )
+
+    def test_production_arm_rejects_expired_future_overlong_and_extra_documents(self):
+        secret = "s" * 32
+        now = datetime.now(timezone.utc)
+        cases = (
+            (_arm_document(issued_at=now - timedelta(minutes=6), expires_at=now - timedelta(seconds=1)), "expired"),
+            (_arm_document(issued_at=now + timedelta(seconds=61)), "future"),
+            (
+                _arm_document(
+                    issued_at=now,
+                    expires_at=now + MAX_PRODUCTION_ARM_LIFETIME + timedelta(seconds=1),
+                ),
+                "lifetime",
+            ),
+            (_arm_document(extra={"unexpected": "field"}), "schema"),
+        )
+        with tempfile.TemporaryDirectory() as directory:
+            arm_path = Path(directory) / "production-arm.json"
+            for document, expected_error in cases:
+                if expected_error == "schema":
+                    document.pop("unexpected")
+                    document["signature"] = production_arm_signature(document, secret)
+                    document["unexpected"] = "field"
+                else:
+                    document["signature"] = production_arm_signature(document, secret)
+                arm_path.write_text(json.dumps(document), encoding="utf-8")
+                os.chmod(arm_path, 0o600)
+                with self.assertRaisesRegex(RuntimeSafetyError, expected_error):
+                    build_runtime_safety_boundary(
+                        environment="production",
+                        legacy_sandbox=None,
+                        expected_account_id="display-id",
+                        expected_account_id_key="account-key",
+                        expected_institution_type="BROKERAGE",
+                        production_arm_file=arm_path,
+                        production_arm_secret=secret,
+                        now=now,
+                    )
+
+    def test_production_arm_expiry_is_rechecked_before_account_use(self):
+        now = datetime.now(timezone.utc)
+        with tempfile.TemporaryDirectory() as directory:
+            arm_path = Path(directory) / "production-arm.json"
+            issue_production_arm(
+                output=arm_path,
+                expected_account_id="display-id",
+                expected_account_id_key="account-key",
+                expected_institution_type="BROKERAGE",
+                ttl_seconds=1,
+                secret="s" * 32,
+                now=now,
+            )
+            boundary = build_runtime_safety_boundary(
+                environment="production",
+                legacy_sandbox=None,
+                expected_account_id="display-id",
+                expected_account_id_key="account-key",
+                expected_institution_type="BROKERAGE",
+                production_arm_file=arm_path,
+                production_arm_secret="s" * 32,
+                now=now,
+            )
+        with self.assertRaisesRegex(RuntimeSafetyError, "expired"):
+            boundary.verify_account(_account(), now=now + timedelta(seconds=1))
+
+    def test_arm_operator_command_creates_an_owner_only_exact_document(self):
+        with tempfile.TemporaryDirectory() as directory:
+            arm_path = Path(directory) / "production-arm.json"
+            with mock.patch.dict(os.environ, {"ETRADE_PRODUCTION_ARMING_SECRET": "s" * 32}, clear=False):
+                result = runtime_safety_main(
+                    [
+                        "issue-production-arm",
+                        "--output", str(arm_path),
+                        "--expected-account-id", "display-id",
+                        "--expected-account-id-key", "account-key",
+                        "--expected-institution-type", "BROKERAGE",
+                        "--ttl-seconds", "300",
+                    ]
+                )
+            self.assertEqual(result, 0)
+            self.assertEqual(os.stat(arm_path).st_mode & 0o777, 0o600)
+            self.assertEqual(
+                set(json.loads(arm_path.read_text(encoding="utf-8"))),
+                {
+                    "version", "environment", "expected_account_id", "expected_account_id_key",
+                    "expected_institution_type", "issued_at", "expires_at", "signature",
+                },
+            )
+
+    def test_arm_writer_rejects_an_unsafe_parent_directory(self):
+        with tempfile.TemporaryDirectory() as directory:
+            unsafe_parent = Path(directory) / "unsafe"
+            unsafe_parent.mkdir()
+            os.chmod(unsafe_parent, 0o777)
+            with self.assertRaisesRegex(RuntimeSafetyError, "parent"):
+                issue_production_arm(
+                    output=unsafe_parent / "production-arm.json",
+                    expected_account_id="display-id",
+                    expected_account_id_key="account-key",
+                    expected_institution_type="BROKERAGE",
+                    ttl_seconds=300,
+                    secret="s" * 32,
+                )
+
+    def test_exact_account_selection_rejects_index_and_identity_ambiguity(self):
+        payload = {
+            "AccountListResponse": {
+                "Accounts": {"Account": [_account(), _account()]}
+            }
+        }
+        accounts = Accounts(_Session(payload), "https://example.invalid", use_sandbox=False, consumer_key="key")
+        with self.assertRaisesRegex(RuntimeError, "exactly one"):
+            accounts.account_list(
+                None,
+                expected_account_id_key="account-key",
+                expected_account_id="display-id",
+                expected_institution_type="BROKERAGE",
+            )
+
+        accounts = Accounts(
+            _Session({"AccountListResponse": {"Accounts": {"Account": [_account()]}}}),
+            "https://example.invalid",
+            use_sandbox=False,
+            consumer_key="key",
+        )
+        accounts.account_list(
+            None,
+            expected_account_id_key="account-key",
+            expected_account_id="display-id",
+            expected_institution_type="BROKERAGE",
+        )
+        self.assertEqual(accounts.account["accountIdKey"], "account-key")
+
+    def test_live_trade_agent_preserves_exact_binding_through_refresh(self):
+        from core_api import stock_trade_class as trade_module
+
+        created_accounts = []
+
+        class FakeAccounts:
+            def __init__(self, *args, **kwargs):
+                self.account = _account()
+                self.calls = []
+                created_accounts.append(self)
+
+            def account_list(self, *args, **kwargs):
+                self.calls.append((args, kwargs))
+                return []
+
+        order_factory = mock.Mock()
+        with mock.patch.object(trade_module, "Accounts", FakeAccounts), mock.patch.object(
+            trade_module, "Market", mock.Mock()
+        ), mock.patch.object(trade_module, "Order", order_factory):
+            boundary = build_runtime_safety_boundary(
+                environment="sandbox",
+                legacy_sandbox=None,
+                expected_account_id="display-id",
+                expected_account_id_key="account-key",
+                expected_institution_type="BROKERAGE",
+            )
+            agent = trade_module.LiveTradeAgent(
+                authenticated_session=object(),
+                base_url="https://example.invalid",
+                selected_account=None,
+                use_sandbox=True,
+                expected_account_id_key="account-key",
+                expected_account_id="display-id",
+                expected_institution_type="BROKERAGE",
+                runtime_safety=boundary,
+            )
+            agent.refresh_session(object(), "https://example.invalid")
+
+        self.assertEqual(len(created_accounts), 2)
+        self.assertEqual(order_factory.call_count, 2)
+        for call in order_factory.call_args_list:
+            self.assertIs(call.kwargs["runtime_safety"], boundary)
+        for account_client in created_accounts:
+            self.assertEqual(
+                account_client.calls,
+                [
+                    (
+                        (None,),
+                        {
+                            "expected_account_id_key": "account-key",
+                            "expected_account_id": "display-id",
+                            "expected_institution_type": "BROKERAGE",
+                        },
+                    )
+                ],
+            )
+
+    def test_authenticated_live_agent_requires_a_runtime_boundary(self):
+        from core_api import stock_trade_class as trade_module
+
+        with self.assertRaisesRegex(RuntimeError, "RuntimeSafetyBoundary"):
+            trade_module.LiveTradeAgent(
+                authenticated_session=object(),
+                base_url="https://example.invalid",
+            )
+
+    def test_live_agent_rejects_arguments_conflicting_with_its_boundary(self):
+        from core_api import stock_trade_class as trade_module
+
+        boundary = build_runtime_safety_boundary(
+            environment="sandbox",
+            legacy_sandbox=None,
+            expected_account_id=None,
+            expected_account_id_key=None,
+            expected_institution_type=None,
+        )
+        with self.assertRaisesRegex(RuntimeError, "conflict"):
+            trade_module.LiveTradeAgent(
+                authenticated_session=object(),
+                base_url="https://example.invalid",
+                use_sandbox=False,
+                runtime_safety=boundary,
+            )
+
+    def test_live_clients_resolve_configless_environment_credentials(self):
+        from market.market_bo import Market
+        from order.order_bo import Order
+
+        env = {"ETRADE_LIVE_CONSUMER_KEY": "env-only-consumer-key"}
+        with mock.patch.dict(os.environ, env, clear=False):
+            account_client = Accounts(object(), "https://example.invalid", use_sandbox=False)
+            market_client = Market(object(), "https://example.invalid", use_sandbox=False)
+            order_client = Order(object(), _account(), "https://example.invalid", use_sandbox=False)
+        self.assertEqual(account_client.consumer_key, env["ETRADE_LIVE_CONSUMER_KEY"])
+        self.assertEqual(market_client.consumer_key, env["ETRADE_LIVE_CONSUMER_KEY"])
+        self.assertEqual(order_client.consumer_key, env["ETRADE_LIVE_CONSUMER_KEY"])
+
+    def test_order_api_rejects_missing_boundary_before_broker_io(self):
+        from order.order_bo import Order
+
+        session = mock.Mock()
+        order_client = Order(
+            session,
+            _account(),
+            "https://example.invalid",
+            use_sandbox=False,
+            consumer_key="key",
+        )
+        with self.assertRaisesRegex(RuntimeSafetyError, "RuntimeSafetyBoundary"):
+            order_client.preview_order(
+                {
+                    "securityType": "EQ",
+                    "client_order_id": "client-id",
+                    "priceType": "LIMIT",
+                    "orderTerm": "GOOD_FOR_DAY",
+                    "limitPrice": 1.0,
+                    "symbol": "SPY",
+                    "orderAction": "BUY",
+                    "quantity": 1,
+                }
+            )
+        session.post.assert_not_called()
+
+    def test_order_api_rechecks_arm_immediately_before_broker_io(self):
+        from order.order_bo import Order
+
+        boundary = mock.Mock(spec=RuntimeSafetyBoundary)
+        boundary.use_sandbox = False
+        session = mock.Mock()
+        order_client = Order(
+            session,
+            _account(),
+            "https://example.invalid",
+            use_sandbox=False,
+            consumer_key="key",
+            runtime_safety=boundary,
+        )
+        boundary.verify_account.reset_mock()
+        boundary.verify_account.side_effect = RuntimeSafetyError("production arm proof is expired")
+        with self.assertRaisesRegex(RuntimeSafetyError, "expired"):
+            order_client.preview_order(
+                {
+                    "securityType": "EQ",
+                    "client_order_id": "client-id",
+                    "priceType": "LIMIT",
+                    "orderTerm": "GOOD_FOR_DAY",
+                    "limitPrice": 1.0,
+                    "symbol": "SPY",
+                    "orderAction": "BUY",
+                    "quantity": 1,
+                }
+            )
+        boundary.verify_account.assert_called_once_with(_account())
+        session.post.assert_not_called()
+
+    def test_legacy_interactive_order_client_is_quarantined(self):
+        from order.order import Order
+
+        with self.assertRaisesRegex(RuntimeSafetyError, "quarantined"):
+            Order(object(), _account(), "https://example.invalid")
+
+    def test_live_agent_refresh_resolves_configless_environment_credentials(self):
+        from core_api.stock_trade_class import LiveTradeAgent
+
+        boundary = build_runtime_safety_boundary(
+            environment="sandbox",
+            legacy_sandbox=None,
+            expected_account_id="display-id",
+            expected_account_id_key="account-key",
+            expected_institution_type="BROKERAGE",
+        )
+
+        def select_account(client, *args, **kwargs):
+            client.account = _account()
+            return [client.account]
+
+        with mock.patch.dict(os.environ, {"ETRADE_SANDBOX_CONSUMER_KEY": "sandbox-env-key"}, clear=False), mock.patch.object(
+            Accounts, "account_list", select_account
+        ):
+            agent = LiveTradeAgent(
+                authenticated_session=object(),
+                base_url="https://example.invalid",
+                runtime_safety=boundary,
+            )
+            agent.refresh_session(object(), "https://example.invalid")
+        self.assertEqual(agent.market.consumer_key, "sandbox-env-key")
+        self.assertEqual(agent.order.consumer_key, "sandbox-env-key")
+
+    def test_dashboard_credentials_reject_defaults_and_accept_strong_values(self):
+        with self.assertRaisesRegex(RuntimeSafetyError, "weak"):
+            validate_dashboard_credentials(
+                {"dashboard_user": "operator", "dashboard_pass": "short", "pin": "1234"}
+            )
+        validate_dashboard_credentials(
+            {
+                "dashboard_user": "operator",
+                "dashboard_pass": "long-random-dashboard-password",
+                "pin": "84927163",
+            }
+        )
+
+    def test_dashboard_settings_and_logs_do_not_leave_plaintext_credentials(self):
+        from live_trading import etrade_cover_call_new as dashboard
+
+        with tempfile.TemporaryDirectory() as directory:
+            settings_path = Path(directory) / "settings.json"
+            log_path = Path(directory) / "dashboard.log"
+            settings = {
+                "dashboard_user": "operator",
+                "dashboard_pass": "long-random-dashboard-password",
+                "pin": "84927163",
+                "dashboard_auth_secret": "session-secret-value",
+            }
+            with mock.patch.object(dashboard, "LIVE_SETTINGS_FILE", str(settings_path)), mock.patch.object(
+                dashboard, "DASHBOARD_LOG_FILE", str(log_path)
+            ):
+                self.assertTrue(dashboard.save_live_settings(settings))
+                self.assertEqual(os.stat(settings_path).st_mode & 0o777, 0o600)
+                dashboard.log_dashboard_request("/api/settings", settings)
+            recorded = log_path.read_text(encoding="utf-8")
+            self.assertEqual(os.stat(log_path).st_mode & 0o777, 0o600)
+            self.assertNotIn(settings["dashboard_pass"], recorded)
+            self.assertNotIn(settings["pin"], recorded)
+            self.assertNotIn(settings["dashboard_auth_secret"], recorded)
+
+    def test_order_audit_log_is_owner_only_and_csv_encoded(self):
+        from live_trading import etrade_cover_call_new as dashboard
+
+        with tempfile.TemporaryDirectory() as directory:
+            audit_path = Path(directory) / "orders.csv"
+            with mock.patch.object(dashboard, "AUDIT_LOG_FILE", str(audit_path)):
+                dashboard.log_order_execution(
+                    {
+                        "ticker": "SPY",
+                        "sell_strike": 500,
+                        "long_strike": 495,
+                        "qty": 1,
+                        "order_id": "broker-id",
+                    },
+                    'reason containing, comma',
+                )
+            self.assertEqual(os.stat(audit_path).st_mode & 0o777, 0o600)
+            recorded = audit_path.read_text(encoding="utf-8")
+            self.assertIn('"reason containing, comma"', recorded)
+
+    def test_legacy_oauth_helper_uses_owner_only_environment_scoped_cache(self):
+        from live_trading import etrade_check_option as legacy
+
+        with tempfile.TemporaryDirectory() as directory:
+            cache_path = Path(directory) / ".etrade_oauth"
+            token = {"access_token": "token", "access_token_secret": "secret"}
+            with mock.patch.object(legacy, "ETRADE_OAUTH_FILE", str(cache_path)):
+                self.assertTrue(legacy.save_etrade_oauth(token, use_sandbox=False))
+                self.assertEqual(legacy.get_etrade_oauth(use_sandbox=False), token)
+            self.assertEqual(os.stat(cache_path).st_mode & 0o777, 0o600)
+
+    def test_quarantined_spread_import_uses_owner_only_log_and_cannot_authenticate(self):
+        repository = Path(__file__).resolve().parents[1]
+        with tempfile.TemporaryDirectory() as directory:
+            environment = os.environ.copy()
+            environment["PYTHONPATH"] = str(repository)
+            result = subprocess.run(
+                [
+                    sys.executable,
+                    "-c",
+                    "import os, stat; "
+                    "from live_trading import etrade_put_credit_spread as legacy; "
+                    "from live_trading.runtime_safety import RuntimeSafetyError; "
+                    "assert stat.S_IMODE(os.stat('etrade_trader.log').st_mode) == 0o600; "
+                    "\ntry:\n legacy.get_etrade_session(False)\n"
+                    "except RuntimeSafetyError:\n pass\n"
+                    "else:\n raise AssertionError('legacy authentication was not quarantined')",
+                ],
+                cwd=directory,
+                env=environment,
+                capture_output=True,
+                text=True,
+            )
+            self.assertEqual(result.returncode, 0, result.stderr)
+
+    def test_log_writer_and_rotating_handler_fail_closed_for_unsafe_paths(self):
+        with tempfile.TemporaryDirectory() as directory:
+            log_path = Path(directory) / "dashboard.log"
+            secure_append_text(log_path, "safe\n")
+            self.assertEqual(os.stat(log_path).st_mode & 0o777, 0o600)
+            rotating_path = Path(directory) / "rotating.log"
+            rotating_handler = OwnerOnlyRotatingFileHandler(rotating_path, maxBytes=100, backupCount=1)
+            rotating_handler.close()
+            self.assertEqual(os.stat(rotating_path).st_mode & 0o777, 0o600)
+            os.chmod(log_path, 0o644)
+            with self.assertRaisesRegex(RuntimeSafetyError, "unsafe"):
+                secure_append_text(log_path, "blocked\n")
+
+            target = Path(directory) / "target.log"
+            target.write_text("target", encoding="utf-8")
+            link_path = Path(directory) / "linked.log"
+            link_path.symlink_to(target)
+            with self.assertRaisesRegex(RuntimeSafetyError, "unsafe"):
+                secure_append_text(link_path, "blocked\n")
+            with self.assertRaisesRegex(RuntimeSafetyError, "unsafe"):
+                OwnerOnlyRotatingFileHandler(link_path, maxBytes=100, backupCount=1)
+
+            unsafe_parent = Path(directory) / "unsafe-parent"
+            unsafe_parent.mkdir()
+            os.chmod(unsafe_parent, 0o777)
+            with self.assertRaisesRegex(RuntimeSafetyError, "parent"):
+                secure_append_text(unsafe_parent / "dashboard.log", "blocked\n")
+
+    def test_client_logger_redacts_auth_headers_and_order_xml(self):
+        with tempfile.TemporaryDirectory() as directory:
+            log_path = Path(directory) / "client.log"
+            logger = configure_owner_only_logger("runtime-safety-redaction-test", str(log_path))
+            self.assertFalse(logger.propagate)
+            logger.debug(
+                "Request Header: %s",
+                {
+                    "Authorization": "OAuth secret",
+                    "Cookie": "sid=secret",
+                    "User-Agent": "private-client-version",
+                },
+            )
+            logger.debug("Request payload: %s", "<Order><token>secret</token></Order>")
+            logger.debug(
+                "Response Body: %s",
+                {"accountId": "private-account", "position": {"quantity": 42}},
+            )
+            logger.debug(json.dumps({"accountIdKey": "private-key", "orderId": 1234}))
+            logger.debug("Request url: %s", "https://example.invalid/accounts/private-key/orders")
+            logger.error("Failed broker response: %s", "plain private broker body")
+            for handler in logger.handlers:
+                handler.flush()
+                handler.close()
+            recorded = log_path.read_text(encoding="utf-8")
+            self.assertNotIn("OAuth secret", recorded)
+            self.assertNotIn("sid=secret", recorded)
+            self.assertNotIn("private-client-version", recorded)
+            self.assertNotIn("<Order>", recorded)
+            self.assertNotIn("private-account", recorded)
+            self.assertNotIn("private-key", recorded)
+            self.assertNotIn("quantity", recorded)
+            self.assertNotIn("plain private broker body", recorded)
+            self.assertIn("sha256", recorded)
+
+    def test_sensitive_json_rewrite_rejects_links_and_unsafe_modes(self):
+        with tempfile.TemporaryDirectory() as directory:
+            cache_path = Path(directory) / ".etrade_oauth"
+            write_owner_only_json(cache_path, {"access_token": "long-token", "padding": "x" * 1000})
+            write_owner_only_json(cache_path, {"access_token": "short-token"})
+            self.assertEqual(os.stat(cache_path).st_mode & 0o777, 0o600)
+            self.assertEqual(read_owner_only_json(cache_path, label="OAuth cache"), {"access_token": "short-token"})
+            self.assertNotIn("padding", cache_path.read_text(encoding="utf-8"))
+            os.chmod(cache_path, 0o644)
+            with self.assertRaisesRegex(RuntimeSafetyError, "owner-only"):
+                read_owner_only_json(cache_path, label="OAuth cache")
+            link_path = Path(directory) / "linked-cache"
+            link_path.symlink_to(cache_path)
+            with self.assertRaisesRegex(RuntimeSafetyError, "invalid|unavailable"):
+                read_owner_only_json(link_path, label="OAuth cache")
+
+    def test_runtime_lock_rejects_unsafe_paths(self):
+        with tempfile.TemporaryDirectory() as directory:
+            lock_path = Path(directory) / "lock"
+            handle = secure_lock_file(lock_path)
+            handle.close()
+            self.assertEqual(os.stat(lock_path).st_mode & 0o777, 0o600)
+            os.chmod(lock_path, 0o644)
+            with self.assertRaisesRegex(RuntimeSafetyError, "unsafe"):
+                secure_lock_file(lock_path)
+            link_path = Path(directory) / "linked-lock"
+            link_path.symlink_to(lock_path)
+            with self.assertRaisesRegex(RuntimeSafetyError, "unsafe"):
+                secure_lock_file(link_path)
+
+    def test_runtime_lock_excludes_a_second_process(self):
+        repository = Path(__file__).resolve().parents[1]
+        with tempfile.TemporaryDirectory() as directory:
+            lock_path = Path(directory) / "lock"
+            handle = secure_lock_file(lock_path)
+            try:
+                environment = os.environ.copy()
+                environment["PYTHONPATH"] = str(repository)
+                result = subprocess.run(
+                    [
+                        sys.executable,
+                        "-c",
+                        "from live_trading.runtime_safety import secure_lock_file; "
+                        f"secure_lock_file({str(lock_path)!r})",
+                    ],
+                    cwd=directory,
+                    env=environment,
+                    capture_output=True,
+                    text=True,
+                )
+            finally:
+                handle.close()
+            self.assertNotEqual(result.returncode, 0)
+            self.assertIn("already running", result.stderr)
+
+    def test_clean_cwd_import_creates_a_protected_client_log(self):
+        repository = Path(__file__).resolve().parents[1]
+        with tempfile.TemporaryDirectory() as directory:
+            command = [
+                sys.executable,
+                "-c",
+                "import live_trading.etrade_cover_call_new; import os, stat; "
+                "assert stat.S_IMODE(os.stat('python_client.log').st_mode) == 0o600",
+            ]
+            environment = os.environ.copy()
+            environment["PYTHONPATH"] = str(repository)
+            result = subprocess.run(command, cwd=directory, env=environment, capture_output=True, text=True)
+            self.assertEqual(result.returncode, 0, result.stderr)
+
+    def test_settings_reject_an_unsafe_parent_directory(self):
+        from live_trading import etrade_cover_call_new as dashboard
+
+        with tempfile.TemporaryDirectory() as directory:
+            unsafe_parent = Path(directory) / "unsafe"
+            unsafe_parent.mkdir()
+            os.chmod(unsafe_parent, 0o777)
+            settings = {
+                "dashboard_user": "operator",
+                "dashboard_pass": "long-random-dashboard-password",
+                "pin": "84927163",
+            }
+            with mock.patch.object(dashboard, "LIVE_SETTINGS_FILE", str(unsafe_parent / "settings.json")):
+                self.assertFalse(dashboard.save_live_settings(settings))
+
+    def test_safe_dashboard_responses_include_browser_security_headers(self):
+        from live_trading import etrade_cover_call_new as dashboard
+
+        handler = object.__new__(dashboard.RefreshHandler)
+        handler.send_response = mock.Mock()
+        handler.send_header = mock.Mock()
+        handler.end_headers = mock.Mock()
+        handler.wfile = io.BytesIO()
+        handler._send_safe_response(200, {"ok": True})
+        headers = {call.args[0]: call.args[1] for call in handler.send_header.call_args_list}
+        self.assertEqual(headers["X-Content-Type-Options"], "nosniff")
+        self.assertEqual(headers["X-Frame-Options"], "DENY")
+        self.assertEqual(headers["Referrer-Policy"], "no-referrer")
+        self.assertEqual(headers["Cross-Origin-Resource-Policy"], "same-origin")
+
+    def test_dashboard_server_is_loopback_only(self):
+        from live_trading import etrade_cover_call_new as dashboard
+
+        fake_server = mock.Mock()
+        with mock.patch.object(dashboard, "ThreadingHTTPServer", return_value=fake_server) as server:
+            dashboard.start_refresh_server(port=8765)
+        server.assert_called_once_with(("127.0.0.1", 8765), dashboard.RefreshHandler)
+        with self.assertRaisesRegex(RuntimeSafetyError, "loopback"):
+            dashboard.start_refresh_server(host="0.0.0.0")
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

- require an explicit sandbox or production environment before OAuth
- bind production startup to an exact account identity and a signed, owner-only, short-lived arm
- revalidate environment, account, and arm immediately before every order API POST/PUT
- quarantine legacy order-capable entry points that bypass the runtime boundary
- protect OAuth caches, settings, audit logs, client logs, locks, and failure screenshots
- remove current-source hardcoded E*TRADE credentials and suppress OAuth verifiers, headers, payloads, response bodies, and account-bearing URLs
- contain the order-capable dashboard to loopback with strong local credentials and restrictive browser headers

## Verification

- clean isolated Python 3.10 worktree: `165 passed`
- focused runtime-safety suite: `31 passed`
- `py_compile` and `git diff --check`: passed
- independent adversarial security review: no remaining P0/P1 blocker in this containment scope

## Deliberate limitations

- no live E*TRADE request, order, service restart, or deployed-dashboard change was performed
- production arms expire after at most 15 minutes; an expired process fails closed on its next order API call
- durable intent identity, capacity reservations, ambiguous-outcome reconciliation, and a sole mutation owner remain the next stacked gateway tranche
- credentials exposed in public Git history must still be revoked/rotated externally and removed through a coordinated history rewrite
- Regime V2 remains advisory-only and cannot authorize execution
