### PR TITLE
R7a: add durable order-intent ledger

### DIFF
--- a/etrade_python_client/RELIABILITY.md
+++ b/etrade_python_client/RELIABILITY.md
@@ -497,10 +497,16 @@ finding.
 
 This is containment in the current source, not production readiness. The
 compatibility order client now rejects calls without the current arm/account
-boundary, but placement has not yet been routed through one durable gateway.
-R7 must make that gateway the sole mutation owner while preserving the
-placement-time check, stable intent identity, capacity reservations, and
-unknown-POST reconciliation.
+boundary. R7a adds an isolated schema 9 order-intent ledger with stable
+identity, account capacity reservations, monotonic fences, immutable outbound
+authorization, and reconciliation-only ambiguous outcomes. It performs no
+network I/O and no live code instantiates it. New closing intents and terminal
+reservation release fail closed until position/open-order evidence exists.
+
+R7b must still make one private E*TRADE gateway the sole mutation owner,
+preserve the placement-time arm/account check, construct broker evidence from
+actual responses, reconcile durable blockers at startup, implement durable
+per-intent cancellation, and reject every direct legacy mutation path.
 
 The exposed OAuth keys still require external revocation and rotation. A later
 coordinated history purge must remove them from all refs and arrange cleanup of
@@ -522,6 +528,13 @@ deployed dashboard has not been reloaded or visually inspected with R6.
   files, guarded response/request logging, order calls without a boundary,
   placement-time arm expiry, dashboard credential rejection, and loopback/CORS
   behavior.
+- R7a includes 32 deterministic order-ledger tests for immutable identity,
+  stable identifiers, exact outbound authorization, capacity/reservation
+  arithmetic, exact evidence types, stale evidence, concurrency, fencing ABA,
+  ambiguous outcomes, restart reconciliation, terminal-risk retention,
+  append-only histories, legacy-closing reconciliation, and the additive schema
+  8 to 9 migration. Independent causal and security reviews found no remaining
+  reproducible P0 in the isolated core.
 - Deployment verification is deliberately recorded as incomplete. This
   incident remains open until the remaining-risk conditions above are
   satisfied.

--- a/etrade_python_client/docs/order_intent_ledger.md
+++ b/etrade_python_client/docs/order_intent_ledger.md
@@ -1,0 +1,119 @@
+# Durable Order Intent Ledger
+
+**Delivery status:** R7a isolated foundation
+
+**Production status:** not connected to live E*TRADE mutation paths
+
+`live_trading/order_intent_ledger.py` is the durable, broker-agnostic state
+machine for order identity, capacity reservation, fencing, and ambiguous broker
+outcomes. It performs no network I/O. R7a deliberately does not instantiate the
+ledger from the live agent, so it provides no protection to the current order
+paths until R7b makes one E*TRADE gateway the sole mutation owner.
+
+## Supported scope
+
+- Explicit `sandbox` or `production` environment and exact account identity.
+- Two-leg vertical option spreads with one buy leg and one sell leg.
+- Opening credit and debit spreads whose price direction and maximum exposure
+  can be derived from immutable order fields.
+- No new closing orders until R7b supplies typed position and open-order
+  capacity evidence. Previously persisted closing orders remain readable and
+  reconcilable after migration, but cannot be newly claimed or amended.
+- No equity orders, naked opening options, arbitrary multi-leg spreads, bulk
+  cancellation, or terminal reservation release. Unsupported operations fail
+  closed.
+
+## State and crash boundary
+
+```mermaid
+stateDiagram-v2
+    [*] --> INTENT
+    INTENT --> CLAIMED: fenced lease
+    CLAIMED --> FAILED: definitive pre-POST failure
+    CLAIMED --> SUBMISSION_UNKNOWN: exact semantic bytes persisted
+    SUBMISSION_UNKNOWN --> SUBMITTED: broker acknowledgement or query
+    SUBMISSION_UNKNOWN --> FILLED: broker query
+    SUBMISSION_UNKNOWN --> CANCELLED: broker query
+    SUBMISSION_UNKNOWN --> REJECTED: broker query
+    SUBMISSION_UNKNOWN --> EXPIRED: broker query
+    SUBMITTED --> SUBMITTED: fenced amendment
+    SUBMITTED --> FILLED: broker query
+    SUBMITTED --> CANCELLED: broker query
+    SUBMITTED --> REJECTED: broker query
+    SUBMITTED --> EXPIRED: broker query
+```
+
+The gateway must persist `SUBMISSION_UNKNOWN` or an in-doubt amendment
+immediately before the corresponding broker mutation. A timeout, malformed
+response, process crash, or expired post-capable lease never returns the intent
+to a retryable state. A broker query must reconcile it first.
+
+## Enforced invariants
+
+- An idempotency scope/key is permanently bound to one immutable economic
+  envelope. Stable client order IDs include account and environment identity.
+- Client IDs and broker order IDs cannot be rebound across original orders,
+  active amendments, or immutable amendment history.
+- Submission and amendment leases use monotonic fencing tokens. Stale workers
+  cannot begin, release, acknowledge, or overwrite newer work, even when the
+  owner name is reused.
+- `BEGIN IMMEDIATE` serializes account-capacity decisions and state
+  transitions. New account mutations stop while any submission or amendment is
+  unresolved.
+- Opening reservations use fresh, typed quote, portfolio, and buying-power
+  evidence. The caller's asserted maximum loss cannot be below the exposure
+  derived from strike width, price, contract multiplier, and quantity.
+- An opening terminal state retains its reservation as
+  `FILLED_PENDING_ABSORPTION`. R7a never releases it: neither a newer timestamp
+  nor a different account digest proves that a specific partial or terminal
+  fill is reflected in positions. R7b must add order-bound position evidence.
+- Evidence dataclasses and their security-critical string, timestamp, integer,
+  byte, and `Decimal` fields must use exact built-in types. Subclass overrides
+  cannot replace validation or comparison behavior.
+- Preparation returns a frozen `OutboundAuthorization` containing immutable
+  serialized broker-schema bytes. `begin_submission` and `begin_amendment`
+  recompute the durable payload, client ID, operation, owner, and fence, then
+  persist the exact authorization in the same transaction that enters the
+  in-doubt state. R7b must deterministically derive the final E*TRADE XML from
+  these bytes and the broker preview ID.
+- Order events, broker-order history, amendment history, and outbound
+  authorizations are append-only.
+- The ledger database must live in an owner-only `0700` directory and remain an
+  owner-only regular `0600` file. SQLite sidecars receive the same validation.
+
+## Schema policy
+
+Schema 9 adds append-only outbound authorizations. The only supported migration
+is the additive schema 8 to 9 transition, which is restart-safe and tested.
+Unknown versions fail closed. Before any future production migration, the
+operator runbook must add an atomic backup, integrity check, rollback exercise,
+and an explicit version-by-version migration.
+
+## R7b release gates
+
+R7a must not be used as evidence that live execution is production-ready. R7b
+must satisfy all of the following before any order-capable process is enabled:
+
+1. A private E*TRADE transport is the only module allowed to call order
+   `POST`, `PUT`, or `DELETE` endpoints.
+2. The transport derives the exact request body only from the immutable
+   authorization plus the broker preview ID; strategy code never receives a
+   mutable executable payload.
+3. Broker response parsing and `BrokerEvidence` construction are private to the
+   gateway. Application callers cannot assert their own reconciliation result.
+4. Startup reconciles every durable blocker before accepting a new mutation.
+5. Submission, closing-position capacity, terminal position absorption,
+   repricing, and per-intent cancellation have durable, crash-tested protocols.
+   Bulk cancellation remains disabled.
+6. The R6 production arm and exact account identity are revalidated immediately
+   before each broker mutation.
+7. Static enforcement rejects direct legacy order mutations outside the private
+   transport.
+8. Broker-fixture tests cover duplicate commands, crash-before/after-POST,
+   unknown responses, malformed replies, stale arm/account/capacity evidence,
+   amendment/cancel races, partial fills, and restart reconciliation.
+
+The R7a focused suite contains 32 deterministic tests. Independent causal and
+security reviews found no remaining reproducible core path to double-submit,
+exceed the reservation cap, release opening exposure early, reuse an identifier,
+or substitute a different authorized economic payload.

--- a/etrade_python_client/docs/production_readiness_upgrade_plan.md
+++ b/etrade_python_client/docs/production_readiness_upgrade_plan.md
@@ -640,12 +640,20 @@ The existing monoliths should remain behind compatibility facades while these
 boundaries are extracted. Remove old paths only after golden tests and
 shadow-parity prove equivalent intended behavior.
 
-The current stacked delivery names this first source-level startup containment
-slice R6. It covers part of the planned live-containment and secret/log work,
-not the entire roadmap entries above. R7 is the next safety boundary:
-centralize every placement under one durable owner, preserve the arm/account
-check, persist stable intent identity and capacity reservations, and reconcile
-ambiguous broker outcomes before retry.
+The current stacked delivery names the source-level startup containment slice
+R6. R7a now implements the isolated durable order-intent foundation: strict
+vertical-spread validation, stable intent/client identity, capacity
+reservations, monotonic submission/amendment fences, exact immutable outbound
+authorization, and reconciliation-only ambiguous outcomes. Its schema 9 ledger
+performs no network I/O and no live caller instantiates it. New closing orders
+and terminal reservation absorption deliberately fail closed until R7b adds
+position-level evidence.
+
+R7b is therefore still the next production safety boundary: centralize every
+placement, amendment, and cancellation under one private E*TRADE gateway;
+preserve the arm/account check at the mutation boundary; derive broker evidence
+inside that gateway; reconcile all startup blockers; and statically prohibit
+direct legacy mutation calls. See `docs/order_intent_ledger.md`.
 
 ## Test and verification matrix
 
@@ -696,9 +704,11 @@ R6 has not restarted or inspected the deployed dashboard, called E*TRADE, or
 exercised a live/sandbox mutation. Current-source credential removal also does
 not establish secret hygiene while the repository remains public and the old
 keys remain in Git history. External revoke/rotate, coordinated history purge,
-strong local credential reprovisioning, R7 durable gateway enforcement, and
-deployment verification remain required. The remaining actions belong to the
-staged acceptance gates above.
+strong local credential reprovisioning, R7b durable gateway enforcement, and
+deployment verification remain required. R7a's isolated ledger passed 32
+focused tests and independent causal/security review, but it has no production
+call site and is not live-execution evidence. The remaining actions belong to
+the staged acceptance gates above.
 
 The working tree was already heavily modified and contains important untracked
 runtime sources. This review intentionally adds only this plan and does not

--- a/etrade_python_client/docs/project_overview.md
+++ b/etrade_python_client/docs/project_overview.md
@@ -149,7 +149,8 @@ flowchart LR
     DASHCFG["Strong Dashboard Credentials<br/>Owner-Only Settings and Logs"]
     DASH["Loopback-Only Dashboard<br/>No Automatic Tunnel / No Wildcard CORS"]
     DIRECT["Compatibility Order Client<br/>(Per-Call Arm + Account Guard)"]
-    GATE["R7 Central Order Gateway<br/>(Durable Single Mutation Owner)"]
+    LEDGER["R7a Order Intent Ledger<br/>(Implemented, Isolated)"]
+    GATE["R7b E*TRADE Gateway<br/>(Planned Single Mutation Owner)"]
     BROKER["E*TRADE"]
 
     CLI --> SAFE
@@ -159,15 +160,19 @@ flowchart LR
     DASHCFG --> DASH
     ACCOUNT --> DIRECT
     DIRECT -->|"current, guarded but non-durable"| BROKER
-    DIRECT -.->|"R7 migration"| GATE
-    GATE -.->|"planned replacement"| BROKER
+    DIRECT -.->|"R7b migration"| GATE
+    LEDGER --> GATE
+    GATE -.->|"not connected yet"| BROKER
 ```
 
 This is source-level containment, not a production-readiness claim. The
 compatibility order client now enforces the arm/account check for every order
-API call, but durable intent identity, reservations, ambiguous-outcome
-reconciliation, and a single broker-mutation owner remain R7 work. The deployed
-service has not been restarted or inspected with R6.
+API call. R7a adds an isolated durable ledger for intent identity, reservations,
+fencing, immutable outbound authorization, and ambiguous-outcome state. No live
+code instantiates it yet: R7b must make a private E*TRADE gateway the sole
+broker-mutation owner and construct reconciliation evidence from broker
+responses. The deployed service has not been restarted or inspected with R6 or
+R7a.
 
 ---
 
@@ -211,6 +216,7 @@ shadow/research-only and cannot affect E*TRADE order eligibility.
 
 *   **Runtime Safety Boundary** ([`runtime_safety.py`](file:///Users/btian/EtradePythonClient/etrade_python_client/live_trading/runtime_safety.py)): Resolves an explicit `sandbox` or `production` environment before OAuth construction. Production requires an exact account identity plus a versioned, signed arm file with a bounded lifetime; unsafe, missing, mismatched, future, or expired proof fails closed. The operator CLI writes the arm atomically as an owner-only file without accepting the signing secret as a command-line argument.
 *   **Account Identity Revalidation** ([`accounts_bo.py`](file:///Users/btian/EtradePythonClient/etrade_python_client/accounts/accounts_bo.py), [`order_bo.py`](file:///Users/btian/EtradePythonClient/etrade_python_client/order/order_bo.py)): Selects production accounts by exact account ID, account key, and institution type instead of a mutable list index. The live process revalidates the armed identity after startup and account refresh, and the compatibility order client repeats it immediately before every order API call. R7 must preserve the check inside the durable single mutation gateway.
+*   **Durable Order Intent Ledger** ([`order_intent_ledger.py`](file:///Users/btian/EtradePythonClient/etrade_python_client/live_trading/order_intent_ledger.py), [`order_intent_ledger.md`](file:///Users/btian/EtradePythonClient/etrade_python_client/docs/order_intent_ledger.md)): R7a provides strict vertical-spread validation, account capacity reservations, stable identifiers, monotonic submission/amendment fences, immutable outbound authorizations, and reconciliation-only handling after an ambiguous mutation. It is intentionally broker-agnostic and not yet called by the live agent; R7b remains the production integration gate.
 *   **Dashboard Containment** ([`etrade_cover_call_new.py`](file:///Users/btian/EtradePythonClient/etrade_python_client/live_trading/etrade_cover_call_new.py)): Serves the order-capable dashboard on loopback only, does not start ngrok automatically, and does not grant wildcard CORS. Startup rejects default or weak dashboard credentials, while local settings and touched logs use owner-only file handling.
 *   **Credential Source Cleanup** ([`etrade_check_option.py`](file:///Users/btian/EtradePythonClient/etrade_python_client/live_trading/etrade_check_option.py), [`etrade_option_chains.py`](file:///Users/btian/EtradePythonClient/etrade_python_client/live_trading/etrade_option_chains.py)): Removes hardcoded OAuth credentials from the current source and requires local configuration or environment variables. Because the repository is currently public and those values remain in Git history, the affected keys must be treated as compromised until they are revoked and rotated externally; a coordinated history purge remains separate follow-up work.
 

--- a/etrade_python_client/live_trading/order_intent_ledger.py
+++ b/etrade_python_client/live_trading/order_intent_ledger.py
@@ -1,0 +1,2191 @@
+"""Durable, broker-agnostic order-intent boundary.
+
+This module owns local safety state only.  It deliberately has no E*TRADE
+imports and performs no network I/O.  A future gateway must call
+``begin_submission`` immediately before a broker POST and write either a
+definitive acknowledgement or a broker-backed reconciliation result afterwards.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import hmac
+import json
+import math
+import os
+import sqlite3
+import stat
+import uuid
+from contextlib import contextmanager
+from dataclasses import dataclass
+from datetime import date, datetime, timedelta, timezone
+from decimal import Decimal, InvalidOperation, localcontext
+from pathlib import Path
+from typing import Any, Callable, Iterator, Literal, Mapping
+
+
+SCHEMA_VERSION = 9
+_MIGRATABLE_SCHEMA_VERSIONS = frozenset({8})
+_BUSY_TIMEOUT_MS = 5_000
+_EVIDENCE_MAX_AGE_SECONDS = 300
+_DECIMAL_PRECISION = 50
+_PAYLOAD_HASH_DOMAIN = b"etrade-order-payload.v2\0"
+_CLIENT_ID_DOMAIN = b"etrade-client-order-id.v2\0"
+_INTENT_KINDS = frozenset({"OPENING", "CLOSING"})
+_ENVIRONMENTS = frozenset({"sandbox", "production"})
+_TERMINAL_STATES = frozenset({"FILLED", "CANCELLED", "REJECTED", "EXPIRED", "FAILED"})
+_BROKER_LIVE_STATES = frozenset({"CLAIMED", "SUBMISSION_UNKNOWN", "SUBMITTED"})
+_BROKER_TERMINAL_STATUS = {
+    "FILLED": "FILLED",
+    "CANCELLED": "CANCELLED",
+    "REJECTED": "REJECTED",
+    "EXPIRED": "EXPIRED",
+}
+_REASON_CODES = frozenset(
+    {
+        "INTENT_CREATED",
+        "SUBMISSION_CLAIMED",
+        "LEASE_RENEWED",
+        "LEASE_EXPIRED_IN_DOUBT",
+        "POST_STARTED",
+        "POST_ACKNOWLEDGED",
+        "POST_TIMEOUT",
+        "POST_TRANSPORT_ERROR",
+        "POST_RESPONSE_INVALID",
+        "PRE_POST_ABORTED",
+        "BROKER_OPEN_RECONCILED",
+        "BROKER_FILLED",
+        "BROKER_CANCELLED",
+        "BROKER_REJECTED",
+        "BROKER_EXPIRED",
+        "RESERVATION_CREATED",
+        "RESERVATION_RELEASED",
+        "FILLED_ABSORBED",
+        "AMENDMENT_LEASE_ACQUIRED",
+        "AMENDMENT_LEASE_RELEASED",
+    }
+)
+_POST_UNKNOWN_REASONS = frozenset({"POST_TIMEOUT", "POST_TRANSPORT_ERROR", "POST_RESPONSE_INVALID"})
+_PRE_POST_FAILURE_REASONS = frozenset({"PRE_POST_ABORTED"})
+_TOP_LEVEL_ORDER_FIELDS = frozenset(
+    {
+        "symbol",
+        "quantity",
+        "securityType",
+        "priceType",
+        "orderTerm",
+        "limitPrice",
+        "orderAction",
+        "callPut",
+        "expiryYear",
+        "expiryMonth",
+        "expiryDay",
+        "strikePrice",
+        "spreadType",
+        "legs",
+    }
+)
+_NORMALIZED_TRANSPORT_FIELDS = frozenset({"client_order_id", "orderType", "preview_id", "required_margin"})
+_LEG_FIELDS = frozenset(
+    {
+        "symbol",
+        "callPut",
+        "expiryYear",
+        "expiryMonth",
+        "expiryDay",
+        "strikePrice",
+        "orderAction",
+        "quantity",
+    }
+)
+
+
+class OrderIntentLedgerError(RuntimeError):
+    """Base class for order-intent failures."""
+
+
+class OrderIntentValidationError(OrderIntentLedgerError):
+    """Input is not safe for durable live-order state."""
+
+
+class OrderIntentIntegrityError(OrderIntentLedgerError):
+    """Persisted immutable identity has been tampered with or corrupted."""
+
+
+class OrderIntentTransitionError(OrderIntentLedgerError):
+    """The requested state transition is not allowed."""
+
+
+class OrderIntentLeaseConflict(OrderIntentLedgerError):
+    """Another worker owns the current submission or amendment lease."""
+
+
+class OrderIntentReconciliationRequired(OrderIntentLedgerError):
+    """The account/environment has unfinished broker work to reconcile."""
+
+
+class OrderIntentReservationError(OrderIntentLedgerError):
+    """An opening intent lacks a valid margin reservation or capacity."""
+
+
+@dataclass(frozen=True)
+class OrderIntent:
+    """Immutable identity envelope for one operator/strategy decision.
+
+    ``canonical_payload`` is the durable, allowlisted economic payload.  It
+    excludes all generated transport values; ``prepare_submission_payload`` is
+    the only supported way to produce authorized submission bytes with the
+    stored client order id.
+    """
+
+    account_id: str
+    environment: str
+    strategy_id: str
+    decision_id: str
+    idempotency_scope: str
+    idempotency_key: str
+    intent_kind: Literal["OPENING", "CLOSING"]
+    wire_payload: str
+    canonical_payload: str
+    payload_hash: str
+
+    @classmethod
+    def build(
+        cls,
+        *,
+        account_id: str,
+        environment: str,
+        strategy_id: str,
+        decision_id: str,
+        idempotency_scope: str,
+        idempotency_key: str,
+        intent_kind: Literal["OPENING", "CLOSING"],
+        order_payload: Mapping[str, Any],
+    ) -> "OrderIntent":
+        _validate_identity("account_id", account_id)
+        _validate_environment(environment)
+        _validate_identity("strategy_id", strategy_id)
+        _validate_identity("decision_id", decision_id)
+        _validate_identity("idempotency_scope", idempotency_scope)
+        _validate_identity("idempotency_key", idempotency_key)
+        if type(intent_kind) is not str or intent_kind not in _INTENT_KINDS:
+            raise OrderIntentValidationError("intent_kind must be OPENING or CLOSING")
+        wire_payload = wire_order_payload(normalize_order_payload(order_payload))
+        derived_kind = _derive_intent_kind(json.loads(wire_payload))
+        if intent_kind != derived_kind:
+            raise OrderIntentValidationError("intent_kind must match the exposure derived from order actions")
+        if intent_kind == "CLOSING":
+            raise OrderIntentValidationError(
+                "closing orders require typed position and open-order capacity evidence"
+            )
+        canonical_payload = canonical_order_payload(json.loads(wire_payload))
+        payload_hash = _payload_hash(canonical_payload)
+        return cls(
+            account_id=account_id,
+            environment=environment,
+            strategy_id=strategy_id,
+            decision_id=decision_id,
+            idempotency_scope=idempotency_scope,
+            idempotency_key=idempotency_key,
+            intent_kind=intent_kind,
+            wire_payload=wire_payload,
+            canonical_payload=canonical_payload,
+            payload_hash=payload_hash,
+        )
+
+
+@dataclass(frozen=True)
+class IntentRecord:
+    intent_id: str
+    envelope: OrderIntent
+    client_order_id: str
+    state: str
+    broker_order_id: str | None
+    submission_fence: int
+    submission_lease_owner: str | None
+    submission_lease_expires_at: datetime | None
+    last_reconciled_run: str | None
+    created_at: datetime
+    updated_at: datetime
+
+
+@dataclass(frozen=True)
+class CreateIntentResult:
+    intent: IntentRecord
+    created: bool
+
+
+@dataclass(frozen=True)
+class SubmissionLease:
+    intent_id: str
+    owner: str
+    fencing_token: int
+    expires_at: datetime
+
+
+@dataclass(frozen=True)
+class AmendmentLease:
+    intent_id: str
+    broker_order_id: str
+    client_order_id: str
+    owner: str
+    fencing_token: int
+    expires_at: datetime
+
+
+@dataclass(frozen=True)
+class OutboundAuthorization:
+    """Exact immutable broker-schema bytes approved for one fenced operation.
+
+    The private transport must derive the final E*TRADE request body solely
+    from ``payload_bytes`` plus the broker preview id. It must never reconstruct
+    economic fields from a mutable caller-owned mapping.
+    """
+
+    intent_id: str
+    operation: Literal["SUBMIT", "AMEND"]
+    owner: str
+    fencing_token: int
+    client_order_id: str
+    payload_bytes: bytes
+    payload_digest: str
+
+
+@dataclass(frozen=True)
+class MarginReservation:
+    intent_id: str
+    account_id: str
+    environment: str
+    amount: Decimal
+    risk_decision_id: str
+    max_loss_amount: Decimal
+    quote_observed_at: datetime
+    quote_digest: str
+    portfolio_observed_at: datetime
+    portfolio_snapshot_digest: str
+    state: str
+    released_reason_code: str | None
+    created_at: datetime
+    released_at: datetime | None
+
+
+@dataclass(frozen=True)
+class BrokerEvidence:
+    """Typed, persisted broker evidence; callers cannot supply opaque receipts."""
+
+    account_id: str
+    environment: str
+    client_order_id: str
+    broker_order_id: str
+    operation: Literal["SUBMIT_ACK", "ORDER_QUERY", "AMEND_ACK", "AMEND_QUERY"]
+    outcome: Literal["OPEN", "FILLED", "CANCELLED", "REJECTED", "EXPIRED"]
+    observed_at: datetime
+    http_status: int
+    raw_response_digest: str
+
+    def validate(self, now: datetime) -> None:
+        if type(self) is not BrokerEvidence:
+            raise OrderIntentValidationError("broker evidence must use the exact BrokerEvidence type")
+        if type(self.operation) is not str or type(self.outcome) is not str:
+            raise OrderIntentValidationError("broker evidence operation/outcome must be exact strings")
+        if self.operation not in {"SUBMIT_ACK", "ORDER_QUERY", "AMEND_ACK", "AMEND_QUERY"}:
+            raise OrderIntentValidationError("unsupported broker evidence operation")
+        if self.outcome not in {"OPEN", *_BROKER_TERMINAL_STATUS}:
+            raise OrderIntentValidationError("unsupported broker evidence outcome")
+        _validate_timestamp(self.observed_at)
+        if self.observed_at > now + timedelta(seconds=5) or now - self.observed_at > timedelta(seconds=_EVIDENCE_MAX_AGE_SECONDS):
+            raise OrderIntentValidationError("broker evidence is stale or from the future")
+        _validate_identity("account_id", self.account_id)
+        _validate_identity("environment", self.environment)
+        _validate_identity("client_order_id", self.client_order_id)
+        _validate_identity("broker_order_id", self.broker_order_id)
+        if type(self.http_status) is not int or self.http_status < 200 or self.http_status > 299:
+            raise OrderIntentValidationError("valid broker evidence requires successful 2xx http_status")
+        _validate_sha256("raw_response_digest", self.raw_response_digest)
+
+
+@dataclass(frozen=True)
+class RiskEvidence:
+    decision_id: str
+    max_loss_amount: Decimal
+    collateral_amount: Decimal
+    quote_observed_at: datetime
+    quote_digest: str
+    portfolio_observed_at: datetime
+    portfolio_snapshot_digest: str
+
+    def validate(self, now: datetime) -> None:
+        if type(self) is not RiskEvidence:
+            raise OrderIntentValidationError("risk evidence must use the exact RiskEvidence type")
+        _validate_identity("decision_id", self.decision_id)
+        for name, amount in (("max_loss_amount", self.max_loss_amount), ("collateral_amount", self.collateral_amount)):
+            if type(amount) is not Decimal or not amount.is_finite() or amount <= 0:
+                raise OrderIntentValidationError(f"{name} must be a positive finite Decimal")
+        if self.collateral_amount < self.max_loss_amount:
+            raise OrderIntentValidationError("collateral_amount cannot be less than max_loss_amount")
+        _validate_timestamp(self.quote_observed_at)
+        if self.quote_observed_at > now + timedelta(seconds=5) or now - self.quote_observed_at > timedelta(seconds=_EVIDENCE_MAX_AGE_SECONDS):
+            raise OrderIntentValidationError("risk evidence is stale or from the future")
+        _validate_sha256("quote_digest", self.quote_digest)
+        _validate_timestamp(self.portfolio_observed_at)
+        if self.portfolio_observed_at > now + timedelta(seconds=5) or now - self.portfolio_observed_at > timedelta(seconds=_EVIDENCE_MAX_AGE_SECONDS):
+            raise OrderIntentValidationError("portfolio risk evidence is stale or from the future")
+        _validate_sha256("portfolio_snapshot_digest", self.portfolio_snapshot_digest)
+
+
+@dataclass(frozen=True)
+class AccountCapacityEvidence:
+    """Broker capacity snapshot whose digest covers positions and capacity fields."""
+
+    account_id: str
+    environment: str
+    broker_buying_power: Decimal
+    risk_budget: Decimal
+    observed_at: datetime
+    portfolio_snapshot_digest: str
+
+    def validate(self, now: datetime) -> None:
+        if type(self) is not AccountCapacityEvidence:
+            raise OrderIntentValidationError(
+                "capacity evidence must use the exact AccountCapacityEvidence type"
+            )
+        _validate_identity("account_id", self.account_id)
+        _validate_environment(self.environment)
+        for name, amount in (("broker_buying_power", self.broker_buying_power), ("risk_budget", self.risk_budget)):
+            if type(amount) is not Decimal or not amount.is_finite() or amount < 0:
+                raise OrderIntentValidationError(f"{name} must be a non-negative finite Decimal")
+        _validate_timestamp(self.observed_at)
+        if self.observed_at > now + timedelta(seconds=5) or now - self.observed_at > timedelta(seconds=_EVIDENCE_MAX_AGE_SECONDS):
+            raise OrderIntentValidationError("capacity evidence is stale or from the future")
+        _validate_sha256("portfolio_snapshot_digest", self.portfolio_snapshot_digest)
+
+
+@dataclass(frozen=True)
+class IntentEvent:
+    sequence: int
+    intent_id: str
+    account_id: str
+    environment: str
+    client_order_id: str
+    event_type: str
+    from_state: str | None
+    to_state: str | None
+    actor: str
+    reason_code: str
+    broker_status: str | None
+    broker_order_id: str | None
+    observed_at: datetime | None
+    evidence_operation: str | None
+    http_status: int | None
+    raw_response_digest: str | None
+    created_at: datetime
+
+
+def canonical_order_payload(order_payload: Mapping[str, Any]) -> str:
+    """Validate and canonicalize an allowlisted E*TRADE order payload."""
+    if type(order_payload) is not dict or not order_payload:
+        raise OrderIntentValidationError("order payload must be a non-empty mapping")
+    _validate_mapping_keys(order_payload, _TOP_LEVEL_ORDER_FIELDS, "order payload")
+    if "legs" in order_payload:
+        legs = order_payload["legs"]
+        if type(legs) not in {list, tuple} or len(legs) < 2:
+            raise OrderIntentValidationError("spread order requires at least two legs")
+        for leg in legs:
+            if type(leg) is not dict:
+                raise OrderIntentValidationError("each order leg must be a mapping")
+            _validate_mapping_keys(leg, _LEG_FIELDS, "order leg")
+    payload = _canonical_value(order_payload)
+    return json.dumps(payload, sort_keys=True, separators=(",", ":"), ensure_ascii=True)
+
+
+def normalize_order_payload(order_payload: Mapping[str, Any]) -> dict[str, Any]:
+    """Strip only generated transport/derived fields before immutable intent creation.
+
+    The gateway must call this contract on output from ``generate_option_order``.
+    Any other field that the XML builder would ignore remains an error during
+    strict shape validation rather than silently influencing the intent hash.
+    """
+    if type(order_payload) is not dict:
+        raise OrderIntentValidationError("order payload must be a mapping")
+    return {key: value for key, value in order_payload.items() if key not in _NORMALIZED_TRANSPORT_FIELDS}
+
+
+def wire_order_payload(order_payload: Mapping[str, Any]) -> str:
+    """Return a strict broker-schema payload with primitive JSON values intact."""
+    if type(order_payload) is not dict or not order_payload:
+        raise OrderIntentValidationError("order payload must be a non-empty mapping")
+    _validate_mapping_keys(order_payload, _TOP_LEVEL_ORDER_FIELDS, "order payload")
+    if "legs" in order_payload:
+        legs = order_payload["legs"]
+        if type(legs) not in {list, tuple} or len(legs) < 2:
+            raise OrderIntentValidationError("spread order requires at least two legs")
+        for leg in legs:
+            if type(leg) is not dict:
+                raise OrderIntentValidationError("each order leg must be a mapping")
+            _validate_mapping_keys(leg, _LEG_FIELDS, "order leg")
+    _validate_broker_order_shape(order_payload)
+    return json.dumps(_wire_value(order_payload), sort_keys=True, separators=(",", ":"), ensure_ascii=True)
+
+
+def stable_client_order_id(intent: OrderIntent) -> str:
+    """Create a stable ten-digit id tied to account, environment, and scope."""
+    material = "\x1f".join(
+        (
+            intent.account_id,
+            intent.environment,
+            intent.idempotency_scope,
+            intent.idempotency_key,
+        )
+    ).encode("utf-8")
+    value = int.from_bytes(hashlib.sha256(_CLIENT_ID_DOMAIN + material).digest()[:8], "big")
+    return str(1_000_000_000 + value % 9_000_000_000)
+
+
+def _stable_amendment_client_order_id(intent: sqlite3.Row, idempotency_key: str) -> str:
+    material = "\x1f".join((intent["account_id"], intent["environment"], intent["idempotency_scope"], intent["idempotency_key"], "amend", idempotency_key)).encode("utf-8")
+    value = int.from_bytes(hashlib.sha256(_CLIENT_ID_DOMAIN + material).digest()[:8], "big")
+    return str(1_000_000_000 + value % 9_000_000_000)
+
+
+class OrderIntentLedger:
+    """SQLite state machine that refuses duplicate or unresolved live risk."""
+
+    def __init__(
+        self,
+        path: str | Path,
+        *,
+        clock: Callable[[], datetime] | None = None,
+        run_id: str | None = None,
+    ) -> None:
+        self.path = Path(path)
+        self._clock = clock or (lambda: datetime.now(timezone.utc))
+        self.run_id = run_id or uuid.uuid4().hex
+        _validate_identity("run_id", self.run_id)
+        self._securely_precreate_database()
+        self._initialize_schema()
+
+    def close(self) -> None:
+        """Compatibility no-op; each operation owns a short SQLite connection."""
+
+    def create_intent(self, envelope: OrderIntent, *, intent_id: str | None = None) -> CreateIntentResult:
+        if type(envelope) is not OrderIntent:
+            raise OrderIntentValidationError("create_intent requires an OrderIntent envelope")
+        _validate_envelope(envelope)
+        if envelope.intent_kind == "CLOSING":
+            raise OrderIntentValidationError(
+                "new closing intents require typed position and open-order capacity evidence"
+            )
+        requested_id = intent_id or uuid.uuid4().hex
+        _validate_identity("intent_id", requested_id)
+        client_order_id = stable_client_order_id(envelope)
+        now = self._now_us()
+        with self._transaction() as conn:
+            existing = conn.execute(
+                """
+                SELECT * FROM order_intents
+                WHERE account_id = ? AND environment = ?
+                  AND idempotency_scope = ? AND idempotency_key = ?
+                """,
+                (
+                    envelope.account_id,
+                    envelope.environment,
+                    envelope.idempotency_scope,
+                    envelope.idempotency_key,
+                ),
+            ).fetchone()
+            if existing is not None:
+                record = self._intent_from_row(existing)
+                if record.envelope != envelope:
+                    raise OrderIntentIntegrityError(
+                        "idempotency key is already bound to a different immutable envelope"
+                    )
+                return CreateIntentResult(record, created=False)
+            by_id = conn.execute(
+                "SELECT * FROM order_intents WHERE intent_id = ?", (requested_id,)
+            ).fetchone()
+            if by_id is not None:
+                record = self._intent_from_row(by_id)
+                if record.envelope != envelope:
+                    raise OrderIntentIntegrityError("intent_id is already bound to another envelope")
+                return CreateIntentResult(record, created=False)
+            collision = conn.execute(
+                "SELECT intent_id FROM order_intents WHERE client_order_id = ?", (client_order_id,)
+            ).fetchone()
+            if collision is not None:
+                raise OrderIntentIntegrityError(
+                    "stable client-order-id collision; do not submit ambiguous order intent"
+                )
+            amendment_collision = conn.execute(
+                "SELECT intent_id FROM amendment_leases WHERE client_order_id = ? UNION ALL SELECT intent_id FROM amendment_history WHERE client_order_id = ? LIMIT 1",
+                (client_order_id, client_order_id),
+            ).fetchone()
+            if amendment_collision is not None:
+                raise OrderIntentIntegrityError(
+                    "stable client-order-id collision with an amendment; do not submit ambiguous order intent"
+                )
+            conn.execute(
+                """
+                INSERT INTO order_intents (
+                    intent_id, account_id, environment, strategy_id, decision_id,
+                    idempotency_scope, idempotency_key, intent_kind, wire_payload, canonical_payload,
+                    payload_hash, client_order_id, state, broker_order_id,
+                    submission_fence, submission_lease_owner,
+                    submission_lease_expires_at, last_reconciled_run, created_at, updated_at
+                ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, 'INTENT', NULL, 0, NULL, NULL, NULL, ?, ?)
+                """,
+                (
+                    requested_id,
+                    envelope.account_id,
+                    envelope.environment,
+                    envelope.strategy_id,
+                    envelope.decision_id,
+                    envelope.idempotency_scope,
+                    envelope.idempotency_key,
+                    envelope.intent_kind,
+                    envelope.wire_payload,
+                    envelope.canonical_payload,
+                    envelope.payload_hash,
+                    client_order_id,
+                    now,
+                    now,
+                ),
+            )
+            self._append_event(
+                conn, requested_id, "INTENT_CREATED", None, "INTENT", "system", "INTENT_CREATED", now
+            )
+            return CreateIntentResult(self._intent_from_row(self._require_intent(conn, requested_id)), True)
+
+    def get_intent(self, intent_id: str) -> IntentRecord | None:
+        _validate_identity("intent_id", intent_id)
+        with self._connection() as conn:
+            row = conn.execute("SELECT * FROM order_intents WHERE intent_id = ?", (intent_id,)).fetchone()
+        return self._intent_from_row(row) if row else None
+
+    def set_reservation_cap(self, evidence: AccountCapacityEvidence) -> Decimal:
+        if type(evidence) is not AccountCapacityEvidence:
+            raise OrderIntentValidationError("set_reservation_cap requires typed AccountCapacityEvidence")
+        now = self._now_us()
+        AccountCapacityEvidence.validate(evidence, _from_us(now))
+        cap = _canonical_amount(min(evidence.broker_buying_power, evidence.risk_budget))
+        with self._transaction() as conn:
+            existing = conn.execute("SELECT observed_at FROM reservation_caps WHERE account_id = ? AND environment = ?", (evidence.account_id, evidence.environment)).fetchone()
+            if existing is not None and _to_us(evidence.observed_at) <= int(existing["observed_at"]):
+                raise OrderIntentIntegrityError("capacity evidence must be newer than the persisted account snapshot")
+            conn.execute(
+                """
+                INSERT INTO reservation_caps (account_id, environment, cap_amount, broker_buying_power, risk_budget, observed_at, portfolio_snapshot_digest, updated_at)
+                VALUES (?, ?, ?, ?, ?, ?, ?, ?)
+                ON CONFLICT(account_id, environment) DO UPDATE SET
+                    cap_amount = excluded.cap_amount, broker_buying_power = excluded.broker_buying_power,
+                    risk_budget = excluded.risk_budget, observed_at = excluded.observed_at,
+                    portfolio_snapshot_digest = excluded.portfolio_snapshot_digest, updated_at = excluded.updated_at
+                """,
+                (evidence.account_id, evidence.environment, cap, _canonical_amount(evidence.broker_buying_power), _canonical_amount(evidence.risk_budget), _to_us(evidence.observed_at), evidence.portfolio_snapshot_digest, now),
+            )
+        return Decimal(cap)
+
+    def reserve_margin(self, intent_id: str, evidence: RiskEvidence) -> MarginReservation:
+        _validate_identity("intent_id", intent_id)
+        now = self._now_us()
+        if type(evidence) is not RiskEvidence:
+            raise OrderIntentValidationError("reserve_margin requires typed RiskEvidence")
+        RiskEvidence.validate(evidence, _from_us(now))
+        value = _canonical_amount(evidence.collateral_amount)
+        with self._transaction() as conn:
+            intent = self._require_intent(conn, intent_id)
+            if intent["intent_kind"] != "OPENING" or intent["state"] != "INTENT":
+                raise OrderIntentTransitionError("only a new opening intent may reserve margin")
+            if evidence.decision_id != intent["decision_id"]:
+                raise OrderIntentIntegrityError("risk evidence decision id does not match intent")
+            exposure_floor = _opening_exposure_floor(json.loads(intent["wire_payload"]))
+            if evidence.max_loss_amount < exposure_floor or evidence.collateral_amount < exposure_floor:
+                raise OrderIntentReservationError(
+                    "risk evidence is below the immutable opening exposure floor"
+                )
+            cap = conn.execute(
+                "SELECT cap_amount, observed_at, portfolio_snapshot_digest FROM reservation_caps WHERE account_id = ? AND environment = ?",
+                (intent["account_id"], intent["environment"]),
+            ).fetchone()
+            if cap is None:
+                raise OrderIntentReservationError("opening reservations require an account/environment cap")
+            if (
+                int(cap["observed_at"]) != _to_us(evidence.portfolio_observed_at)
+                or cap["portfolio_snapshot_digest"] != evidence.portfolio_snapshot_digest
+            ):
+                raise OrderIntentIntegrityError(
+                    "reservation risk evidence must use the exact portfolio snapshot that set its capacity cap"
+                )
+            existing = conn.execute(
+                "SELECT * FROM margin_reservations WHERE intent_id = ?", (intent_id,)
+            ).fetchone()
+            if existing is not None:
+                reservation = self._reservation_from_row(existing)
+                if reservation.state == "ACTIVE" and (
+                    reservation.amount == Decimal(value) and reservation.risk_decision_id == evidence.decision_id
+                    and reservation.max_loss_amount == evidence.max_loss_amount and reservation.quote_observed_at == evidence.quote_observed_at
+                    and reservation.quote_digest == evidence.quote_digest and reservation.portfolio_observed_at == evidence.portfolio_observed_at
+                    and reservation.portfolio_snapshot_digest == evidence.portfolio_snapshot_digest
+                ):
+                    return reservation
+                raise OrderIntentTransitionError("reservation already exists and is immutable")
+            active = self._active_reservation_total(conn, intent["account_id"], intent["environment"])
+            with localcontext() as decimal_context:
+                decimal_context.prec = _DECIMAL_PRECISION
+                exceeds_cap = active + Decimal(value) > Decimal(cap["cap_amount"])
+            if exceeds_cap:
+                raise OrderIntentReservationError("margin reservation exceeds account/environment cap")
+            conn.execute(
+                """
+                INSERT INTO margin_reservations (
+                    intent_id, account_id, environment, amount, risk_decision_id, max_loss_amount,
+                    quote_observed_at, quote_digest, portfolio_observed_at, portfolio_snapshot_digest, state, released_reason_code, created_at, released_at
+                ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, 'ACTIVE', NULL, ?, NULL)
+                """,
+                (intent_id, intent["account_id"], intent["environment"], value, evidence.decision_id, _canonical_amount(evidence.max_loss_amount), _to_us(evidence.quote_observed_at), evidence.quote_digest, _to_us(evidence.portfolio_observed_at), evidence.portfolio_snapshot_digest, now),
+            )
+            self._append_event(conn, intent_id, "RESERVATION_CREATED", "INTENT", "INTENT", "system", "RESERVATION_CREATED", now)
+            return self._reservation_from_row(
+                conn.execute("SELECT * FROM margin_reservations WHERE intent_id = ?", (intent_id,)).fetchone()
+            )
+
+    def get_margin_reservation(self, intent_id: str) -> MarginReservation | None:
+        _validate_identity("intent_id", intent_id)
+        with self._connection() as conn:
+            row = conn.execute("SELECT * FROM margin_reservations WHERE intent_id = ?", (intent_id,)).fetchone()
+        return self._reservation_from_row(row) if row else None
+
+    def active_reserved_margin(self, account_id: str, environment: str) -> Decimal:
+        _validate_identity("account_id", account_id)
+        _validate_identity("environment", environment)
+        with self._connection() as conn:
+            return self._active_reservation_total(conn, account_id, environment)
+
+    def claim_submission(self, intent_id: str, owner: str, *, lease_seconds: float) -> SubmissionLease:
+        _validate_identity("intent_id", intent_id)
+        _validate_identity("owner", owner)
+        now = self._now_us()
+        expires_at = self._lease_expiry_us(lease_seconds, now)
+        lease: SubmissionLease | None = None
+        failure: Exception | None = None
+        with self._transaction() as conn:
+            intent = self._require_intent(conn, intent_id)
+            self._expire_claimed_leases(conn, intent["account_id"], intent["environment"], now)
+            self._expire_amendment_leases(conn, intent["account_id"], intent["environment"], now)
+            intent = self._require_intent(conn, intent_id)
+            if intent["state"] != "INTENT":
+                if intent["state"] in _BROKER_LIVE_STATES:
+                    failure = OrderIntentReconciliationRequired(
+                        f"intent {intent_id} is no longer safe to submit without reconciliation"
+                    )
+                else:
+                    failure = OrderIntentTransitionError(f"cannot claim submission from {intent['state']}")
+            elif intent["intent_kind"] == "CLOSING":
+                failure = OrderIntentReservationError(
+                    "closing submission requires typed position and open-order capacity evidence"
+                )
+            elif self._blocker_rows(conn, intent["account_id"], intent["environment"]) or self._amendment_blocker_rows(conn, intent["account_id"], intent["environment"]):
+                failure = OrderIntentReconciliationRequired("account/environment has unresolved broker intents")
+            else:
+                if intent["intent_kind"] == "OPENING":
+                    self._require_active_opening_reservation(conn, intent, now)
+                fence = int(intent["submission_fence"]) + 1
+                conn.execute(
+                    """
+                    UPDATE order_intents
+                    SET state = 'CLAIMED', submission_fence = ?, submission_lease_owner = ?,
+                        submission_lease_expires_at = ?, last_reconciled_run = NULL, updated_at = ?
+                    WHERE intent_id = ?
+                    """,
+                    (fence, owner, expires_at, now, intent_id),
+                )
+                self._append_event(conn, intent_id, "SUBMISSION_CLAIMED", "INTENT", "CLAIMED", owner, "SUBMISSION_CLAIMED", now)
+                lease = SubmissionLease(intent_id, owner, fence, _from_us(expires_at))
+        if failure is not None:
+            raise failure
+        assert lease is not None
+        return lease
+
+    def renew_submission_lease(
+        self, intent_id: str, owner: str, fencing_token: int, *, lease_seconds: float
+    ) -> SubmissionLease:
+        _validate_identity("intent_id", intent_id)
+        _validate_identity("owner", owner)
+        _validate_fencing_token(fencing_token)
+        now = self._now_us()
+        expires_at = self._lease_expiry_us(lease_seconds, now)
+        lease: SubmissionLease | None = None
+        expired = False
+        with self._transaction() as conn:
+            intent = self._require_intent(conn, intent_id)
+            if intent["intent_kind"] == "CLOSING":
+                raise OrderIntentReservationError(
+                    "closing submission renewal requires typed position and open-order capacity evidence"
+                )
+            if self._claim_expired(intent, now):
+                self._mark_claim_in_doubt(conn, intent, now)
+                expired = True
+            else:
+                self._require_submission_fence(intent, owner, fencing_token)
+                if intent["intent_kind"] == "OPENING":
+                    self._require_active_opening_reservation(conn, intent, now)
+                if self._amendment_blocker_rows(conn, intent["account_id"], intent["environment"]):
+                    raise OrderIntentReconciliationRequired("account/environment has an unresolved amendment")
+                conn.execute(
+                    "UPDATE order_intents SET submission_lease_expires_at = ?, updated_at = ? WHERE intent_id = ?",
+                    (expires_at, now, intent_id),
+                )
+                self._append_event(conn, intent_id, "LEASE_RENEWED", "CLAIMED", "CLAIMED", owner, "LEASE_RENEWED", now)
+                lease = SubmissionLease(intent_id, owner, fencing_token, _from_us(expires_at))
+        if expired:
+            raise OrderIntentReconciliationRequired("expired claimed lease is in-doubt and cannot be renewed")
+        assert lease is not None
+        return lease
+
+    def prepare_submission_payload(self, intent_id: str, owner: str, fencing_token: int) -> OutboundAuthorization:
+        """Return immutable, exact bytes authorized for the fenced submission."""
+        _validate_identity("intent_id", intent_id)
+        _validate_identity("owner", owner)
+        _validate_fencing_token(fencing_token)
+        now = self._now_us()
+        authorization: OutboundAuthorization | None = None
+        expired = False
+        with self._transaction() as conn:
+            intent = self._require_intent(conn, intent_id)
+            if intent["intent_kind"] == "CLOSING":
+                raise OrderIntentReservationError(
+                    "closing payload preparation requires typed position and open-order capacity evidence"
+                )
+            if self._claim_expired(intent, now):
+                self._mark_claim_in_doubt(conn, intent, now)
+                expired = True
+            else:
+                self._require_submission_fence(intent, owner, fencing_token)
+                record = self._intent_from_row(intent)
+                payload = json.loads(record.envelope.wire_payload)
+                if not isinstance(payload, dict):
+                    raise OrderIntentIntegrityError("stored wire payload is not an object")
+                if canonical_order_payload(payload) != record.envelope.canonical_payload:
+                    raise OrderIntentIntegrityError("stored wire payload no longer matches canonical payload")
+                payload["client_order_id"] = record.client_order_id
+                authorization = _outbound_authorization(
+                    intent_id=intent_id,
+                    operation="SUBMIT",
+                    owner=owner,
+                    fencing_token=fencing_token,
+                    client_order_id=record.client_order_id,
+                    payload=payload,
+                )
+        if expired:
+            raise OrderIntentReconciliationRequired("expired claimed lease is in-doubt; do not POST")
+        assert authorization is not None
+        return authorization
+
+    def begin_submission(
+        self, intent_id: str, owner: str, fencing_token: int, authorization: OutboundAuthorization
+    ) -> IntentRecord:
+        """Durably authorize exact bytes and enter in-doubt state before POST."""
+        _validate_identity("intent_id", intent_id)
+        _validate_identity("owner", owner)
+        _validate_fencing_token(fencing_token)
+        now = self._now_us()
+        record: IntentRecord | None = None
+        expired = False
+        with self._transaction() as conn:
+            intent = self._require_intent(conn, intent_id)
+            if intent["intent_kind"] == "CLOSING":
+                raise OrderIntentReservationError(
+                    "closing submission requires typed position and open-order capacity evidence"
+                )
+            if self._claim_expired(intent, now):
+                self._mark_claim_in_doubt(conn, intent, now)
+                expired = True
+            else:
+                self._require_submission_fence(intent, owner, fencing_token)
+                record = self._intent_from_row(intent)
+                payload = json.loads(record.envelope.wire_payload)
+                if not isinstance(payload, dict):
+                    raise OrderIntentIntegrityError("stored wire payload is not an object")
+                payload["client_order_id"] = record.client_order_id
+                validated_authorization = self._require_outbound_authorization(
+                    authorization,
+                    intent_id=intent_id,
+                    operation="SUBMIT",
+                    owner=owner,
+                    fencing_token=fencing_token,
+                    client_order_id=record.client_order_id,
+                    payload=payload,
+                )
+                if intent["intent_kind"] == "OPENING":
+                    self._require_active_opening_reservation(conn, intent, now)
+                if self._amendment_blocker_rows(conn, intent["account_id"], intent["environment"]):
+                    raise OrderIntentReconciliationRequired("account/environment has an unresolved amendment")
+                self._record_outbound_authorization(conn, validated_authorization, now)
+                conn.execute(
+                    """
+                    UPDATE order_intents
+                    SET state = 'SUBMISSION_UNKNOWN', submission_lease_owner = NULL,
+                        submission_lease_expires_at = NULL, pending_operation = 'SUBMIT',
+                        pending_owner = ?, pending_fence = ?, last_reconciled_run = NULL, updated_at = ?
+                    WHERE intent_id = ?
+                    """,
+                    (owner, fencing_token, now, intent_id),
+                )
+                self._append_event(conn, intent_id, "POST_STARTED", "CLAIMED", "SUBMISSION_UNKNOWN", owner, "POST_STARTED", now)
+                record = self._intent_from_row(self._require_intent(conn, intent_id))
+        if expired:
+            raise OrderIntentReconciliationRequired("expired claimed lease is in-doubt; do not POST")
+        assert record is not None
+        return record
+
+    def record_post_acknowledgement(self, intent_id: str, owner: str, fencing_token: int, evidence: BrokerEvidence) -> IntentRecord:
+        """Persist a definitive response to the just-started POST, without a retry."""
+        _validate_identity("intent_id", intent_id)
+        _validate_identity("owner", owner)
+        _validate_fencing_token(fencing_token)
+        now = self._now_us()
+        if type(evidence) is not BrokerEvidence:
+            raise OrderIntentValidationError("broker acknowledgement requires exact BrokerEvidence")
+        BrokerEvidence.validate(evidence, _from_us(now))
+        with self._transaction() as conn:
+            intent = self._require_intent(conn, intent_id)
+            self._validate_broker_evidence(conn, intent, evidence, allowed_operations={"SUBMIT_ACK"}, allowed_outcomes={"OPEN"})
+            if intent["state"] != "SUBMISSION_UNKNOWN" or intent["pending_operation"] != "SUBMIT" or intent["pending_owner"] != owner or int(intent["pending_fence"] or -1) != fencing_token:
+                raise OrderIntentTransitionError("broker acknowledgement requires SUBMISSION_UNKNOWN")
+            if evidence.http_status != 200:
+                raise OrderIntentValidationError("definitive submit acknowledgement requires HTTP 200")
+            self._bind_broker_order_history(conn, evidence.broker_order_id, intent_id, now)
+            conn.execute(
+                """
+                UPDATE order_intents
+                SET state = 'SUBMITTED', broker_order_id = ?, pending_operation = NULL, pending_owner = NULL,
+                    pending_fence = NULL, last_reconciled_run = ?, updated_at = ?
+                WHERE intent_id = ?
+                """,
+                (evidence.broker_order_id, self.run_id, now, intent_id),
+            )
+            self._append_reconciliation_event(conn, intent_id, "SUBMISSION_UNKNOWN", "SUBMITTED", "POST_ACKNOWLEDGED", "POST_ACKNOWLEDGED", evidence, now)
+            return self._intent_from_row(self._require_intent(conn, intent_id))
+
+    def record_post_unknown(self, intent_id: str, owner: str, fencing_token: int, reason_code: str) -> IntentRecord:
+        """Append the precise failed POST outcome; state remains reconciliation-only."""
+        _validate_identity("intent_id", intent_id)
+        _validate_identity("owner", owner)
+        _validate_fencing_token(fencing_token)
+        if type(reason_code) is not str or reason_code not in _POST_UNKNOWN_REASONS:
+            raise OrderIntentValidationError("reason_code must be an allowlisted ambiguous POST failure")
+        now = self._now_us()
+        with self._transaction() as conn:
+            intent = self._require_intent(conn, intent_id)
+            if intent["state"] != "SUBMISSION_UNKNOWN" or intent["pending_operation"] != "SUBMIT" or intent["pending_owner"] != owner or int(intent["pending_fence"] or -1) != fencing_token:
+                raise OrderIntentTransitionError("ambiguous POST result requires SUBMISSION_UNKNOWN")
+            self._append_event(conn, intent_id, "POST_UNKNOWN", "SUBMISSION_UNKNOWN", "SUBMISSION_UNKNOWN", "broker-post", reason_code, now)
+            return self._intent_from_row(intent)
+
+    def mark_pre_post_failed(self, intent_id: str, owner: str, fencing_token: int, reason_code: str = "PRE_POST_ABORTED") -> IntentRecord:
+        """Fail only before POST; after ``begin_submission`` this operation is forbidden."""
+        _validate_identity("intent_id", intent_id)
+        _validate_identity("owner", owner)
+        _validate_fencing_token(fencing_token)
+        if type(reason_code) is not str or reason_code not in _PRE_POST_FAILURE_REASONS:
+            raise OrderIntentValidationError("reason_code must be an allowlisted pre-POST failure")
+        now = self._now_us()
+        record: IntentRecord | None = None
+        expired = False
+        with self._transaction() as conn:
+            intent = self._require_intent(conn, intent_id)
+            if self._claim_expired(intent, now):
+                self._mark_claim_in_doubt(conn, intent, now)
+                expired = True
+            else:
+                self._require_submission_fence(intent, owner, fencing_token)
+                conn.execute(
+                    """
+                    UPDATE order_intents
+                    SET state = 'FAILED', submission_lease_owner = NULL, submission_lease_expires_at = NULL,
+                        last_reconciled_run = ?, updated_at = ? WHERE intent_id = ?
+                    """,
+                    (self.run_id, now, intent_id),
+                )
+                self._release_reservation(conn, intent_id, "PRE_POST_ABORTED", now)
+                self._append_event(conn, intent_id, "PRE_POST_FAILED", "CLAIMED", "FAILED", owner, reason_code, now)
+                record = self._intent_from_row(self._require_intent(conn, intent_id))
+        if expired:
+            raise OrderIntentReconciliationRequired("expired claim may have posted; it cannot be FAILED")
+        assert record is not None
+        return record
+
+    def reconcile_open(self, intent_id: str, evidence: BrokerEvidence) -> IntentRecord:
+        now = self._now_us()
+        if type(evidence) is not BrokerEvidence:
+            raise OrderIntentValidationError("open reconciliation requires exact BrokerEvidence")
+        BrokerEvidence.validate(evidence, _from_us(now))
+        if evidence.outcome != "OPEN" or evidence.operation not in {"ORDER_QUERY", "AMEND_QUERY"}:
+            raise OrderIntentValidationError("open reconciliation requires status OPEN")
+        with self._transaction() as conn:
+            intent = self._require_intent(conn, intent_id)
+            if intent["state"] == "SUBMISSION_UNKNOWN":
+                self._validate_broker_evidence(conn, intent, evidence, allowed_operations={"ORDER_QUERY"}, allowed_outcomes={"OPEN"})
+            elif intent["state"] == "SUBMITTED" and intent["pending_operation"] == "AMEND":
+                self._validate_broker_evidence(conn, intent, evidence, allowed_operations={"AMEND_QUERY"}, allowed_outcomes={"OPEN"})
+            else:
+                raise OrderIntentTransitionError("open reconciliation must match the pending submission or amendment operation")
+            amendment = conn.execute("SELECT * FROM amendment_leases WHERE intent_id = ?", (intent_id,)).fetchone()
+            self._bind_broker_order_history(conn, evidence.broker_order_id, intent_id, now)
+            conn.execute(
+                """
+                UPDATE order_intents
+                SET state = 'SUBMITTED', broker_order_id = ?, pending_operation = NULL, pending_owner = NULL,
+                    pending_fence = NULL, last_reconciled_run = ?, updated_at = ?
+                WHERE intent_id = ?
+                """,
+                (evidence.broker_order_id, self.run_id, now, intent_id),
+            )
+            if intent["pending_operation"] == "AMEND":
+                if amendment is None:
+                    raise OrderIntentIntegrityError("pending amendment is missing its durable operation")
+                self._archive_amendment(conn, amendment, "RECONCILED_OPEN", now)
+            conn.execute("DELETE FROM amendment_leases WHERE intent_id = ?", (intent_id,))
+            self._append_reconciliation_event(conn, intent_id, intent["state"], "SUBMITTED", "BROKER_OPEN_RECONCILED", "BROKER_OPEN_RECONCILED", evidence, now)
+            return self._intent_from_row(self._require_intent(conn, intent_id))
+
+    def reconcile_terminal(
+        self, intent_id: str, terminal_state: Literal["FILLED", "CANCELLED", "REJECTED", "EXPIRED"], evidence: BrokerEvidence
+    ) -> IntentRecord:
+        now = self._now_us()
+        if type(evidence) is not BrokerEvidence:
+            raise OrderIntentValidationError("terminal reconciliation requires exact BrokerEvidence")
+        BrokerEvidence.validate(evidence, _from_us(now))
+        if type(terminal_state) is not str or terminal_state not in _BROKER_TERMINAL_STATUS or evidence.outcome != _BROKER_TERMINAL_STATUS[terminal_state] or evidence.operation not in {"ORDER_QUERY", "AMEND_QUERY"}:
+            raise OrderIntentValidationError("terminal state must match attested broker status")
+        reason_code = f"BROKER_{terminal_state}"
+        with self._transaction() as conn:
+            intent = self._require_intent(conn, intent_id)
+            if intent["state"] not in {"SUBMISSION_UNKNOWN", "SUBMITTED"}:
+                raise OrderIntentTransitionError("terminal broker reconciliation requires unknown or submitted intent")
+            if intent["state"] == "SUBMISSION_UNKNOWN":
+                self._validate_broker_evidence(conn, intent, evidence, allowed_operations={"ORDER_QUERY"}, allowed_outcomes={evidence.outcome})
+            elif intent["pending_operation"] == "AMEND":
+                self._validate_broker_evidence(conn, intent, evidence, allowed_operations={"AMEND_QUERY"}, allowed_outcomes={evidence.outcome})
+            elif intent["pending_operation"] is None:
+                self._validate_broker_evidence(conn, intent, evidence, allowed_operations={"ORDER_QUERY"}, allowed_outcomes={evidence.outcome})
+            else:
+                raise OrderIntentTransitionError("terminal reconciliation does not match pending operation")
+            existing_id = intent["broker_order_id"]
+            if existing_id is not None and existing_id != evidence.broker_order_id and intent["pending_operation"] != "AMEND":
+                raise OrderIntentIntegrityError("attestation broker order id conflicts with durable intent")
+            amendment = conn.execute("SELECT * FROM amendment_leases WHERE intent_id = ?", (intent_id,)).fetchone()
+            self._bind_broker_order_history(conn, evidence.broker_order_id, intent_id, now)
+            conn.execute(
+                """
+                UPDATE order_intents
+                SET state = ?, broker_order_id = ?, submission_lease_owner = NULL,
+                    submission_lease_expires_at = NULL, pending_operation = NULL, pending_owner = NULL,
+                    pending_fence = NULL, last_reconciled_run = ?, updated_at = ?
+                WHERE intent_id = ?
+                """,
+                (terminal_state, evidence.broker_order_id, self.run_id, now, intent_id),
+            )
+            if intent["intent_kind"] == "OPENING":
+                conn.execute("UPDATE margin_reservations SET state = 'FILLED_PENDING_ABSORPTION' WHERE intent_id = ? AND state = 'ACTIVE'", (intent_id,))
+            else:
+                self._release_reservation(conn, intent_id, reason_code, now)
+            if intent["pending_operation"] == "AMEND":
+                if amendment is None:
+                    raise OrderIntentIntegrityError("pending amendment is missing its durable operation")
+                self._archive_amendment(conn, amendment, "TERMINAL", now)
+            conn.execute("DELETE FROM amendment_leases WHERE intent_id = ?", (intent_id,))
+            self._append_reconciliation_event(conn, intent_id, intent["state"], terminal_state, "BROKER_TERMINAL_RECONCILED", reason_code, evidence, now)
+            return self._intent_from_row(self._require_intent(conn, intent_id))
+
+    def absorb_filled_reservation(
+        self, intent_id: str, evidence: AccountCapacityEvidence
+    ) -> MarginReservation:
+        """Fail closed until R7b can prove a terminal order's position effect.
+
+        A newer or merely different account digest cannot prove that the
+        snapshot incorporated this specific order, especially after a partial
+        fill. Keeping the reservation blocks new exposure without guessing.
+        """
+        _validate_identity("intent_id", intent_id)
+        if type(evidence) is not AccountCapacityEvidence:
+            raise OrderIntentValidationError("absorb_filled_reservation requires typed AccountCapacityEvidence")
+        AccountCapacityEvidence.validate(evidence, _from_us(self._now_us()))
+        raise OrderIntentReconciliationRequired(
+            "terminal reservations require R7b position-level absorption evidence"
+        )
+
+    def reconciliation_blockers(self, account_id: str, environment: str) -> tuple[IntentRecord, ...]:
+        _validate_identity("account_id", account_id)
+        _validate_identity("environment", environment)
+        now = self._now_us()
+        with self._transaction() as conn:
+            self._expire_claimed_leases(conn, account_id, environment, now)
+            self._expire_amendment_leases(conn, account_id, environment, now)
+            rows = self._blocker_rows(conn, account_id, environment)
+            return tuple(self._intent_from_row(row) for row in rows)
+
+    def mark_reconciled(self, intent_id: str, evidence: BrokerEvidence) -> IntentRecord:
+        """Acknowledge that a known submitted order was observed OPEN this run."""
+        now = self._now_us()
+        if type(evidence) is not BrokerEvidence:
+            raise OrderIntentValidationError("submitted reconciliation requires exact BrokerEvidence")
+        BrokerEvidence.validate(evidence, _from_us(now))
+        if evidence.outcome != "OPEN" or evidence.operation not in {"ORDER_QUERY", "AMEND_QUERY"}:
+            raise OrderIntentValidationError("submitted acknowledgement requires OPEN attestation")
+        with self._transaction() as conn:
+            intent = self._require_intent(conn, intent_id)
+            self._validate_broker_evidence(conn, intent, evidence, allowed_operations={"ORDER_QUERY", "AMEND_QUERY"}, allowed_outcomes={"OPEN"})
+            if intent["pending_operation"] is not None:
+                raise OrderIntentTransitionError("pending submission or amendment must resolve through its matching operation")
+            if intent["state"] != "SUBMITTED" or intent["broker_order_id"] != evidence.broker_order_id:
+                raise OrderIntentIntegrityError("attestation does not match a submitted durable order")
+            conn.execute("UPDATE order_intents SET last_reconciled_run = ?, updated_at = ? WHERE intent_id = ?", (self.run_id, now, intent_id))
+            self._append_reconciliation_event(conn, intent_id, "SUBMITTED", "SUBMITTED", "BROKER_OPEN_RECONCILED", "BROKER_OPEN_RECONCILED", evidence, now)
+            return self._intent_from_row(self._require_intent(conn, intent_id))
+
+    def acquire_amendment_lease(self, intent_id: str, owner: str, *, lease_seconds: float, idempotency_key: str, amendment_payload: Mapping[str, Any]) -> AmendmentLease:
+        _validate_identity("intent_id", intent_id)
+        _validate_identity("owner", owner)
+        _validate_identity("amendment_idempotency_key", idempotency_key)
+        amendment_wire_payload = wire_order_payload(normalize_order_payload(amendment_payload))
+        amendment_canonical_payload = canonical_order_payload(json.loads(amendment_wire_payload))
+        amendment_payload_hash = _payload_hash(amendment_canonical_payload)
+        now = self._now_us()
+        expires_at = self._lease_expiry_us(lease_seconds, now)
+        lease: AmendmentLease | None = None
+        failure: Exception | None = None
+        with self._transaction() as conn:
+            intent = self._require_intent(conn, intent_id)
+            self._expire_claimed_leases(conn, intent["account_id"], intent["environment"], now)
+            self._expire_amendment_leases(conn, intent["account_id"], intent["environment"], now)
+            if self._blocker_rows(conn, intent["account_id"], intent["environment"], exclude_intent_id=intent_id) or self._amendment_blocker_rows(conn, intent["account_id"], intent["environment"], exclude_intent_id=intent_id):
+                failure = OrderIntentReconciliationRequired("account/environment has unresolved broker intents")
+            else:
+                intent = self._require_intent(conn, intent_id)
+                if intent["intent_kind"] == "CLOSING":
+                    failure = OrderIntentReservationError(
+                        "closing amendment requires typed position and open-order capacity evidence"
+                    )
+                elif intent["state"] != "SUBMITTED" or not intent["broker_order_id"] or intent["last_reconciled_run"] != self.run_id:
+                    failure = OrderIntentReconciliationRequired("amendment needs a current reconciled submitted broker order")
+                else:
+                    _validate_reprice_only_amendment(intent["wire_payload"], amendment_wire_payload)
+                    if intent["intent_kind"] == "OPENING":
+                        self._require_opening_amendment_reservation(conn, intent, amendment_wire_payload, now)
+                    completed = conn.execute(
+                        "SELECT * FROM amendment_history WHERE intent_id = ? AND idempotency_key = ?",
+                        (intent_id, idempotency_key),
+                    ).fetchone()
+                    if completed is not None:
+                        if (
+                            completed["canonical_payload"] != amendment_canonical_payload
+                            or completed["payload_hash"] != amendment_payload_hash
+                        ):
+                            failure = OrderIntentIntegrityError(
+                                "completed amendment idempotency key cannot be rebound to another payload"
+                            )
+                        else:
+                            failure = OrderIntentTransitionError(
+                                "completed amendment idempotency key cannot be posted again"
+                            )
+                    else:
+                        existing = conn.execute("SELECT * FROM amendment_leases WHERE intent_id = ?", (intent_id,)).fetchone()
+                        if existing is not None and existing["owner"] != owner and int(existing["expires_at"]) > now:
+                            failure = OrderIntentLeaseConflict("another worker owns the amendment lease")
+                        else:
+                            if existing is not None and (existing["idempotency_key"] != idempotency_key or existing["canonical_payload"] != amendment_canonical_payload or existing["broker_order_id"] != intent["broker_order_id"]):
+                                failure = OrderIntentIntegrityError("amendment retry must use the same target, idempotency key, and payload")
+                            if failure is not None:
+                                pass
+                            else:
+                                amendment_fence = int(intent["amendment_fence"]) + 1
+                                amendment_client_id = _stable_amendment_client_order_id(intent, idempotency_key)
+                                self._ensure_amendment_client_id_is_unambiguous(conn, amendment_client_id, intent_id, idempotency_key)
+                                conn.execute(
+                                    "UPDATE order_intents SET amendment_fence = ?, updated_at = ? WHERE intent_id = ?",
+                                    (amendment_fence, now, intent_id),
+                                )
+                                conn.execute(
+                                    """
+                                    INSERT INTO amendment_leases (intent_id, broker_order_id, client_order_id, idempotency_key, wire_payload, canonical_payload, payload_hash, owner, fencing_token, state, expires_at, updated_at)
+                                    VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, 'LEASED', ?, ?)
+                                    ON CONFLICT(intent_id) DO UPDATE SET owner = excluded.owner, fencing_token = excluded.fencing_token, state = 'LEASED', expires_at = excluded.expires_at, updated_at = excluded.updated_at
+                                    """,
+                                    (intent_id, intent["broker_order_id"], amendment_client_id, idempotency_key, amendment_wire_payload, amendment_canonical_payload, amendment_payload_hash, owner, amendment_fence, expires_at, now),
+                                )
+                                self._append_event(conn, intent_id, "AMENDMENT_LEASE_ACQUIRED", "SUBMITTED", "SUBMITTED", owner, "AMENDMENT_LEASE_ACQUIRED", now, broker_order_id=intent["broker_order_id"])
+                                lease = AmendmentLease(intent_id, intent["broker_order_id"], amendment_client_id, owner, amendment_fence, _from_us(expires_at))
+        if failure is not None:
+            raise failure
+        assert lease is not None
+        return lease
+
+    def release_amendment_lease(self, intent_id: str, owner: str, fencing_token: int) -> None:
+        _validate_identity("intent_id", intent_id)
+        _validate_identity("owner", owner)
+        _validate_fencing_token(fencing_token)
+        now = self._now_us()
+        payload: dict[str, Any] | None = None
+        expired = False
+        with self._transaction() as conn:
+            existing = conn.execute("SELECT * FROM amendment_leases WHERE intent_id = ?", (intent_id,)).fetchone()
+            if existing is None:
+                return
+            if existing["owner"] != owner or int(existing["fencing_token"]) != fencing_token:
+                raise OrderIntentLeaseConflict("amendment lease owner or fencing token does not match")
+            if existing["state"] != "LEASED":
+                raise OrderIntentReconciliationRequired("an in-doubt amendment must be reconciled, not released")
+            conn.execute("DELETE FROM amendment_leases WHERE intent_id = ?", (intent_id,))
+            intent = self._require_intent(conn, intent_id)
+            self._append_event(conn, intent_id, "AMENDMENT_LEASE_RELEASED", "SUBMITTED", "SUBMITTED", owner, "AMENDMENT_LEASE_RELEASED", now, broker_order_id=intent["broker_order_id"])
+
+    def begin_amendment(
+        self, intent_id: str, owner: str, fencing_token: int, authorization: OutboundAuthorization
+    ) -> AmendmentLease:
+        """Durably authorize exact bytes before the broker change-order POST."""
+        _validate_identity("intent_id", intent_id)
+        _validate_identity("owner", owner)
+        _validate_fencing_token(fencing_token)
+        now = self._now_us()
+        lease: AmendmentLease | None = None
+        expired = False
+        with self._transaction() as conn:
+            intent = self._require_intent(conn, intent_id)
+            amendment = conn.execute("SELECT * FROM amendment_leases WHERE intent_id = ?", (intent_id,)).fetchone()
+            if intent["intent_kind"] == "CLOSING":
+                raise OrderIntentReservationError(
+                    "closing amendment requires typed position and open-order capacity evidence"
+                )
+            if amendment is None or amendment["state"] != "LEASED" or amendment["owner"] != owner or int(amendment["fencing_token"]) != fencing_token:
+                raise OrderIntentLeaseConflict("amendment owner or fencing token does not match")
+            if int(amendment["expires_at"]) <= now:
+                self._mark_amendment_in_doubt(conn, intent, amendment, now)
+                expired = True
+            else:
+                payload = json.loads(amendment["wire_payload"])
+                if not isinstance(payload, dict):
+                    raise OrderIntentIntegrityError("stored amendment wire payload is not an object")
+                payload["client_order_id"] = amendment["client_order_id"]
+                validated_authorization = self._require_outbound_authorization(
+                    authorization,
+                    intent_id=intent_id,
+                    operation="AMEND",
+                    owner=owner,
+                    fencing_token=fencing_token,
+                    client_order_id=amendment["client_order_id"],
+                    payload=payload,
+                )
+                if self._blocker_rows(conn, intent["account_id"], intent["environment"], exclude_intent_id=intent_id) or self._amendment_blocker_rows(conn, intent["account_id"], intent["environment"], exclude_intent_id=intent_id):
+                    raise OrderIntentReconciliationRequired("account/environment has unresolved broker work")
+                if intent["intent_kind"] == "OPENING":
+                    self._require_opening_amendment_reservation(conn, intent, amendment["wire_payload"], now)
+                self._record_outbound_authorization(conn, validated_authorization, now)
+                conn.execute("UPDATE amendment_leases SET state = 'IN_DOUBT', updated_at = ? WHERE intent_id = ?", (now, intent_id))
+                conn.execute("UPDATE order_intents SET pending_operation = 'AMEND', pending_owner = ?, pending_fence = ?, last_reconciled_run = NULL, updated_at = ? WHERE intent_id = ?", (owner, fencing_token, now, intent_id))
+                self._append_event(conn, intent_id, "AMENDMENT_STARTED", "SUBMITTED", "SUBMITTED", owner, "POST_STARTED", now, broker_order_id=intent["broker_order_id"])
+                lease = AmendmentLease(intent_id, amendment["broker_order_id"], amendment["client_order_id"], owner, fencing_token, _from_us(amendment["expires_at"]))
+        if expired:
+            raise OrderIntentReconciliationRequired("expired amendment lease is in-doubt and cannot be reissued")
+        assert lease is not None
+        return lease
+
+    def prepare_amendment_payload(self, intent_id: str, owner: str, fencing_token: int) -> OutboundAuthorization:
+        """Return immutable, exact bytes authorized for the fenced amendment."""
+        _validate_identity("intent_id", intent_id)
+        _validate_identity("owner", owner)
+        _validate_fencing_token(fencing_token)
+        now = self._now_us()
+        authorization: OutboundAuthorization | None = None
+        expired = False
+        with self._transaction() as conn:
+            intent = self._require_intent(conn, intent_id)
+            if intent["intent_kind"] == "CLOSING":
+                raise OrderIntentReservationError(
+                    "closing amendment payload requires typed position and open-order capacity evidence"
+                )
+            amendment = conn.execute("SELECT * FROM amendment_leases WHERE intent_id = ?", (intent_id,)).fetchone()
+            if amendment is None or amendment["state"] != "LEASED" or amendment["owner"] != owner or int(amendment["fencing_token"]) != fencing_token:
+                raise OrderIntentLeaseConflict("amendment payload is not leased by this fenced owner")
+            if int(amendment["expires_at"]) <= now:
+                intent = self._require_intent(conn, intent_id)
+                self._mark_amendment_in_doubt(conn, intent, amendment, now)
+                expired = True
+            else:
+                payload = json.loads(amendment["wire_payload"])
+                if wire_order_payload(payload) != amendment["wire_payload"] or canonical_order_payload(payload) != amendment["canonical_payload"] or _payload_hash(amendment["canonical_payload"]) != amendment["payload_hash"]:
+                    raise OrderIntentIntegrityError("persisted amendment payload identity does not verify")
+                payload["client_order_id"] = amendment["client_order_id"]
+                authorization = _outbound_authorization(
+                    intent_id=intent_id,
+                    operation="AMEND",
+                    owner=owner,
+                    fencing_token=fencing_token,
+                    client_order_id=amendment["client_order_id"],
+                    payload=payload,
+                )
+        if expired:
+            raise OrderIntentReconciliationRequired("expired amendment cannot be prepared or reissued")
+        assert authorization is not None
+        return authorization
+
+    def record_amendment_acknowledgement(self, intent_id: str, owner: str, fencing_token: int, evidence: BrokerEvidence) -> IntentRecord:
+        _validate_identity("intent_id", intent_id)
+        _validate_identity("owner", owner)
+        _validate_fencing_token(fencing_token)
+        now = self._now_us()
+        if type(evidence) is not BrokerEvidence:
+            raise OrderIntentValidationError("amendment acknowledgement requires exact BrokerEvidence")
+        BrokerEvidence.validate(evidence, _from_us(now))
+        with self._transaction() as conn:
+            intent = self._require_intent(conn, intent_id)
+            amendment = conn.execute("SELECT * FROM amendment_leases WHERE intent_id = ?", (intent_id,)).fetchone()
+            self._validate_broker_evidence(conn, intent, evidence, allowed_operations={"AMEND_ACK"}, allowed_outcomes={"OPEN"})
+            if amendment is None or amendment["state"] != "IN_DOUBT" or amendment["owner"] != owner or int(amendment["fencing_token"]) != fencing_token or intent["pending_operation"] != "AMEND" or intent["pending_owner"] != owner or int(intent["pending_fence"] or -1) != fencing_token:
+                raise OrderIntentLeaseConflict("amendment acknowledgement is not fenced to this in-doubt amendment")
+            if evidence.http_status != 200:
+                raise OrderIntentValidationError("definitive amendment acknowledgement requires HTTP 200")
+            self._bind_broker_order_history(conn, evidence.broker_order_id, intent_id, now)
+            conn.execute("UPDATE order_intents SET broker_order_id = ?, pending_operation = NULL, pending_owner = NULL, pending_fence = NULL, last_reconciled_run = ?, updated_at = ? WHERE intent_id = ?", (evidence.broker_order_id, self.run_id, now, intent_id))
+            self._archive_amendment(conn, amendment, "ACKNOWLEDGED", now)
+            conn.execute("DELETE FROM amendment_leases WHERE intent_id = ?", (intent_id,))
+            self._append_reconciliation_event(conn, intent_id, "SUBMITTED", "SUBMITTED", "AMENDMENT_ACKNOWLEDGED", "POST_ACKNOWLEDGED", evidence, now)
+            return self._intent_from_row(self._require_intent(conn, intent_id))
+
+    def events(self, intent_id: str) -> tuple[IntentEvent, ...]:
+        _validate_identity("intent_id", intent_id)
+        with self._connection() as conn:
+            rows = conn.execute("SELECT * FROM order_events WHERE intent_id = ? ORDER BY sequence", (intent_id,)).fetchall()
+        return tuple(self._event_from_row(row) for row in rows)
+
+    def _securely_precreate_database(self) -> None:
+        # sqlite3 accepts only a pathname, not a caller-owned file descriptor.
+        # We therefore fail closed: a private 0700 parent is created first and
+        # every pathname (including SQLite sidecars) is opened with O_NOFOLLOW
+        # and descriptor-validated before SQLite is allowed to use it.
+        self._ensure_secure_parent()
+        if self.path.exists() or self.path.is_symlink():
+            self._validate_database_file()
+            return
+        flags = os.O_CREAT | os.O_EXCL | os.O_WRONLY
+        if hasattr(os, "O_NOFOLLOW"):
+            flags |= os.O_NOFOLLOW
+        try:
+            descriptor = os.open(self.path, flags, 0o600)
+        except FileExistsError:
+            self._validate_database_file()
+            return
+        try:
+            os.fchmod(descriptor, 0o600)
+            info = os.fstat(descriptor)
+            if not stat.S_ISREG(info.st_mode) or info.st_uid != os.getuid() or info.st_mode & 0o077:
+                raise OrderIntentValidationError("new ledger database is not owner-only")
+        finally:
+            os.close(descriptor)
+
+    def _ensure_secure_parent(self) -> None:
+        try:
+            info = self.path.parent.lstat()
+        except FileNotFoundError:
+            try:
+                os.mkdir(self.path.parent, 0o700)
+            except FileExistsError:
+                pass
+            except OSError as exc:
+                raise OrderIntentValidationError("could not create ledger parent directory") from exc
+            info = self.path.parent.lstat()
+        if not stat.S_ISDIR(info.st_mode) or stat.S_ISLNK(info.st_mode):
+            raise OrderIntentValidationError("ledger parent must be a real directory")
+        if info.st_uid != os.getuid() or info.st_mode & 0o077:
+            raise OrderIntentValidationError("ledger parent must be owned by this user and owner-only")
+
+    def _validate_database_file(self) -> None:
+        self._validate_private_file(self.path, "ledger database")
+
+    @staticmethod
+    def _validate_private_file(path: Path, label: str) -> None:
+        flags = os.O_RDONLY
+        if hasattr(os, "O_NOFOLLOW"):
+            flags |= os.O_NOFOLLOW
+        try:
+            descriptor = os.open(path, flags)
+        except OSError as exc:
+            raise OrderIntentValidationError(f"could not safely open {label}") from exc
+        try:
+            info = os.fstat(descriptor)
+            if not stat.S_ISREG(info.st_mode) or info.st_uid != os.getuid() or info.st_mode & 0o077:
+                raise OrderIntentValidationError(f"{label} must be regular, current-user, and owner-only")
+        finally:
+            os.close(descriptor)
+
+    def _secure_sqlite_sidecars(self) -> None:
+        for suffix in ("-wal", "-shm", "-journal"):
+            sidecar = Path(f"{self.path}{suffix}")
+            if not sidecar.exists() and not sidecar.is_symlink():
+                continue
+            self._validate_private_file(sidecar, f"SQLite {suffix[1:]} sidecar")
+            try:
+                os.chmod(sidecar, 0o600)
+            except OSError as exc:
+                raise OrderIntentValidationError(f"could not secure SQLite {suffix[1:]} sidecar") from exc
+            self._validate_private_file(sidecar, f"SQLite {suffix[1:]} sidecar")
+
+    def _initialize_schema(self) -> None:
+        with self._connection() as conn:
+            metadata_table = conn.execute(
+                "SELECT 1 FROM sqlite_master WHERE type = 'table' AND name = 'ledger_metadata'"
+            ).fetchone()
+            if metadata_table is None:
+                mode = conn.execute("PRAGMA journal_mode = DELETE").fetchone()[0]
+                if str(mode).lower() != "delete":
+                    raise OrderIntentLedgerError("ledger requires SQLite DELETE journaling in its private directory")
+                conn.execute("CREATE TABLE ledger_metadata (singleton INTEGER PRIMARY KEY CHECK (singleton = 1), schema_version INTEGER NOT NULL)")
+            conn.execute("INSERT OR IGNORE INTO ledger_metadata (singleton, schema_version) VALUES (1, ?)", (SCHEMA_VERSION,))
+            metadata = conn.execute("SELECT schema_version FROM ledger_metadata WHERE singleton = 1").fetchone()
+            current_schema_version = int(metadata["schema_version"])
+            if current_schema_version != SCHEMA_VERSION and current_schema_version not in _MIGRATABLE_SCHEMA_VERSIONS:
+                raise OrderIntentLedgerError(f"unsupported ledger schema {metadata['schema_version']}; expected {SCHEMA_VERSION}")
+            conn.executescript(
+                """
+                CREATE TABLE IF NOT EXISTS order_intents (
+                    intent_id TEXT PRIMARY KEY,
+                    account_id TEXT NOT NULL,
+                    environment TEXT NOT NULL,
+                    strategy_id TEXT NOT NULL,
+                    decision_id TEXT NOT NULL,
+                    idempotency_scope TEXT NOT NULL,
+                    idempotency_key TEXT NOT NULL,
+                    intent_kind TEXT NOT NULL CHECK (intent_kind IN ('OPENING', 'CLOSING')),
+                    wire_payload TEXT NOT NULL,
+                    canonical_payload TEXT NOT NULL,
+                    payload_hash TEXT NOT NULL,
+                    client_order_id TEXT NOT NULL UNIQUE,
+                    state TEXT NOT NULL CHECK (state IN ('INTENT', 'CLAIMED', 'SUBMISSION_UNKNOWN', 'SUBMITTED', 'FILLED', 'CANCELLED', 'REJECTED', 'EXPIRED', 'FAILED')),
+                    broker_order_id TEXT UNIQUE,
+                    submission_fence INTEGER NOT NULL CHECK (submission_fence >= 0),
+                    amendment_fence INTEGER NOT NULL DEFAULT 0 CHECK (amendment_fence >= 0),
+                    submission_lease_owner TEXT,
+                    submission_lease_expires_at INTEGER,
+                    pending_operation TEXT CHECK (pending_operation IN ('SUBMIT', 'AMEND') OR pending_operation IS NULL),
+                    pending_owner TEXT,
+                    pending_fence INTEGER,
+                    last_reconciled_run TEXT,
+                    created_at INTEGER NOT NULL,
+                    updated_at INTEGER NOT NULL,
+                    UNIQUE (account_id, environment, idempotency_scope, idempotency_key),
+                    CHECK ((state = 'CLAIMED') = (submission_lease_owner IS NOT NULL AND submission_lease_expires_at IS NOT NULL AND submission_fence > 0)),
+                    CHECK (state NOT IN ('SUBMITTED', 'FILLED', 'CANCELLED', 'REJECTED', 'EXPIRED') OR broker_order_id IS NOT NULL),
+                    CHECK (state != 'FAILED' OR broker_order_id IS NULL)
+                );
+                CREATE TABLE IF NOT EXISTS reservation_caps (
+                    account_id TEXT NOT NULL,
+                    environment TEXT NOT NULL,
+                    cap_amount TEXT NOT NULL,
+                    broker_buying_power TEXT NOT NULL,
+                    risk_budget TEXT NOT NULL,
+                    observed_at INTEGER NOT NULL,
+                    portfolio_snapshot_digest TEXT NOT NULL,
+                    updated_at INTEGER NOT NULL,
+                    PRIMARY KEY (account_id, environment),
+                    CHECK (CAST(cap_amount AS REAL) >= 0 AND CAST(broker_buying_power AS REAL) >= 0 AND CAST(risk_budget AS REAL) >= 0),
+                    CHECK (length(portfolio_snapshot_digest) = 64)
+                );
+                CREATE TABLE IF NOT EXISTS margin_reservations (
+                    intent_id TEXT PRIMARY KEY REFERENCES order_intents(intent_id),
+                    account_id TEXT NOT NULL,
+                    environment TEXT NOT NULL,
+                    amount TEXT NOT NULL,
+                    risk_decision_id TEXT NOT NULL,
+                    max_loss_amount TEXT NOT NULL,
+                    quote_observed_at INTEGER NOT NULL,
+                    quote_digest TEXT NOT NULL,
+                    portfolio_observed_at INTEGER NOT NULL,
+                    portfolio_snapshot_digest TEXT NOT NULL,
+                    state TEXT NOT NULL CHECK (state IN ('ACTIVE', 'FILLED_PENDING_ABSORPTION', 'RELEASED')),
+                    released_reason_code TEXT,
+                    created_at INTEGER NOT NULL,
+                    released_at INTEGER,
+                    CHECK (CAST(amount AS REAL) > 0 AND CAST(max_loss_amount AS REAL) > 0),
+                    CHECK (length(quote_digest) = 64 AND length(portfolio_snapshot_digest) = 64),
+                    CHECK ((state IN ('ACTIVE', 'FILLED_PENDING_ABSORPTION')) = (released_reason_code IS NULL AND released_at IS NULL))
+                );
+                CREATE TABLE IF NOT EXISTS amendment_leases (
+                    intent_id TEXT PRIMARY KEY REFERENCES order_intents(intent_id),
+                    broker_order_id TEXT NOT NULL,
+                    client_order_id TEXT NOT NULL,
+                    idempotency_key TEXT NOT NULL,
+                    wire_payload TEXT NOT NULL,
+                    canonical_payload TEXT NOT NULL,
+                    payload_hash TEXT NOT NULL,
+                    owner TEXT NOT NULL,
+                    fencing_token INTEGER NOT NULL,
+                    state TEXT NOT NULL CHECK (state IN ('LEASED', 'IN_DOUBT')),
+                    expires_at INTEGER NOT NULL,
+                    updated_at INTEGER NOT NULL
+                );
+                CREATE TABLE IF NOT EXISTS amendment_history (
+                    intent_id TEXT NOT NULL REFERENCES order_intents(intent_id),
+                    idempotency_key TEXT NOT NULL,
+                    target_broker_order_id TEXT NOT NULL,
+                    client_order_id TEXT NOT NULL UNIQUE,
+                    wire_payload TEXT NOT NULL,
+                    canonical_payload TEXT NOT NULL,
+                    payload_hash TEXT NOT NULL,
+                    completion_state TEXT NOT NULL CHECK (completion_state IN ('ACKNOWLEDGED', 'RECONCILED_OPEN', 'TERMINAL')),
+                    completed_at INTEGER NOT NULL,
+                    PRIMARY KEY (intent_id, idempotency_key),
+                    CHECK (length(payload_hash) = 64)
+                );
+                CREATE TABLE IF NOT EXISTS outbound_authorizations (
+                    intent_id TEXT NOT NULL REFERENCES order_intents(intent_id),
+                    operation TEXT NOT NULL CHECK (operation IN ('SUBMIT', 'AMEND')),
+                    fencing_token INTEGER NOT NULL CHECK (fencing_token > 0),
+                    client_order_id TEXT NOT NULL,
+                    payload_bytes BLOB NOT NULL,
+                    payload_digest TEXT NOT NULL,
+                    authorized_at INTEGER NOT NULL,
+                    PRIMARY KEY (intent_id, operation, fencing_token),
+                    CHECK (length(payload_bytes) > 0 AND length(payload_digest) = 64)
+                );
+                CREATE TABLE IF NOT EXISTS order_events (
+                    sequence INTEGER PRIMARY KEY AUTOINCREMENT,
+                    intent_id TEXT NOT NULL REFERENCES order_intents(intent_id),
+                    account_id TEXT NOT NULL,
+                    environment TEXT NOT NULL,
+                    client_order_id TEXT NOT NULL,
+                    event_type TEXT NOT NULL,
+                    from_state TEXT,
+                    to_state TEXT,
+                    actor TEXT NOT NULL,
+                    reason_code TEXT NOT NULL CHECK (reason_code IN (
+                        'INTENT_CREATED','SUBMISSION_CLAIMED','LEASE_RENEWED','LEASE_EXPIRED_IN_DOUBT',
+                        'POST_STARTED','POST_ACKNOWLEDGED','POST_TIMEOUT','POST_TRANSPORT_ERROR','POST_RESPONSE_INVALID',
+                        'PRE_POST_ABORTED','BROKER_OPEN_RECONCILED','BROKER_FILLED','BROKER_CANCELLED','BROKER_REJECTED','BROKER_EXPIRED',
+                        'RESERVATION_CREATED','RESERVATION_RELEASED','FILLED_ABSORBED','AMENDMENT_LEASE_ACQUIRED','AMENDMENT_LEASE_RELEASED'
+                    )),
+                    broker_status TEXT,
+                    broker_order_id TEXT,
+                    observed_at INTEGER,
+                    evidence_operation TEXT,
+                    http_status INTEGER,
+                    raw_response_digest TEXT,
+                    created_at INTEGER NOT NULL,
+                    CHECK (http_status IS NULL OR http_status BETWEEN 100 AND 599),
+                    CHECK (raw_response_digest IS NULL OR length(raw_response_digest) = 64)
+                );
+                CREATE INDEX IF NOT EXISTS idx_intents_account_environment_state ON order_intents(account_id, environment, state);
+                CREATE INDEX IF NOT EXISTS idx_reservations_account_environment ON margin_reservations(account_id, environment, state);
+                CREATE TABLE IF NOT EXISTS broker_order_history (
+                    broker_order_id TEXT PRIMARY KEY,
+                    intent_id TEXT NOT NULL REFERENCES order_intents(intent_id),
+                    first_seen_at INTEGER NOT NULL
+                );
+                CREATE TRIGGER IF NOT EXISTS prevent_order_event_update BEFORE UPDATE ON order_events BEGIN SELECT RAISE(ABORT, 'order events are append-only'); END;
+                CREATE TRIGGER IF NOT EXISTS prevent_order_event_delete BEFORE DELETE ON order_events BEGIN SELECT RAISE(ABORT, 'order events are append-only'); END;
+                CREATE TRIGGER IF NOT EXISTS prevent_amendment_history_update BEFORE UPDATE ON amendment_history BEGIN SELECT RAISE(ABORT, 'amendment history is immutable'); END;
+                CREATE TRIGGER IF NOT EXISTS prevent_amendment_history_delete BEFORE DELETE ON amendment_history BEGIN SELECT RAISE(ABORT, 'amendment history is immutable'); END;
+                CREATE TRIGGER IF NOT EXISTS prevent_outbound_authorization_update BEFORE UPDATE ON outbound_authorizations BEGIN SELECT RAISE(ABORT, 'outbound authorizations are immutable'); END;
+                CREATE TRIGGER IF NOT EXISTS prevent_outbound_authorization_delete BEFORE DELETE ON outbound_authorizations BEGIN SELECT RAISE(ABORT, 'outbound authorizations are immutable'); END;
+                CREATE TRIGGER IF NOT EXISTS prevent_broker_order_history_update BEFORE UPDATE ON broker_order_history BEGIN SELECT RAISE(ABORT, 'broker order history is immutable'); END;
+                CREATE TRIGGER IF NOT EXISTS prevent_broker_order_history_delete BEFORE DELETE ON broker_order_history BEGIN SELECT RAISE(ABORT, 'broker order history is immutable'); END;
+                CREATE TRIGGER IF NOT EXISTS prevent_intent_identity_mutation BEFORE UPDATE ON order_intents
+                WHEN OLD.account_id != NEW.account_id OR OLD.environment != NEW.environment OR OLD.strategy_id != NEW.strategy_id
+                   OR OLD.decision_id != NEW.decision_id OR OLD.idempotency_scope != NEW.idempotency_scope
+                   OR OLD.idempotency_key != NEW.idempotency_key OR OLD.intent_kind != NEW.intent_kind
+                   OR OLD.wire_payload != NEW.wire_payload OR OLD.canonical_payload != NEW.canonical_payload OR OLD.payload_hash != NEW.payload_hash
+                   OR OLD.client_order_id != NEW.client_order_id
+                BEGIN SELECT RAISE(ABORT, 'order intent identity is immutable'); END;
+                CREATE TRIGGER IF NOT EXISTS prevent_terminal_rewrite BEFORE UPDATE ON order_intents
+                WHEN OLD.state IN ('FILLED', 'CANCELLED', 'REJECTED', 'EXPIRED', 'FAILED') AND NEW.state != OLD.state
+                BEGIN SELECT RAISE(ABORT, 'terminal order intent cannot transition'); END;
+                """
+            )
+            if current_schema_version != SCHEMA_VERSION:
+                conn.execute("UPDATE ledger_metadata SET schema_version = ? WHERE singleton = 1", (SCHEMA_VERSION,))
+            self._secure_sqlite_sidecars()
+
+    @contextmanager
+    def _connection(self) -> Iterator[sqlite3.Connection]:
+        self._ensure_secure_parent()
+        self._validate_database_file()
+        conn = sqlite3.connect(str(self.path), timeout=_BUSY_TIMEOUT_MS / 1000, isolation_level=None)
+        try:
+            conn.row_factory = sqlite3.Row
+            conn.execute("PRAGMA foreign_keys = ON")
+            conn.execute(f"PRAGMA busy_timeout = {_BUSY_TIMEOUT_MS}")
+            conn.execute("PRAGMA synchronous = FULL")
+            self._secure_sqlite_sidecars()
+            yield conn
+        finally:
+            conn.close()
+
+    @contextmanager
+    def _transaction(self) -> Iterator[sqlite3.Connection]:
+        with self._connection() as conn:
+            conn.execute("BEGIN IMMEDIATE")
+            try:
+                yield conn
+            except Exception:
+                conn.execute("ROLLBACK")
+                raise
+            else:
+                self._secure_sqlite_sidecars()
+                conn.execute("COMMIT")
+                self._secure_sqlite_sidecars()
+
+    def _expire_claimed_leases(self, conn: sqlite3.Connection, account_id: str, environment: str, now: int) -> None:
+        rows = conn.execute(
+            """
+            SELECT * FROM order_intents WHERE account_id = ? AND environment = ?
+              AND state = 'CLAIMED' AND submission_lease_expires_at <= ?
+            """,
+            (account_id, environment, now),
+        ).fetchall()
+        for row in rows:
+            self._mark_claim_in_doubt(conn, row, now)
+
+    def _expire_amendment_leases(self, conn: sqlite3.Connection, account_id: str, environment: str, now: int) -> None:
+        rows = conn.execute(
+            """
+            SELECT amendment_leases.*, order_intents.account_id, order_intents.environment
+            FROM amendment_leases JOIN order_intents USING(intent_id)
+            WHERE order_intents.account_id = ? AND order_intents.environment = ?
+              AND amendment_leases.state = 'LEASED' AND amendment_leases.expires_at <= ?
+            """,
+            (account_id, environment, now),
+        ).fetchall()
+        for amendment in rows:
+            intent = self._require_intent(conn, amendment["intent_id"])
+            self._mark_amendment_in_doubt(conn, intent, amendment, now)
+
+    def _mark_claim_in_doubt(self, conn: sqlite3.Connection, intent: sqlite3.Row, now: int) -> None:
+        if intent["state"] != "CLAIMED":
+            return
+        conn.execute(
+            """
+            UPDATE order_intents SET state = 'SUBMISSION_UNKNOWN', submission_lease_owner = NULL,
+                submission_lease_expires_at = NULL, last_reconciled_run = NULL, updated_at = ?
+            WHERE intent_id = ?
+            """,
+            (now, intent["intent_id"]),
+        )
+        self._append_event(conn, intent["intent_id"], "LEASE_EXPIRED_IN_DOUBT", "CLAIMED", "SUBMISSION_UNKNOWN", "system", "LEASE_EXPIRED_IN_DOUBT", now)
+
+    def _mark_amendment_in_doubt(self, conn: sqlite3.Connection, intent: sqlite3.Row, amendment: sqlite3.Row, now: int) -> None:
+        if amendment["state"] != "LEASED":
+            return
+        conn.execute("UPDATE amendment_leases SET state = 'IN_DOUBT', updated_at = ? WHERE intent_id = ?", (now, intent["intent_id"]))
+        conn.execute("UPDATE order_intents SET pending_operation = 'AMEND', pending_owner = ?, pending_fence = ?, last_reconciled_run = NULL, updated_at = ? WHERE intent_id = ?", (amendment["owner"], amendment["fencing_token"], now, intent["intent_id"]))
+        self._append_event(conn, intent["intent_id"], "AMENDMENT_LEASE_EXPIRED_IN_DOUBT", "SUBMITTED", "SUBMITTED", "system", "LEASE_EXPIRED_IN_DOUBT", now, broker_order_id=intent["broker_order_id"])
+
+    def _blocker_rows(self, conn: sqlite3.Connection, account_id: str, environment: str, *, exclude_intent_id: str | None = None) -> list[sqlite3.Row]:
+        params: list[Any] = [account_id, environment, self.run_id]
+        exclusion = ""
+        if exclude_intent_id is not None:
+            exclusion = " AND intent_id != ?"
+            params.append(exclude_intent_id)
+        return conn.execute(
+            f"""
+            SELECT * FROM order_intents WHERE account_id = ? AND environment = ?
+              AND state IN ('CLAIMED', 'SUBMISSION_UNKNOWN', 'SUBMITTED')
+              AND (last_reconciled_run IS NULL OR last_reconciled_run != ?){exclusion}
+            ORDER BY created_at, intent_id
+            """,
+            params,
+        ).fetchall()
+
+    @staticmethod
+    def _amendment_blocker_rows(conn: sqlite3.Connection, account_id: str, environment: str, *, exclude_intent_id: str | None = None) -> list[sqlite3.Row]:
+        params: list[Any] = [account_id, environment]
+        exclusion = ""
+        if exclude_intent_id is not None:
+            exclusion = " AND amendment_leases.intent_id != ?"
+            params.append(exclude_intent_id)
+        return conn.execute(
+            f"""
+            SELECT amendment_leases.* FROM amendment_leases
+            JOIN order_intents USING(intent_id)
+            WHERE order_intents.account_id = ? AND order_intents.environment = ?
+              AND amendment_leases.state IN ('LEASED', 'IN_DOUBT'){exclusion}
+            ORDER BY amendment_leases.updated_at, amendment_leases.intent_id
+            """,
+            params,
+        ).fetchall()
+
+    def _require_opening_amendment_reservation(self, conn: sqlite3.Connection, intent: sqlite3.Row, amendment_wire_payload: str, now: int) -> None:
+        amended_floor = _opening_exposure_floor(json.loads(amendment_wire_payload))
+        self._require_active_opening_reservation(conn, intent, now)
+        reservation = conn.execute(
+            "SELECT amount, max_loss_amount FROM margin_reservations WHERE intent_id = ?",
+            (intent["intent_id"],),
+        ).fetchone()
+        if reservation is None or Decimal(reservation["amount"]) < amended_floor or Decimal(reservation["max_loss_amount"]) < amended_floor:
+            raise OrderIntentReservationError(
+                "opening amendment increases immutable exposure beyond its active reservation"
+            )
+
+    def _require_active_opening_reservation(self, conn: sqlite3.Connection, intent: sqlite3.Row, now: int) -> None:
+        reservation = conn.execute("SELECT * FROM margin_reservations WHERE intent_id = ?", (intent["intent_id"],)).fetchone()
+        cap = conn.execute("SELECT cap_amount, observed_at, portfolio_snapshot_digest FROM reservation_caps WHERE account_id = ? AND environment = ?", (intent["account_id"], intent["environment"])).fetchone()
+        if reservation is None or reservation["state"] != "ACTIVE" or cap is None:
+            raise OrderIntentReservationError("opening submission requires an active capped margin reservation")
+        if now - int(reservation["quote_observed_at"]) > _EVIDENCE_MAX_AGE_SECONDS * 1_000_000 or now - int(reservation["portfolio_observed_at"]) > _EVIDENCE_MAX_AGE_SECONDS * 1_000_000 or now - int(cap["observed_at"]) > _EVIDENCE_MAX_AGE_SECONDS * 1_000_000:
+            raise OrderIntentReservationError("opening submission requires fresh quote, portfolio, and capacity evidence")
+        if int(cap["observed_at"]) < int(reservation["portfolio_observed_at"]):
+            raise OrderIntentReservationError("capacity snapshot predates reserved portfolio evidence")
+        if int(cap["observed_at"]) == int(reservation["portfolio_observed_at"]) and cap["portfolio_snapshot_digest"] != reservation["portfolio_snapshot_digest"]:
+            raise OrderIntentIntegrityError("capacity snapshot digest conflicts with reserved portfolio evidence")
+        pending_fill = conn.execute("SELECT 1 FROM margin_reservations WHERE account_id = ? AND environment = ? AND state = 'FILLED_PENDING_ABSORPTION'", (intent["account_id"], intent["environment"])).fetchone()
+        if pending_fill is not None:
+            raise OrderIntentReservationError("filled risk reservation must be absorbed by a newer portfolio snapshot before new openings")
+        if self._active_reservation_total(conn, intent["account_id"], intent["environment"]) > Decimal(cap["cap_amount"]):
+            raise OrderIntentReservationError("active reservations exceed account/environment cap")
+
+    @staticmethod
+    def _require_outbound_authorization(
+        authorization: OutboundAuthorization,
+        *,
+        intent_id: str,
+        operation: Literal["SUBMIT", "AMEND"],
+        owner: str,
+        fencing_token: int,
+        client_order_id: str,
+        payload: Mapping[str, Any],
+    ) -> OutboundAuthorization:
+        if type(authorization) is not OutboundAuthorization:
+            raise OrderIntentValidationError("begin operation requires an immutable outbound authorization")
+        primitive_fields = (
+            (authorization.intent_id, str),
+            (authorization.operation, str),
+            (authorization.owner, str),
+            (authorization.fencing_token, int),
+            (authorization.client_order_id, str),
+            (authorization.payload_bytes, bytes),
+            (authorization.payload_digest, str),
+        )
+        if any(type(value) is not expected_type for value, expected_type in primitive_fields):
+            raise OrderIntentValidationError("outbound authorization fields must use exact primitive types")
+        computed_digest = hashlib.sha256(authorization.payload_bytes).hexdigest()
+        if not hmac.compare_digest(authorization.payload_digest, computed_digest):
+            raise OrderIntentIntegrityError("outbound authorization payload digest does not verify")
+        expected = _outbound_authorization(
+            intent_id=intent_id,
+            operation=operation,
+            owner=owner,
+            fencing_token=fencing_token,
+            client_order_id=client_order_id,
+            payload=payload,
+        )
+        string_fields_match = all(
+            hmac.compare_digest(actual, wanted)
+            for actual, wanted in (
+                (authorization.intent_id, expected.intent_id),
+                (authorization.operation, expected.operation),
+                (authorization.owner, expected.owner),
+                (authorization.client_order_id, expected.client_order_id),
+                (authorization.payload_digest, expected.payload_digest),
+            )
+        )
+        if (
+            not string_fields_match
+            or authorization.fencing_token != expected.fencing_token
+            or not hmac.compare_digest(authorization.payload_bytes, expected.payload_bytes)
+        ):
+            raise OrderIntentIntegrityError("outbound authorization does not exactly match the durable fenced payload")
+        return expected
+
+    @staticmethod
+    def _record_outbound_authorization(
+        conn: sqlite3.Connection, authorization: OutboundAuthorization, now: int
+    ) -> None:
+        conn.execute(
+            """
+            INSERT INTO outbound_authorizations
+                (intent_id, operation, fencing_token, client_order_id, payload_bytes, payload_digest, authorized_at)
+            VALUES (?, ?, ?, ?, ?, ?, ?)
+            """,
+            (
+                authorization.intent_id,
+                authorization.operation,
+                authorization.fencing_token,
+                authorization.client_order_id,
+                authorization.payload_bytes,
+                authorization.payload_digest,
+                now,
+            ),
+        )
+
+    @staticmethod
+    def _require_submission_fence(intent: sqlite3.Row, owner: str, fencing_token: int) -> None:
+        _validate_identity("owner", owner)
+        _validate_fencing_token(fencing_token)
+        if intent["state"] != "CLAIMED":
+            raise OrderIntentTransitionError("submission operation requires a claimed intent")
+        if intent["submission_lease_owner"] != owner or int(intent["submission_fence"]) != fencing_token:
+            raise OrderIntentLeaseConflict("submission lease owner or fencing token does not match")
+
+    @staticmethod
+    def _claim_expired(intent: sqlite3.Row, now: int) -> bool:
+        return intent["state"] == "CLAIMED" and int(intent["submission_lease_expires_at"]) <= now
+
+    @staticmethod
+    def _ensure_broker_order_is_unambiguous(conn: sqlite3.Connection, broker_order_id: str, intent_id: str) -> None:
+        existing = conn.execute("SELECT intent_id FROM broker_order_history WHERE broker_order_id = ?", (broker_order_id,)).fetchone()
+        if existing is not None and existing["intent_id"] != intent_id:
+            raise OrderIntentIntegrityError("broker order id is already bound to another durable intent")
+
+    @staticmethod
+    def _bind_broker_order_history(conn: sqlite3.Connection, broker_order_id: str, intent_id: str, now: int) -> None:
+        OrderIntentLedger._ensure_broker_order_is_unambiguous(conn, broker_order_id, intent_id)
+        conn.execute("INSERT OR IGNORE INTO broker_order_history (broker_order_id, intent_id, first_seen_at) VALUES (?, ?, ?)", (broker_order_id, intent_id, now))
+
+    @staticmethod
+    def _archive_amendment(conn: sqlite3.Connection, amendment: sqlite3.Row, completion_state: str, now: int) -> None:
+        if completion_state not in {"ACKNOWLEDGED", "RECONCILED_OPEN", "TERMINAL"}:
+            raise OrderIntentValidationError("invalid amendment completion state")
+        existing = conn.execute(
+            "SELECT * FROM amendment_history WHERE intent_id = ? AND idempotency_key = ?",
+            (amendment["intent_id"], amendment["idempotency_key"]),
+        ).fetchone()
+        expected = (
+            amendment["broker_order_id"], amendment["client_order_id"], amendment["wire_payload"],
+            amendment["canonical_payload"], amendment["payload_hash"],
+        )
+        if existing is not None:
+            actual = (
+                existing["target_broker_order_id"], existing["client_order_id"], existing["wire_payload"],
+                existing["canonical_payload"], existing["payload_hash"],
+            )
+            if actual != expected:
+                raise OrderIntentIntegrityError("amendment history identity conflict")
+            return
+        conn.execute(
+            """
+            INSERT INTO amendment_history (
+                intent_id, idempotency_key, target_broker_order_id, client_order_id,
+                wire_payload, canonical_payload, payload_hash, completion_state, completed_at
+            ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)
+            """,
+            (amendment["intent_id"], amendment["idempotency_key"], amendment["broker_order_id"], amendment["client_order_id"], amendment["wire_payload"], amendment["canonical_payload"], amendment["payload_hash"], completion_state, now),
+        )
+
+    @staticmethod
+    def _ensure_amendment_client_id_is_unambiguous(conn: sqlite3.Connection, client_order_id: str, intent_id: str, idempotency_key: str) -> None:
+        original = conn.execute("SELECT intent_id FROM order_intents WHERE client_order_id = ?", (client_order_id,)).fetchone()
+        if original is not None:
+            raise OrderIntentIntegrityError("amendment client order id collides with an original intent")
+        active = conn.execute("SELECT intent_id, idempotency_key FROM amendment_leases WHERE client_order_id = ?", (client_order_id,)).fetchone()
+        if active is not None and (active["intent_id"], active["idempotency_key"]) != (intent_id, idempotency_key):
+            raise OrderIntentIntegrityError("amendment client order id collides with another active amendment")
+        completed = conn.execute("SELECT intent_id, idempotency_key FROM amendment_history WHERE client_order_id = ?", (client_order_id,)).fetchone()
+        if completed is not None and (completed["intent_id"], completed["idempotency_key"]) != (intent_id, idempotency_key):
+            raise OrderIntentIntegrityError("amendment client order id collides with completed amendment history")
+
+    @staticmethod
+    def _validate_broker_evidence(conn: sqlite3.Connection, intent: sqlite3.Row, evidence: BrokerEvidence, *, allowed_operations: set[str], allowed_outcomes: set[str]) -> None:
+        if evidence.operation not in allowed_operations or evidence.outcome not in allowed_outcomes:
+            raise OrderIntentValidationError("broker evidence operation/outcome is not valid for this transition")
+        if evidence.account_id != intent["account_id"] or evidence.environment != intent["environment"]:
+            raise OrderIntentIntegrityError("broker evidence account/environment does not match intent")
+        expected_client_id = intent["client_order_id"]
+        if evidence.operation.startswith("AMEND"):
+            amendment = conn.execute("SELECT client_order_id FROM amendment_leases WHERE intent_id = ?", (intent["intent_id"],)).fetchone()
+            if amendment is None:
+                raise OrderIntentIntegrityError("amendment evidence has no durable amendment operation")
+            expected_client_id = amendment["client_order_id"]
+        if evidence.client_order_id != expected_client_id:
+            raise OrderIntentIntegrityError("broker evidence client order id does not match durable intent")
+
+    @staticmethod
+    def _active_reservation_total(conn: sqlite3.Connection, account_id: str, environment: str) -> Decimal:
+        rows = conn.execute("SELECT amount FROM margin_reservations WHERE account_id = ? AND environment = ? AND state IN ('ACTIVE', 'FILLED_PENDING_ABSORPTION')", (account_id, environment)).fetchall()
+        with localcontext() as decimal_context:
+            decimal_context.prec = _DECIMAL_PRECISION
+            return sum((Decimal(row["amount"]) for row in rows), Decimal("0"))
+
+    def _release_reservation(self, conn: sqlite3.Connection, intent_id: str, reason_code: str, now: int) -> None:
+        reservation = conn.execute("SELECT * FROM margin_reservations WHERE intent_id = ?", (intent_id,)).fetchone()
+        if reservation is None or reservation["state"] != "ACTIVE":
+            return
+        conn.execute("UPDATE margin_reservations SET state = 'RELEASED', released_reason_code = ?, released_at = ? WHERE intent_id = ?", (reason_code, now, intent_id))
+        intent = self._require_intent(conn, intent_id)
+        self._append_event(conn, intent_id, "RESERVATION_RELEASED", intent["state"], intent["state"], "system", "RESERVATION_RELEASED", now, broker_order_id=intent["broker_order_id"])
+
+    def _append_reconciliation_event(self, conn: sqlite3.Connection, intent_id: str, from_state: str, to_state: str, event_type: str, reason_code: str, evidence: BrokerEvidence, now: int) -> None:
+        self._append_event(conn, intent_id, event_type, from_state, to_state, "broker-evidence", reason_code, now, broker_status=evidence.outcome, broker_order_id=evidence.broker_order_id, observed_at=_to_us(evidence.observed_at), evidence_operation=evidence.operation, http_status=evidence.http_status, raw_response_digest=evidence.raw_response_digest)
+
+    def _append_event(self, conn: sqlite3.Connection, intent_id: str, event_type: str, from_state: str | None, to_state: str | None, actor: str, reason_code: str, now: int, *, broker_status: str | None = None, broker_order_id: str | None = None, observed_at: int | None = None, evidence_operation: str | None = None, http_status: int | None = None, raw_response_digest: str | None = None) -> None:
+        if reason_code not in _REASON_CODES:
+            raise OrderIntentValidationError("reason_code is not allowlisted")
+        _validate_identity("actor", actor)
+        identity = conn.execute("SELECT account_id, environment, client_order_id FROM order_intents WHERE intent_id = ?", (intent_id,)).fetchone()
+        if identity is None:
+            raise OrderIntentValidationError("cannot append event for unknown intent")
+        conn.execute(
+            """
+            INSERT INTO order_events (intent_id, account_id, environment, client_order_id, event_type, from_state, to_state, actor, reason_code, broker_status, broker_order_id, observed_at, evidence_operation, http_status, raw_response_digest, created_at)
+            VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+            """,
+            (intent_id, identity["account_id"], identity["environment"], identity["client_order_id"], event_type, from_state, to_state, actor, reason_code, broker_status, broker_order_id, observed_at, evidence_operation, http_status, raw_response_digest, now),
+        )
+
+    def _require_intent(self, conn: sqlite3.Connection, intent_id: str) -> sqlite3.Row:
+        row = conn.execute("SELECT * FROM order_intents WHERE intent_id = ?", (intent_id,)).fetchone()
+        if row is None:
+            raise OrderIntentValidationError("unknown intent_id")
+        return row
+
+    def _now_us(self) -> int:
+        value = self._clock()
+        _validate_timestamp(value)
+        return _to_us(value)
+
+    @staticmethod
+    def _lease_expiry_us(lease_seconds: float, now: int) -> int:
+        if type(lease_seconds) not in {int, float}:
+            raise OrderIntentValidationError("lease_seconds must be an exact int or float")
+        seconds = float(lease_seconds)
+        if not math.isfinite(seconds) or seconds <= 0:
+            raise OrderIntentValidationError("lease_seconds must be positive and finite")
+        return now + int(seconds * 1_000_000)
+
+    @staticmethod
+    def _intent_from_row(row: sqlite3.Row) -> IntentRecord:
+        envelope = OrderIntent(
+            account_id=row["account_id"], environment=row["environment"], strategy_id=row["strategy_id"],
+            decision_id=row["decision_id"], idempotency_scope=row["idempotency_scope"],
+            idempotency_key=row["idempotency_key"], intent_kind=row["intent_kind"], wire_payload=row["wire_payload"],
+            canonical_payload=row["canonical_payload"], payload_hash=row["payload_hash"],
+        )
+        _validate_envelope(envelope)
+        expected_client_id = stable_client_order_id(envelope)
+        if row["client_order_id"] != expected_client_id:
+            raise OrderIntentIntegrityError("stored client order id does not match immutable scope identity")
+        return IntentRecord(
+            intent_id=row["intent_id"], envelope=envelope, client_order_id=row["client_order_id"], state=row["state"],
+            broker_order_id=row["broker_order_id"], submission_fence=int(row["submission_fence"]),
+            submission_lease_owner=row["submission_lease_owner"],
+            submission_lease_expires_at=_from_us(row["submission_lease_expires_at"]) if row["submission_lease_expires_at"] is not None else None,
+            last_reconciled_run=row["last_reconciled_run"], created_at=_from_us(row["created_at"]), updated_at=_from_us(row["updated_at"]),
+        )
+
+    @staticmethod
+    def _reservation_from_row(row: sqlite3.Row) -> MarginReservation:
+        return MarginReservation(intent_id=row["intent_id"], account_id=row["account_id"], environment=row["environment"], amount=Decimal(row["amount"]), risk_decision_id=row["risk_decision_id"], max_loss_amount=Decimal(row["max_loss_amount"]), quote_observed_at=_from_us(row["quote_observed_at"]), quote_digest=row["quote_digest"], portfolio_observed_at=_from_us(row["portfolio_observed_at"]), portfolio_snapshot_digest=row["portfolio_snapshot_digest"], state=row["state"], released_reason_code=row["released_reason_code"], created_at=_from_us(row["created_at"]), released_at=_from_us(row["released_at"]) if row["released_at"] is not None else None)
+
+    @staticmethod
+    def _event_from_row(row: sqlite3.Row) -> IntentEvent:
+        return IntentEvent(sequence=int(row["sequence"]), intent_id=row["intent_id"], account_id=row["account_id"], environment=row["environment"], client_order_id=row["client_order_id"], event_type=row["event_type"], from_state=row["from_state"], to_state=row["to_state"], actor=row["actor"], reason_code=row["reason_code"], broker_status=row["broker_status"], broker_order_id=row["broker_order_id"], observed_at=_from_us(row["observed_at"]) if row["observed_at"] is not None else None, evidence_operation=row["evidence_operation"], http_status=row["http_status"], raw_response_digest=row["raw_response_digest"], created_at=_from_us(row["created_at"]))
+
+
+def _validate_envelope(envelope: OrderIntent) -> None:
+    if type(envelope) is not OrderIntent:
+        raise OrderIntentValidationError("intent envelope must use the exact OrderIntent type")
+    for name in ("account_id", "strategy_id", "decision_id", "idempotency_scope", "idempotency_key"):
+        _validate_identity(name, getattr(envelope, name))
+    _validate_environment(envelope.environment)
+    if type(envelope.intent_kind) is not str or envelope.intent_kind not in _INTENT_KINDS:
+        raise OrderIntentValidationError("invalid intent kind")
+    for name in ("wire_payload", "canonical_payload", "payload_hash"):
+        if type(getattr(envelope, name)) is not str:
+            raise OrderIntentValidationError(f"{name} must be an exact string")
+    _validate_sha256("payload_hash", envelope.payload_hash)
+    if _payload_hash(envelope.canonical_payload) != envelope.payload_hash:
+        raise OrderIntentIntegrityError("payload hash does not match canonical payload")
+    try:
+        wire_payload = json.loads(envelope.wire_payload)
+    except (TypeError, json.JSONDecodeError) as exc:
+        raise OrderIntentIntegrityError("wire payload is invalid JSON") from exc
+    if wire_order_payload(wire_payload) != envelope.wire_payload or canonical_order_payload(wire_payload) != envelope.canonical_payload or _derive_intent_kind(wire_payload) != envelope.intent_kind:
+        raise OrderIntentIntegrityError("wire payload does not satisfy strict canonical identity")
+
+
+def _payload_hash(canonical_payload: str) -> str:
+    if type(canonical_payload) is not str:
+        raise OrderIntentValidationError("canonical payload must be an exact string")
+    return hashlib.sha256(_PAYLOAD_HASH_DOMAIN + canonical_payload.encode("utf-8")).hexdigest()
+
+
+def _outbound_authorization(
+    *,
+    intent_id: str,
+    operation: Literal["SUBMIT", "AMEND"],
+    owner: str,
+    fencing_token: int,
+    client_order_id: str,
+    payload: Mapping[str, Any],
+) -> OutboundAuthorization:
+    """Construct deterministic bytes that the gateway must submit unchanged."""
+    _validate_identity("intent_id", intent_id)
+    _validate_identity("owner", owner)
+    _validate_identity("client_order_id", client_order_id)
+    if operation not in {"SUBMIT", "AMEND"}:
+        raise OrderIntentValidationError("unsupported outbound authorization operation")
+    if type(fencing_token) is not int or fencing_token <= 0:
+        raise OrderIntentValidationError("fencing_token must be a positive integer")
+    try:
+        payload_bytes = json.dumps(payload, sort_keys=True, separators=(",", ":"), ensure_ascii=True).encode("utf-8")
+    except (TypeError, ValueError) as exc:
+        raise OrderIntentIntegrityError("durable outbound payload cannot be serialized") from exc
+    return OutboundAuthorization(
+        intent_id=intent_id,
+        operation=operation,
+        owner=owner,
+        fencing_token=fencing_token,
+        client_order_id=client_order_id,
+        payload_bytes=payload_bytes,
+        payload_digest=hashlib.sha256(payload_bytes).hexdigest(),
+    )
+
+
+def _validate_mapping_keys(value: Mapping[str, Any], allowed: frozenset[str], context: str) -> None:
+    keys = list(value.keys())
+    if any(type(key) is not str for key in keys):
+        raise OrderIntentValidationError(f"{context} keys must all be strings")
+    unexpected = set(keys) - allowed
+    if unexpected:
+        raise OrderIntentValidationError(f"{context} contains disallowed fields: {', '.join(sorted(unexpected))}")
+
+
+def _validate_broker_order_shape(payload: Mapping[str, Any]) -> None:
+    security_type = payload.get("securityType")
+    if security_type not in {"EQ", "OPTN"}:
+        raise OrderIntentValidationError("securityType must be EQ or OPTN")
+    if payload.get("priceType") not in {"MARKET", "LIMIT", "NET_CREDIT", "NET_DEBIT"}:
+        raise OrderIntentValidationError("unsupported priceType")
+    if payload.get("orderTerm") != "GOOD_FOR_DAY":
+        raise OrderIntentValidationError("only GOOD_FOR_DAY orderTerm is supported")
+    has_legs = "legs" in payload
+    if security_type == "EQ":
+        raise OrderIntentValidationError(
+            "equity orders are unsupported until position-aware exposure evidence is implemented"
+        )
+    elif has_legs:
+        if payload.get("orderAction") != "SPREAD" or payload.get("spreadType") != "VERTICAL":
+            raise OrderIntentValidationError("only VERTICAL option spreads are supported")
+        legs = payload["legs"]
+        if len(legs) != 2:
+            raise OrderIntentValidationError("vertical spread must contain exactly two legs")
+        ignored_cross_shape = {"symbol", "quantity", "callPut", "expiryYear", "expiryMonth", "expiryDay", "strikePrice"} & set(payload)
+        if ignored_cross_shape:
+            raise OrderIntentValidationError("spread payload must derive identity exclusively from legs")
+        first = legs[0]
+        reference = (first.get("symbol"), first.get("expiryYear"), first.get("expiryMonth"), first.get("expiryDay"), first.get("callPut"), first.get("quantity"))
+        for leg in legs:
+            required = {"symbol", "callPut", "expiryYear", "expiryMonth", "expiryDay", "strikePrice", "orderAction", "quantity"}
+            if not required.issubset(leg) or leg.get("callPut") not in {"PUT", "CALL"} or leg.get("orderAction") not in {"BUY_OPEN", "SELL_OPEN", "BUY_CLOSE", "SELL_CLOSE"}:
+                raise OrderIntentValidationError("invalid spread leg")
+            _validate_expiry(leg["expiryYear"], leg["expiryMonth"], leg["expiryDay"])
+            _require_positive_number(leg["strikePrice"], "strikePrice")
+            _require_positive_integral(leg["quantity"], "quantity")
+            if (leg.get("symbol"), leg.get("expiryYear"), leg.get("expiryMonth"), leg.get("expiryDay"), leg.get("callPut"), leg.get("quantity")) != reference:
+                raise OrderIntentValidationError("vertical spread legs must share symbol, expiry, callPut, and quantity")
+        strikes = {leg["strikePrice"] for leg in legs}
+        sides = {leg["orderAction"].split("_")[0] for leg in legs}
+        exposure = {leg["orderAction"].split("_")[1] for leg in legs}
+        if len(strikes) != 2 or sides != {"BUY", "SELL"} or len(exposure) != 1:
+            raise OrderIntentValidationError("vertical spread requires distinct strikes, one buy/one sell, and uniform OPEN/CLOSE exposure")
+        if exposure == {"OPEN"}:
+            if payload["priceType"] not in {"NET_CREDIT", "NET_DEBIT"} or "limitPrice" not in payload:
+                raise OrderIntentValidationError("opening verticals require bounded NET_CREDIT or NET_DEBIT pricing")
+            with localcontext() as decimal_context:
+                decimal_context.prec = _DECIMAL_PRECISION
+                width = abs(Decimal(str(legs[0]["strikePrice"])) - Decimal(str(legs[1]["strikePrice"])))
+                limit_price = Decimal(str(payload["limitPrice"]))
+            sell_leg = next(leg for leg in legs if leg["orderAction"] == "SELL_OPEN")
+            buy_leg = next(leg for leg in legs if leg["orderAction"] == "BUY_OPEN")
+            short_risk = (sell_leg["callPut"] == "PUT" and sell_leg["strikePrice"] > buy_leg["strikePrice"]) or (sell_leg["callPut"] == "CALL" and sell_leg["strikePrice"] < buy_leg["strikePrice"])
+            expected_price_type = "NET_CREDIT" if short_risk else "NET_DEBIT"
+            if payload["priceType"] != expected_price_type:
+                raise OrderIntentValidationError("opening vertical price type does not match leg risk orientation")
+            if payload["priceType"] == "NET_CREDIT" and not (Decimal("0") <= limit_price < width):
+                raise OrderIntentValidationError("opening vertical credit must be non-negative and strictly less than strike width")
+            if payload["priceType"] == "NET_DEBIT" and not (Decimal("0") < limit_price <= width):
+                raise OrderIntentValidationError("opening vertical debit must be positive and no greater than strike width")
+    else:
+        required = {"symbol", "quantity", "orderAction", "callPut", "expiryYear", "expiryMonth", "expiryDay", "strikePrice", "priceType", "orderTerm"}
+        if not required.issubset(payload) or payload.get("orderAction") not in {"BUY_OPEN", "SELL_OPEN", "BUY_CLOSE", "SELL_CLOSE"} or payload.get("callPut") not in {"PUT", "CALL"} or type(payload.get("symbol")) is not str or not payload["symbol"].strip() or "spreadType" in payload:
+            raise OrderIntentValidationError("invalid single-option order shape")
+        _require_positive_integral(payload["quantity"], "quantity")
+        _validate_expiry(payload["expiryYear"], payload["expiryMonth"], payload["expiryDay"])
+        _require_positive_number(payload["strikePrice"], "strikePrice")
+    if payload["priceType"] != "MARKET":
+        if "limitPrice" not in payload:
+            raise OrderIntentValidationError("non-market orders require limitPrice")
+        if payload["priceType"] == "NET_CREDIT":
+            _require_nonnegative_number(payload["limitPrice"], "limitPrice")
+        else:
+            _require_positive_number(payload["limitPrice"], "limitPrice")
+
+
+def _derive_intent_kind(payload: Mapping[str, Any]) -> Literal["OPENING", "CLOSING"]:
+    actions = [leg["orderAction"] for leg in payload.get("legs", [])] or [payload["orderAction"]]
+    normalized = {"BUY_OPEN" if action == "BUY" else "SELL_CLOSE" if action == "SELL" else action for action in actions}
+    opening = {action.endswith("_OPEN") for action in normalized}
+    if len(opening) != 1:
+        raise OrderIntentValidationError("mixed opening and closing exposure is unsupported")
+    return "OPENING" if True in opening else "CLOSING"
+
+
+def _validate_reprice_only_amendment(original_wire_payload: str, amendment_wire_payload: str) -> None:
+    """Permit a durable broker amendment to change only the limit price."""
+    original = json.loads(original_wire_payload)
+    amendment = json.loads(amendment_wire_payload)
+    if original.get("priceType") == "MARKET" or amendment.get("priceType") == "MARKET":
+        raise OrderIntentValidationError("market orders cannot be repriced")
+    original.pop("limitPrice", None)
+    amendment.pop("limitPrice", None)
+    if original != amendment:
+        raise OrderIntentValidationError("amendment may only change immutable order intent limitPrice")
+
+
+def _opening_exposure_floor(payload: Mapping[str, Any]) -> Decimal:
+    """Return the minimum defensible reserve for an opening vertical spread.
+
+    Other opening order forms lack position-aware collateral semantics in this
+    ledger and are intentionally fail-closed rather than accepting a caller
+    supplied number that could understate live exposure.
+    """
+    if payload.get("orderAction") != "SPREAD" or payload.get("spreadType") != "VERTICAL" or "legs" not in payload:
+        raise OrderIntentReservationError("opening reservations currently require a validated vertical spread")
+    legs = payload["legs"]
+    if _derive_intent_kind(payload) != "OPENING" or len(legs) != 2:
+        raise OrderIntentReservationError("opening exposure floor requires exactly two opening vertical legs")
+    quantity = legs[0]["quantity"]
+    with localcontext() as decimal_context:
+        decimal_context.prec = _DECIMAL_PRECISION
+        width = abs(Decimal(str(legs[0]["strikePrice"])) - Decimal(str(legs[1]["strikePrice"])))
+        gross = width * Decimal("100") * Decimal(quantity)
+        limit_price = Decimal(str(payload["limitPrice"]))
+        if payload["priceType"] == "NET_CREDIT":
+            if not (Decimal("0") <= limit_price < width):
+                raise OrderIntentValidationError("vertical credit must be non-negative and strictly less than strike width")
+            return gross - limit_price * Decimal("100") * Decimal(quantity)
+        if payload["priceType"] == "NET_DEBIT":
+            if not (Decimal("0") < limit_price <= width):
+                raise OrderIntentValidationError("vertical debit must be positive and no greater than strike width")
+            return limit_price * Decimal("100") * Decimal(quantity)
+    raise OrderIntentReservationError("opening vertical exposure requires NET_CREDIT or NET_DEBIT pricing")
+
+
+def _require_positive_integral(value: Any, name: str) -> None:
+    if type(value) is not int or value <= 0:
+        raise OrderIntentValidationError(f"{name} must be a positive integer")
+
+
+def _require_positive_number(value: Any, name: str) -> None:
+    if type(value) not in {int, float, Decimal}:
+        raise OrderIntentValidationError(f"{name} must be a positive finite number")
+    if (type(value) is Decimal and (not value.is_finite() or value <= 0)) or (
+        type(value) in {int, float} and (not math.isfinite(value) or value <= 0)
+    ):
+        raise OrderIntentValidationError(f"{name} must be a positive finite number")
+
+
+def _require_nonnegative_number(value: Any, name: str) -> None:
+    if type(value) not in {int, float, Decimal}:
+        raise OrderIntentValidationError(f"{name} must be a non-negative finite number")
+    if (type(value) is Decimal and (not value.is_finite() or value < 0)) or (
+        type(value) in {int, float} and (not math.isfinite(value) or value < 0)
+    ):
+        raise OrderIntentValidationError(f"{name} must be a non-negative finite number")
+
+
+def _validate_expiry(year: Any, month: Any, day: Any) -> None:
+    if any(type(value) is not int for value in (year, month, day)):
+        raise OrderIntentValidationError("expiry must use integral year/month/day")
+    try:
+        date(year, month, day)
+    except ValueError as exc:
+        raise OrderIntentValidationError("expiry is not a valid calendar date") from exc
+
+
+def _canonical_value(value: Any) -> Any:
+    value_type = type(value)
+    if value is None or value_type in {str, bool}:
+        return value
+    if value_type is int:
+        return {"__number__": str(value)}
+    if value_type is Decimal:
+        return {"__number__": _canonical_amount(value)}
+    if value_type is float:
+        if not math.isfinite(value):
+            raise OrderIntentValidationError("payload cannot contain non-finite float")
+        return {"__number__": _canonical_amount(value)}
+    if value_type is dict:
+        keys = list(value.keys())
+        if any(type(key) is not str for key in keys):
+            raise OrderIntentValidationError("payload keys must all be strings")
+        return {key: _canonical_value(value[key]) for key in sorted(keys)}
+    if value_type in {list, tuple}:
+        return [_canonical_value(item) for item in value]
+    raise OrderIntentValidationError(f"unsupported payload value type {type(value).__name__}")
+
+
+def _wire_value(value: Any) -> Any:
+    value_type = type(value)
+    if value is None or value_type in {str, bool, int}:
+        return value
+    if value_type is Decimal:
+        if not value.is_finite():
+            raise OrderIntentValidationError("payload cannot contain non-finite Decimal")
+        return float(value)
+    if value_type is float:
+        if not math.isfinite(value):
+            raise OrderIntentValidationError("payload cannot contain non-finite float")
+        return value
+    if value_type is dict:
+        keys = list(value.keys())
+        if any(type(key) is not str for key in keys):
+            raise OrderIntentValidationError("payload keys must all be strings")
+        return {key: _wire_value(value[key]) for key in sorted(keys)}
+    if value_type in {list, tuple}:
+        return [_wire_value(item) for item in value]
+    raise OrderIntentValidationError(f"unsupported payload value type {type(value).__name__}")
+
+
+def _canonical_amount(value: Decimal | int | float | str) -> str:
+    if type(value) not in {Decimal, int, float, str}:
+        raise OrderIntentValidationError("amount must use an exact decimal-compatible primitive type")
+    try:
+        parsed = Decimal(str(value))
+    except (InvalidOperation, ValueError) as exc:
+        raise OrderIntentValidationError("amount must be a finite decimal") from exc
+    if not parsed.is_finite() or parsed < 0:
+        raise OrderIntentValidationError("amount must be non-negative and finite")
+    normalized = format(parsed, "f")
+    if "." in normalized:
+        normalized = normalized.rstrip("0").rstrip(".")
+    return "0" if normalized in {"", "-0"} else normalized
+
+
+def _validate_identity(name: str, value: str) -> None:
+    if type(value) is not str or not value or len(value) > 256 or any(ord(char) < 33 or ord(char) > 126 for char in value):
+        raise OrderIntentValidationError(f"{name} must be a printable non-empty ASCII string up to 256 characters")
+
+
+def _validate_fencing_token(value: int) -> None:
+    if type(value) is not int or value <= 0:
+        raise OrderIntentValidationError("fencing_token must be a positive exact integer")
+
+
+def _validate_environment(value: str) -> None:
+    if type(value) is not str or value not in _ENVIRONMENTS:
+        raise OrderIntentValidationError("environment must be sandbox or production")
+
+
+def _validate_sha256(name: str, value: str) -> None:
+    if type(value) is not str or len(value) != 64 or any(char not in "0123456789abcdef" for char in value):
+        raise OrderIntentValidationError(f"{name} must be a lowercase SHA-256 hex digest")
+
+
+def _validate_timestamp(value: datetime) -> None:
+    if type(value) is not datetime or value.tzinfo is not timezone.utc:
+        raise OrderIntentValidationError("timestamp must be an exact UTC datetime")
+
+
+def _to_us(value: datetime) -> int:
+    return int(value.astimezone(timezone.utc).timestamp() * 1_000_000)
+
+
+def _from_us(value: int) -> datetime:
+    return datetime.fromtimestamp(int(value) / 1_000_000, tz=timezone.utc)

--- a/etrade_python_client/tests/test_order_intent_ledger.py
+++ b/etrade_python_client/tests/test_order_intent_ledger.py
@@ -1,0 +1,1175 @@
+from __future__ import annotations
+
+import os
+import json
+import hashlib
+import sqlite3
+import tempfile
+import threading
+import unittest
+from concurrent.futures import ThreadPoolExecutor
+from datetime import datetime, timedelta, timezone
+from decimal import Decimal, localcontext
+from pathlib import Path
+
+from live_trading.order_intent_ledger import (
+    SCHEMA_VERSION,
+    BrokerEvidence,
+    AccountCapacityEvidence,
+    OutboundAuthorization,
+    OrderIntent,
+    OrderIntentIntegrityError,
+    OrderIntentLedger,
+    OrderIntentLeaseConflict,
+    OrderIntentReconciliationRequired,
+    OrderIntentReservationError,
+    OrderIntentTransitionError,
+    OrderIntentValidationError,
+    RiskEvidence,
+    canonical_order_payload,
+    normalize_order_payload,
+    stable_client_order_id,
+    wire_order_payload,
+)
+
+
+class AlwaysEqualAuthorization(OutboundAuthorization):
+    def __eq__(self, other):
+        return True
+
+    def __ne__(self, other):
+        return False
+
+
+class AlwaysEqualStr(str):
+    def __eq__(self, other):
+        return True
+
+    def __ne__(self, other):
+        return False
+
+
+class AlwaysEqualBytes(bytes):
+    def __eq__(self, other):
+        return True
+
+    def __ne__(self, other):
+        return False
+
+
+class AlwaysEqualInt(int):
+    def __eq__(self, other):
+        return True
+
+    def __ne__(self, other):
+        return False
+
+
+class AlwaysSmallDecimal(Decimal):
+    def __lt__(self, other):
+        return False
+
+    def __le__(self, other):
+        return False
+
+
+class BypassRiskEvidence(RiskEvidence):
+    def validate(self, now):
+        return None
+
+
+class BypassCapacityEvidence(AccountCapacityEvidence):
+    def validate(self, now):
+        return None
+
+
+class BypassBrokerEvidence(BrokerEvidence):
+    def validate(self, now):
+        return None
+
+
+class EvilDateTime(datetime):
+    def __sub__(self, other):
+        return timedelta(0)
+
+    def __gt__(self, other):
+        return False
+
+
+def hostile_authorizations(authorization):
+    malicious_bytes = b'{"malicious":"substitution"}'
+    return (
+        (
+            "authorization_subclass",
+            AlwaysEqualAuthorization(
+                intent_id=authorization.intent_id,
+                operation=authorization.operation,
+                owner=authorization.owner,
+                fencing_token=authorization.fencing_token,
+                client_order_id=authorization.client_order_id,
+                payload_bytes=malicious_bytes,
+                payload_digest="0" * 64,
+            ),
+        ),
+        (
+            "custom_str",
+            OutboundAuthorization(
+                intent_id=AlwaysEqualStr("malicious-intent"),
+                operation=authorization.operation,
+                owner=authorization.owner,
+                fencing_token=authorization.fencing_token,
+                client_order_id=authorization.client_order_id,
+                payload_bytes=authorization.payload_bytes,
+                payload_digest=authorization.payload_digest,
+            ),
+        ),
+        (
+            "custom_bytes",
+            OutboundAuthorization(
+                intent_id=authorization.intent_id,
+                operation=authorization.operation,
+                owner=authorization.owner,
+                fencing_token=authorization.fencing_token,
+                client_order_id=authorization.client_order_id,
+                payload_bytes=AlwaysEqualBytes(malicious_bytes),
+                payload_digest=hashlib.sha256(malicious_bytes).hexdigest(),
+            ),
+        ),
+    )
+
+
+class Clock:
+    def __init__(self):
+        self.now = datetime(2026, 7, 26, 16, 0, tzinfo=timezone.utc)
+
+    def __call__(self):
+        return self.now
+
+    def advance(self, seconds):
+        self.now += timedelta(seconds=seconds)
+
+
+def raw_payload(strike=620):
+    return {
+        "securityType": "OPTN", "orderAction": "SPREAD",
+        "priceType": "NET_CREDIT", "limitPrice": 1.25, "orderTerm": "GOOD_FOR_DAY",
+        "spreadType": "VERTICAL",
+        "legs": [
+            {"symbol": "SPY", "callPut": "PUT", "expiryYear": 2026, "expiryMonth": 8, "expiryDay": 21, "strikePrice": strike, "orderAction": "SELL_OPEN", "quantity": 1},
+            {"symbol": "SPY", "callPut": "PUT", "expiryYear": 2026, "expiryMonth": 8, "expiryDay": 21, "strikePrice": strike - 5, "orderAction": "BUY_OPEN", "quantity": 1},
+        ],
+    }
+
+
+def closing_payload():
+    payload = raw_payload()
+    payload["legs"][0]["orderAction"] = "SELL_CLOSE"
+    payload["legs"][1]["orderAction"] = "BUY_CLOSE"
+    return payload
+
+
+def make_intent(*, account="acct-1", environment="production", key="key-1", decision="decision-1", kind="OPENING", strike=620):
+    order_payload = raw_payload(strike)
+    if kind == "CLOSING":
+        order_payload["legs"][0]["orderAction"] = "SELL_CLOSE"
+        order_payload["legs"][1]["orderAction"] = "BUY_CLOSE"
+    return OrderIntent.build(
+        account_id=account, environment=environment, strategy_id="credit-spread", decision_id=decision,
+        idempotency_scope="decision", idempotency_key=key, intent_kind=kind, order_payload=order_payload,
+    )
+
+
+def risk(record, clock, *, collateral="500", max_loss="400", quote_time=None):
+    return RiskEvidence(
+        decision_id=record.envelope.decision_id,
+        max_loss_amount=Decimal(max_loss), collateral_amount=Decimal(collateral),
+        quote_observed_at=quote_time or clock.now,
+        quote_digest="a" * 64, portfolio_observed_at=quote_time or clock.now, portfolio_snapshot_digest="b" * 64,
+    )
+
+
+def capacity(clock, *, account="acct-1", environment="production", observed_at=None, buying_power="1000", risk_budget="1000", digest="b" * 64):
+    return AccountCapacityEvidence(account_id=account, environment=environment, broker_buying_power=Decimal(buying_power), risk_budget=Decimal(risk_budget), observed_at=observed_at or clock.now, portfolio_snapshot_digest=digest)
+
+
+def evidence(record, clock, *, operation="ORDER_QUERY", outcome="OPEN", broker_order_id="broker-1", client_order_id=None, observed_at=None):
+    return BrokerEvidence(
+        account_id=record.envelope.account_id, environment=record.envelope.environment,
+        client_order_id=client_order_id or record.client_order_id, broker_order_id=broker_order_id,
+        operation=operation, outcome=outcome, observed_at=observed_at or clock.now,
+        http_status=200, raw_response_digest="c" * 64,
+    )
+
+
+class OrderIntentLedgerTests(unittest.TestCase):
+    def setUp(self):
+        self.tmp = tempfile.TemporaryDirectory()
+        os.chmod(self.tmp.name, 0o700)
+        self.path = Path(self.tmp.name) / "runtime" / "orders.sqlite3"
+        self.clock = Clock()
+        self.ledger = OrderIntentLedger(self.path, clock=self.clock, run_id="run-a")
+
+    def tearDown(self):
+        self.tmp.cleanup()
+
+    def opening(self, *, key="key-1", account="acct-1"):
+        record = self.ledger.create_intent(make_intent(key=key, account=account)).intent
+        self.ledger.set_reservation_cap(capacity(self.clock, account=account))
+        self.ledger.reserve_margin(record.intent_id, risk(record, self.clock))
+        return record
+
+    def begin_submission(self, record, owner, lease):
+        authorization = self.ledger.prepare_submission_payload(record.intent_id, owner, lease.fencing_token)
+        return self.ledger.begin_submission(record.intent_id, owner, lease.fencing_token, authorization)
+
+    def begin_amendment(self, record, owner, lease):
+        authorization = self.ledger.prepare_amendment_payload(record.intent_id, owner, lease.fencing_token)
+        return self.ledger.begin_amendment(record.intent_id, owner, lease.fencing_token, authorization)
+
+    def test_wire_payload_is_actual_broker_schema_and_hash_representation_is_separate(self):
+        record = self.opening()
+        lease = self.ledger.claim_submission(record.intent_id, "worker", lease_seconds=30)
+        prepared = self.ledger.prepare_submission_payload(record.intent_id, "worker", lease.fencing_token)
+        payload = json.loads(prepared.payload_bytes)
+        self.assertIsInstance(payload["limitPrice"], float)
+        self.assertIsInstance(payload["legs"][0]["strikePrice"], int)
+        self.assertIsInstance(payload["legs"][0]["quantity"], int)
+        self.assertEqual(payload["client_order_id"], record.client_order_id)
+        self.assertNotIn("__number__", str(prepared))
+        self.assertIn("__number__", record.envelope.canonical_payload)
+
+    def test_generated_vertical_payload_is_normalized_without_hashing_ignored_fields(self):
+        generated = raw_payload()
+        generated.update({"client_order_id": 1234567890, "orderType": "SPREADS", "required_margin": 500})
+        normalized = normalize_order_payload(generated)
+        self.assertNotIn("client_order_id", normalized)
+        self.assertNotIn("orderType", normalized)
+        self.assertNotIn("required_margin", normalized)
+        record = OrderIntent.build(
+            account_id="acct", environment="production", strategy_id="s", decision_id="d",
+            idempotency_scope="scope", idempotency_key="key", intent_kind="OPENING", order_payload=generated,
+        )
+        self.assertNotIn("symbol", json.loads(record.wire_payload))
+        invalid = dict(normalized)
+        invalid["symbol"] = "SPY"
+        with self.assertRaises(OrderIntentValidationError):
+            OrderIntent.build(
+                account_id="acct", environment="production", strategy_id="s", decision_id="d",
+                idempotency_scope="scope", idempotency_key="other", intent_kind="OPENING", order_payload=invalid,
+            )
+
+    def test_idempotency_scope_is_not_payload_hash_and_client_id_binds_account_environment(self):
+        first = self.ledger.create_intent(make_intent()).intent
+        retry = self.ledger.create_intent(make_intent())
+        repeated = self.ledger.create_intent(make_intent(key="key-2", decision="decision-2")).intent
+        other = self.ledger.create_intent(make_intent(account="acct-2", key="key-1")).intent
+        self.assertFalse(retry.created)
+        self.assertEqual(first.envelope.payload_hash, repeated.envelope.payload_hash)
+        self.assertNotEqual(first.client_order_id, repeated.client_order_id)
+        self.assertNotEqual(first.client_order_id, other.client_order_id)
+        with self.assertRaises(OrderIntentIntegrityError):
+            self.ledger.create_intent(make_intent(strike=615))
+
+    def test_environment_exposure_and_broker_schema_are_strictly_derived(self):
+        with self.assertRaises(OrderIntentValidationError):
+            OrderIntent.build(account_id="acct", environment="live", strategy_id="s", decision_id="d", idempotency_scope="scope", idempotency_key="key", intent_kind="OPENING", order_payload=raw_payload())
+        with self.assertRaises(OrderIntentValidationError):
+            OrderIntent.build(account_id="acct", environment="production", strategy_id="s", decision_id="d", idempotency_scope="scope", idempotency_key="key", intent_kind="CLOSING", order_payload=raw_payload())
+        with self.assertRaises(OrderIntentValidationError):
+            OrderIntent.build(
+                account_id="acct",
+                environment="production",
+                strategy_id="s",
+                decision_id="d",
+                idempotency_scope="scope",
+                idempotency_key="closing",
+                intent_kind="CLOSING",
+                order_payload=closing_payload(),
+            )
+        malformed = raw_payload()
+        malformed["legs"][0]["quantity"] = 0
+        with self.assertRaises(OrderIntentValidationError):
+            OrderIntent.build(account_id="acct", environment="production", strategy_id="s", decision_id="d", idempotency_scope="scope", idempotency_key="key", intent_kind="OPENING", order_payload=malformed)
+
+    def test_equity_buy_and_sell_are_fail_closed_without_position_evidence(self):
+        for action in ("BUY", "SELL"):
+            payload = {
+                "symbol": "SPY", "securityType": "EQ", "orderAction": action,
+                "quantity": 100, "priceType": "MARKET", "orderTerm": "GOOD_FOR_DAY",
+            }
+            with self.assertRaises(OrderIntentValidationError):
+                OrderIntent.build(
+                    account_id="acct", environment="production", strategy_id="s", decision_id="d",
+                    idempotency_scope="scope", idempotency_key=f"equity-{action}",
+                    intent_kind="OPENING", order_payload=payload,
+                )
+
+    def test_opening_vertical_price_semantics_are_bounded_and_debit_reserve_is_derived(self):
+        for price_type, limit_price in (("NET_DEBIT", 10.0), ("MARKET", None), ("LIMIT", 1.0)):
+            payload = raw_payload()
+            payload["priceType"] = price_type
+            if limit_price is None:
+                payload.pop("limitPrice")
+            else:
+                payload["limitPrice"] = limit_price
+            with self.assertRaises(OrderIntentValidationError):
+                OrderIntent.build(
+                    account_id="acct", environment="production", strategy_id="s", decision_id="d",
+                    idempotency_scope="scope", idempotency_key=f"invalid-{price_type}",
+                    intent_kind="OPENING", order_payload=payload,
+                )
+        debit = raw_payload()
+        debit["priceType"] = "NET_DEBIT"
+        debit["limitPrice"] = 1.25
+        debit["legs"][0]["orderAction"] = "BUY_OPEN"
+        debit["legs"][1]["orderAction"] = "SELL_OPEN"
+        record = self.ledger.create_intent(OrderIntent.build(
+            account_id="acct-1", environment="production", strategy_id="credit-spread", decision_id="debit",
+            idempotency_scope="decision", idempotency_key="debit", intent_kind="OPENING", order_payload=debit,
+        )).intent
+        self.ledger.set_reservation_cap(capacity(self.clock))
+        with self.assertRaises(OrderIntentReservationError):
+            self.ledger.reserve_margin(record.intent_id, risk(record, self.clock, collateral="124.99", max_loss="124.99"))
+        reserved = self.ledger.reserve_margin(record.intent_id, risk(record, self.clock, collateral="125", max_loss="125"))
+        self.assertEqual(reserved.amount, Decimal("125"))
+
+    def test_opening_vertical_price_type_must_match_put_and_call_risk_orientation(self):
+        short_put_as_debit = raw_payload()
+        short_put_as_debit["priceType"] = "NET_DEBIT"
+        with self.assertRaises(OrderIntentValidationError):
+            OrderIntent.build(account_id="acct", environment="production", strategy_id="s", decision_id="d", idempotency_scope="scope", idempotency_key="put-debit", intent_kind="OPENING", order_payload=short_put_as_debit)
+        long_put_as_credit = raw_payload()
+        long_put_as_credit["legs"][0]["orderAction"] = "BUY_OPEN"
+        long_put_as_credit["legs"][1]["orderAction"] = "SELL_OPEN"
+        with self.assertRaises(OrderIntentValidationError):
+            OrderIntent.build(account_id="acct", environment="production", strategy_id="s", decision_id="d", idempotency_scope="scope", idempotency_key="put-credit", intent_kind="OPENING", order_payload=long_put_as_credit)
+        long_call_as_credit = raw_payload()
+        for leg in long_call_as_credit["legs"]:
+            leg["callPut"] = "CALL"
+        with self.assertRaises(OrderIntentValidationError):
+            OrderIntent.build(account_id="acct", environment="production", strategy_id="s", decision_id="d", idempotency_scope="scope", idempotency_key="call-credit", intent_kind="OPENING", order_payload=long_call_as_credit)
+        short_call_as_debit = raw_payload()
+        for leg in short_call_as_debit["legs"]:
+            leg["callPut"] = "CALL"
+        short_call_as_debit["legs"][0]["strikePrice"] = 615
+        short_call_as_debit["legs"][1]["strikePrice"] = 620
+        short_call_as_debit["priceType"] = "NET_DEBIT"
+        with self.assertRaises(OrderIntentValidationError):
+            OrderIntent.build(account_id="acct", environment="production", strategy_id="s", decision_id="d", idempotency_scope="scope", idempotency_key="call-debit", intent_kind="OPENING", order_payload=short_call_as_debit)
+        malformed = raw_payload()
+        malformed["legs"][1]["expiryDay"] = 31
+        malformed["legs"][1]["expiryMonth"] = 2
+        with self.assertRaises(OrderIntentValidationError):
+            OrderIntent.build(account_id="acct", environment="production", strategy_id="s", decision_id="d", idempotency_scope="scope", idempotency_key="key", intent_kind="OPENING", order_payload=malformed)
+
+    def test_risk_evidence_is_required_positive_fresh_and_bound_to_decision(self):
+        record = self.ledger.create_intent(make_intent()).intent
+        self.ledger.set_reservation_cap(capacity(self.clock))
+        with self.assertRaises(OrderIntentValidationError):
+            self.ledger.reserve_margin(record.intent_id, risk(record, self.clock, collateral="0", max_loss="0"))
+        with self.assertRaises(OrderIntentReservationError):
+            self.ledger.reserve_margin(record.intent_id, risk(record, self.clock, collateral="1", max_loss="1"))
+        with self.assertRaises(OrderIntentValidationError):
+            self.ledger.reserve_margin(record.intent_id, risk(record, self.clock, quote_time=self.clock.now - timedelta(minutes=6)))
+        bad = risk(record, self.clock)
+        object.__setattr__(bad, "decision_id", "other-decision")
+        with self.assertRaises(OrderIntentIntegrityError):
+            self.ledger.reserve_margin(record.intent_id, bad)
+        reservation = self.ledger.reserve_margin(record.intent_id, risk(record, self.clock))
+        self.assertEqual(reservation.max_loss_amount, Decimal("400"))
+        self.assertEqual(reservation.quote_digest, "a" * 64)
+        changed = risk(record, self.clock)
+        object.__setattr__(changed, "quote_digest", "e" * 64)
+        with self.assertRaises(OrderIntentTransitionError):
+            self.ledger.reserve_margin(record.intent_id, changed)
+
+    def test_evidence_rejects_numeric_identity_datetime_and_validate_subclasses(self):
+        record = self.ledger.create_intent(make_intent()).intent
+        normal_capacity = capacity(self.clock)
+        with self.assertRaises(OrderIntentValidationError):
+            self.ledger.set_reservation_cap(
+                BypassCapacityEvidence(**normal_capacity.__dict__)
+            )
+        with self.assertRaises(OrderIntentValidationError):
+            self.ledger.set_reservation_cap(
+                AccountCapacityEvidence(
+                    account_id="acct-1",
+                    environment="production",
+                    broker_buying_power=AlwaysSmallDecimal("1"),
+                    risk_budget=AlwaysSmallDecimal("1"),
+                    observed_at=self.clock.now,
+                    portfolio_snapshot_digest="b" * 64,
+                )
+            )
+        self.ledger.set_reservation_cap(normal_capacity)
+
+        normal_risk = risk(record, self.clock)
+        with self.assertRaises(OrderIntentValidationError):
+            self.ledger.reserve_margin(
+                record.intent_id, BypassRiskEvidence(**normal_risk.__dict__)
+            )
+        with self.assertRaises(OrderIntentValidationError):
+            self.ledger.reserve_margin(
+                record.intent_id,
+                RiskEvidence(
+                    decision_id=record.envelope.decision_id,
+                    max_loss_amount=AlwaysSmallDecimal("1"),
+                    collateral_amount=AlwaysSmallDecimal("1"),
+                    quote_observed_at=self.clock.now,
+                    quote_digest="a" * 64,
+                    portfolio_observed_at=self.clock.now,
+                    portfolio_snapshot_digest="b" * 64,
+                ),
+            )
+        with localcontext() as decimal_context:
+            decimal_context.prec = 1
+            with self.assertRaises(OrderIntentReservationError):
+                self.ledger.reserve_margin(
+                    record.intent_id,
+                    risk(record, self.clock, collateral="1", max_loss="1"),
+                )
+
+        self.ledger.reserve_margin(record.intent_id, normal_risk)
+        lease = self.ledger.claim_submission(record.intent_id, "worker", lease_seconds=30)
+        self.begin_submission(record, "worker", lease)
+        normal_broker = evidence(record, self.clock, operation="SUBMIT_ACK")
+        with self.assertRaises(OrderIntentValidationError):
+            self.ledger.record_post_acknowledgement(
+                record.intent_id,
+                "worker",
+                lease.fencing_token,
+                BypassBrokerEvidence(**normal_broker.__dict__),
+            )
+        hostile_identity = evidence(record, self.clock, operation="SUBMIT_ACK")
+        object.__setattr__(
+            hostile_identity,
+            "client_order_id",
+            AlwaysEqualStr(record.client_order_id),
+        )
+        with self.assertRaises(OrderIntentValidationError):
+            self.ledger.record_post_acknowledgement(
+                record.intent_id, "worker", lease.fencing_token, hostile_identity
+            )
+        hostile_time = evidence(record, self.clock, operation="SUBMIT_ACK")
+        object.__setattr__(
+            hostile_time,
+            "observed_at",
+            EvilDateTime(
+                self.clock.now.year,
+                self.clock.now.month,
+                self.clock.now.day,
+                self.clock.now.hour,
+                self.clock.now.minute,
+                tzinfo=timezone.utc,
+            ),
+        )
+        with self.assertRaises(OrderIntentValidationError):
+            self.ledger.record_post_acknowledgement(
+                record.intent_id, "worker", lease.fencing_token, hostile_time
+            )
+
+    def test_claim_rejects_stale_persisted_capacity_and_risk_evidence(self):
+        record = self.opening()
+        self.clock.advance(301)
+        with self.assertRaises(OrderIntentReservationError):
+            self.ledger.claim_submission(record.intent_id, "worker", lease_seconds=30)
+
+    def test_atomic_concurrent_reservation_cap_and_same_account_claim_blocker(self):
+        self.ledger.set_reservation_cap(capacity(self.clock))
+        left = self.ledger.create_intent(make_intent(key="left")).intent
+        right = self.ledger.create_intent(make_intent(key="right")).intent
+        barrier = threading.Barrier(2)
+        def reserve(record):
+            barrier.wait()
+            try:
+                self.ledger.reserve_margin(record.intent_id, risk(record, self.clock, collateral="600", max_loss="400"))
+                return True
+            except OrderIntentReservationError:
+                return False
+        with ThreadPoolExecutor(max_workers=2) as pool:
+            results = list(pool.map(reserve, (left, right)))
+        self.assertEqual(sum(results), 1)
+        winner = left if self.ledger.get_margin_reservation(left.intent_id) else right
+        other = right if winner is left else left
+        self.ledger.reserve_margin(
+            other.intent_id,
+            risk(other, self.clock, collateral="400", max_loss="400"),
+        )
+        lease = self.ledger.claim_submission(winner.intent_id, "worker-a", lease_seconds=30)
+        self.begin_submission(winner, "worker-a", lease)
+        with self.assertRaises(OrderIntentReconciliationRequired):
+            self.ledger.claim_submission(other.intent_id, "worker-b", lease_seconds=30)
+
+    def test_capacity_snapshots_are_ordered_can_reach_zero_and_block_new_claims(self):
+        record = self.ledger.create_intent(make_intent()).intent
+        self.ledger.set_reservation_cap(capacity(self.clock))
+        self.ledger.reserve_margin(record.intent_id, risk(record, self.clock))
+        with self.assertRaises(OrderIntentIntegrityError):
+            self.ledger.set_reservation_cap(capacity(self.clock, buying_power="0", risk_budget="0"))
+        self.clock.advance(1)
+        self.assertEqual(self.ledger.set_reservation_cap(capacity(self.clock, buying_power="0", risk_budget="0")), Decimal("0"))
+        with self.assertRaises(OrderIntentReservationError):
+            self.ledger.claim_submission(record.intent_id, "worker", lease_seconds=30)
+        blocked = self.ledger.create_intent(make_intent(key="zero-cap", decision="zero-cap")).intent
+        with self.assertRaises(OrderIntentReservationError):
+            self.ledger.reserve_margin(blocked.intent_id, risk(blocked, self.clock))
+
+    def test_reservation_requires_the_capacity_snapshot_used_for_its_portfolio_risk(self):
+        record = self.ledger.create_intent(make_intent()).intent
+        self.ledger.set_reservation_cap(capacity(self.clock, digest="d" * 64))
+        with self.assertRaises(OrderIntentIntegrityError):
+            self.ledger.reserve_margin(record.intent_id, risk(record, self.clock))
+
+    def test_expired_claim_is_durable_in_doubt_and_stale_worker_cannot_post_or_fail(self):
+        record = self.opening()
+        lease = self.ledger.claim_submission(record.intent_id, "worker", lease_seconds=5)
+        self.clock.advance(5)
+        with self.assertRaises(OrderIntentReconciliationRequired):
+            self.ledger.prepare_submission_payload(record.intent_id, "worker", lease.fencing_token)
+        self.assertEqual(self.ledger.get_intent(record.intent_id).state, "SUBMISSION_UNKNOWN")
+        with self.assertRaises(OrderIntentReconciliationRequired):
+            self.ledger.claim_submission(record.intent_id, "other", lease_seconds=5)
+
+    def test_submission_begin_rejects_economic_or_client_id_authorization_tampering(self):
+        record = self.opening()
+        lease = self.ledger.claim_submission(record.intent_id, "worker", lease_seconds=30)
+        authorization = self.ledger.prepare_submission_payload(record.intent_id, "worker", lease.fencing_token)
+        mutations = (
+            ("limitPrice", lambda payload: payload.__setitem__("limitPrice", 1.50)),
+            ("priceType", lambda payload: payload.__setitem__("priceType", "NET_DEBIT")),
+            ("orderTerm", lambda payload: payload.__setitem__("orderTerm", "IMMEDIATE_OR_CANCEL")),
+            ("spreadType", lambda payload: payload.__setitem__("spreadType", "CALENDAR")),
+            ("symbol", lambda payload: payload["legs"][0].__setitem__("symbol", "QQQ")),
+            ("callPut", lambda payload: payload["legs"][0].__setitem__("callPut", "CALL")),
+            ("expiry", lambda payload: payload["legs"][0].__setitem__("expiryDay", 28)),
+            ("strikePrice", lambda payload: payload["legs"][0].__setitem__("strikePrice", 625)),
+            ("orderAction", lambda payload: payload["legs"][0].__setitem__("orderAction", "BUY_OPEN")),
+            ("quantity", lambda payload: payload["legs"][0].__setitem__("quantity", 2)),
+            ("client_order_id", lambda payload: payload.__setitem__("client_order_id", "9999999999")),
+        )
+        for field, mutate in mutations:
+            with self.subTest(field=field):
+                payload = json.loads(authorization.payload_bytes)
+                mutate(payload)
+                payload_bytes = json.dumps(payload, sort_keys=True, separators=(",", ":"), ensure_ascii=True).encode("utf-8")
+                forged = OutboundAuthorization(
+                    intent_id=authorization.intent_id,
+                    operation=authorization.operation,
+                    owner=authorization.owner,
+                    fencing_token=authorization.fencing_token,
+                    client_order_id=payload["client_order_id"],
+                    payload_bytes=payload_bytes,
+                    payload_digest=hashlib.sha256(payload_bytes).hexdigest(),
+                )
+                with self.assertRaises(OrderIntentIntegrityError):
+                    self.ledger.begin_submission(record.intent_id, "worker", lease.fencing_token, forged)
+                self.assertEqual(self.ledger.get_intent(record.intent_id).state, "CLAIMED")
+        for attack, hostile in hostile_authorizations(authorization):
+            with self.subTest(attack=attack):
+                with self.assertRaises(OrderIntentValidationError):
+                    self.ledger.begin_submission(record.intent_id, "worker", lease.fencing_token, hostile)
+                self.assertEqual(self.ledger.get_intent(record.intent_id).state, "CLAIMED")
+        self.ledger.begin_submission(record.intent_id, "worker", lease.fencing_token, authorization)
+        with sqlite3.connect(self.path) as conn:
+            persisted = conn.execute(
+                "SELECT payload_bytes, payload_digest FROM outbound_authorizations WHERE intent_id = ? AND operation = 'SUBMIT'",
+                (record.intent_id,),
+            ).fetchone()
+        self.assertEqual(persisted, (authorization.payload_bytes, authorization.payload_digest))
+
+    def test_owner_and_fence_primitives_are_exact_at_every_mutation_boundary(self):
+        record = self.opening()
+        lease = self.ledger.claim_submission(record.intent_id, "worker", lease_seconds=30)
+        authorization = self.ledger.prepare_submission_payload(
+            record.intent_id, "worker", lease.fencing_token
+        )
+        hostile_owner = AlwaysEqualStr("worker")
+        hostile_fence = AlwaysEqualInt(lease.fencing_token)
+        for operation in (
+            lambda: self.ledger.renew_submission_lease(
+                record.intent_id, "worker", hostile_fence, lease_seconds=30
+            ),
+            lambda: self.ledger.prepare_submission_payload(
+                record.intent_id, hostile_owner, lease.fencing_token
+            ),
+            lambda: self.ledger.begin_submission(
+                record.intent_id, "worker", hostile_fence, authorization
+            ),
+            lambda: self.ledger.mark_pre_post_failed(
+                record.intent_id, "worker", hostile_fence
+            ),
+            lambda: self.ledger.mark_pre_post_failed(
+                record.intent_id, "worker", True
+            ),
+        ):
+            with self.assertRaises(OrderIntentValidationError):
+                operation()
+            self.assertEqual(self.ledger.get_intent(record.intent_id).state, "CLAIMED")
+
+        self.ledger.begin_submission(
+            record.intent_id, "worker", lease.fencing_token, authorization
+        )
+        submit_evidence = evidence(record, self.clock, operation="SUBMIT_ACK")
+        for owner, token in (
+            (hostile_owner, lease.fencing_token),
+            ("worker", hostile_fence),
+        ):
+            with self.assertRaises(OrderIntentValidationError):
+                self.ledger.record_post_acknowledgement(
+                    record.intent_id, owner, token, submit_evidence
+                )
+            with self.assertRaises(OrderIntentValidationError):
+                self.ledger.record_post_unknown(
+                    record.intent_id, owner, token, "POST_TIMEOUT"
+                )
+        self.ledger.record_post_acknowledgement(
+            record.intent_id,
+            "worker",
+            lease.fencing_token,
+            submit_evidence,
+        )
+
+        amendment = self.ledger.acquire_amendment_lease(
+            record.intent_id,
+            "nudger",
+            lease_seconds=30,
+            idempotency_key="primitive-fence",
+            amendment_payload=raw_payload(),
+        )
+        amendment_authorization = self.ledger.prepare_amendment_payload(
+            record.intent_id, "nudger", amendment.fencing_token
+        )
+        hostile_amendment_fence = AlwaysEqualInt(amendment.fencing_token)
+        for operation in (
+            lambda: self.ledger.prepare_amendment_payload(
+                record.intent_id, "nudger", hostile_amendment_fence
+            ),
+            lambda: self.ledger.begin_amendment(
+                record.intent_id,
+                "nudger",
+                hostile_amendment_fence,
+                amendment_authorization,
+            ),
+            lambda: self.ledger.release_amendment_lease(
+                record.intent_id, "nudger", hostile_amendment_fence
+            ),
+        ):
+            with self.assertRaises(OrderIntentValidationError):
+                operation()
+        self.ledger.begin_amendment(
+            record.intent_id,
+            "nudger",
+            amendment.fencing_token,
+            amendment_authorization,
+        )
+        with self.assertRaises(OrderIntentValidationError):
+            self.ledger.record_amendment_acknowledgement(
+                record.intent_id,
+                AlwaysEqualStr("nudger"),
+                amendment.fencing_token,
+                evidence(
+                    record,
+                    self.clock,
+                    operation="AMEND_ACK",
+                    client_order_id=amendment.client_order_id,
+                    broker_order_id="primitive-amended",
+                ),
+            )
+
+    def test_amendment_begin_rejects_economic_or_client_id_authorization_tampering(self):
+        record = self.opening()
+        submit = self.ledger.claim_submission(record.intent_id, "worker", lease_seconds=30)
+        self.begin_submission(record, "worker", submit)
+        self.ledger.record_post_acknowledgement(record.intent_id, "worker", submit.fencing_token, evidence(record, self.clock, operation="SUBMIT_ACK"))
+        amendment = self.ledger.acquire_amendment_lease(record.intent_id, "nudger", lease_seconds=30, idempotency_key="amend-auth", amendment_payload=raw_payload())
+        authorization = self.ledger.prepare_amendment_payload(record.intent_id, "nudger", amendment.fencing_token)
+        for field, value in (("limitPrice", 1.50), ("client_order_id", "9999999999")):
+            with self.subTest(field=field):
+                payload = json.loads(authorization.payload_bytes)
+                payload[field] = value
+                payload_bytes = json.dumps(payload, sort_keys=True, separators=(",", ":"), ensure_ascii=True).encode("utf-8")
+                forged = OutboundAuthorization(
+                    intent_id=authorization.intent_id,
+                    operation=authorization.operation,
+                    owner=authorization.owner,
+                    fencing_token=authorization.fencing_token,
+                    client_order_id=payload["client_order_id"],
+                    payload_bytes=payload_bytes,
+                    payload_digest=hashlib.sha256(payload_bytes).hexdigest(),
+                )
+                with self.assertRaises(OrderIntentIntegrityError):
+                    self.ledger.begin_amendment(record.intent_id, "nudger", amendment.fencing_token, forged)
+        for attack, hostile in hostile_authorizations(authorization):
+            with self.subTest(attack=attack):
+                with self.assertRaises(OrderIntentValidationError):
+                    self.ledger.begin_amendment(record.intent_id, "nudger", amendment.fencing_token, hostile)
+        self.ledger.begin_amendment(record.intent_id, "nudger", amendment.fencing_token, authorization)
+        with sqlite3.connect(self.path) as conn:
+            persisted = conn.execute(
+                "SELECT payload_bytes, payload_digest FROM outbound_authorizations WHERE intent_id = ? AND operation = 'AMEND'",
+                (record.intent_id,),
+            ).fetchone()
+        self.assertEqual(persisted, (authorization.payload_bytes, authorization.payload_digest))
+
+    def test_fabricated_stale_or_wrong_identity_broker_evidence_cannot_acknowledge(self):
+        record = self.opening()
+        lease = self.ledger.claim_submission(record.intent_id, "worker", lease_seconds=30)
+        self.begin_submission(record, "worker", lease)
+        stale = evidence(record, self.clock, operation="SUBMIT_ACK", observed_at=self.clock.now - timedelta(minutes=6))
+        with self.assertRaises(OrderIntentValidationError):
+            self.ledger.record_post_acknowledgement(record.intent_id, "worker", lease.fencing_token, stale)
+        wrong = evidence(record, self.clock, operation="SUBMIT_ACK", client_order_id="1000000000")
+        with self.assertRaises(OrderIntentIntegrityError):
+            self.ledger.record_post_acknowledgement(record.intent_id, "worker", lease.fencing_token, wrong)
+        ack = self.ledger.record_post_acknowledgement(record.intent_id, "worker", lease.fencing_token, evidence(record, self.clock, operation="SUBMIT_ACK"))
+        self.assertEqual(ack.state, "SUBMITTED")
+
+    def test_restart_reconciliation_keeps_terminal_reservation_until_r7b_position_evidence(self):
+        record = self.opening()
+        lease = self.ledger.claim_submission(record.intent_id, "worker", lease_seconds=30)
+        self.begin_submission(record, "worker", lease)
+        self.ledger.record_post_unknown(record.intent_id, "worker", lease.fencing_token, "POST_TIMEOUT")
+        restarted = OrderIntentLedger(self.path, clock=self.clock, run_id="run-b")
+        self.assertEqual([item.intent_id for item in restarted.reconciliation_blockers("acct-1", "production")], [record.intent_id])
+        filled = restarted.reconcile_terminal(record.intent_id, "FILLED", evidence(record, self.clock, outcome="FILLED"))
+        self.assertEqual(filled.state, "FILLED")
+        self.assertEqual(restarted.get_margin_reservation(record.intent_id).state, "FILLED_PENDING_ABSORPTION")
+        next_opening = restarted.create_intent(make_intent(key="next-opening", decision="next-decision")).intent
+        restarted.reserve_margin(next_opening.intent_id, risk(next_opening, self.clock))
+        with self.assertRaises(OrderIntentReservationError):
+            restarted.claim_submission(next_opening.intent_id, "new-worker", lease_seconds=30)
+        self.clock.advance(1)
+        with self.assertRaises(OrderIntentReconciliationRequired):
+            restarted.absorb_filled_reservation(record.intent_id, capacity(self.clock))
+        with self.assertRaises(OrderIntentReconciliationRequired):
+            restarted.absorb_filled_reservation(
+                record.intent_id, capacity(self.clock, digest="d" * 64)
+            )
+        self.assertEqual(
+            restarted.get_margin_reservation(record.intent_id).state,
+            "FILLED_PENDING_ABSORPTION",
+        )
+        event = next(item for item in restarted.events(record.intent_id) if item.reason_code == "BROKER_FILLED")
+        self.assertEqual(event.raw_response_digest, "c" * 64)
+        self.assertEqual((event.account_id, event.environment, event.client_order_id), ("acct-1", "production", record.client_order_id))
+        self.assertEqual((event.evidence_operation, event.http_status, event.broker_status), ("ORDER_QUERY", 200, "FILLED"))
+
+    def test_amendment_is_persisted_before_post_fenced_and_expiry_is_reconciliation_only(self):
+        record = self.opening()
+        submit = self.ledger.claim_submission(record.intent_id, "worker", lease_seconds=30)
+        self.begin_submission(record, "worker", submit)
+        submitted = self.ledger.record_post_acknowledgement(record.intent_id, "worker", submit.fencing_token, evidence(record, self.clock, operation="SUBMIT_ACK"))
+        amendment = self.ledger.acquire_amendment_lease(submitted.intent_id, "nudger", lease_seconds=5, idempotency_key="amend-1", amendment_payload=raw_payload())
+        begun = self.begin_amendment(submitted, "nudger", amendment)
+        self.assertEqual(begun.client_order_id, amendment.client_order_id)
+        with self.assertRaises(OrderIntentReconciliationRequired):
+            self.ledger.acquire_amendment_lease(submitted.intent_id, "other", lease_seconds=5, idempotency_key="amend-1", amendment_payload=raw_payload())
+        self.clock.advance(6)
+        self.assertEqual(self.ledger.reconciliation_blockers("acct-1", "production")[0].intent_id, submitted.intent_id)
+        self.ledger.reconcile_terminal(submitted.intent_id, "CANCELLED", evidence(submitted, self.clock, operation="AMEND_QUERY", outcome="CANCELLED", client_order_id=amendment.client_order_id))
+        with sqlite3.connect(self.path) as conn:
+            completion = conn.execute("SELECT completion_state FROM amendment_history WHERE intent_id = ? AND idempotency_key = ?", (submitted.intent_id, "amend-1")).fetchone()
+        self.assertEqual(completion, ("TERMINAL",))
+
+    def test_amendment_acknowledgement_requires_its_own_client_id_and_fence(self):
+        record = self.opening()
+        submit = self.ledger.claim_submission(record.intent_id, "worker", lease_seconds=30)
+        self.begin_submission(record, "worker", submit)
+        self.ledger.record_post_acknowledgement(record.intent_id, "worker", submit.fencing_token, evidence(record, self.clock, operation="SUBMIT_ACK"))
+        amendment = self.ledger.acquire_amendment_lease(record.intent_id, "nudger", lease_seconds=30, idempotency_key="amend-1", amendment_payload=raw_payload())
+        prepared = self.ledger.prepare_amendment_payload(record.intent_id, "nudger", amendment.fencing_token)
+        prepared_payload = json.loads(prepared.payload_bytes)
+        self.assertEqual(prepared_payload["client_order_id"], amendment.client_order_id)
+        self.assertIsInstance(prepared_payload["limitPrice"], float)
+        self.ledger.begin_amendment(record.intent_id, "nudger", amendment.fencing_token, prepared)
+        with self.assertRaises(OrderIntentIntegrityError):
+            self.ledger.record_amendment_acknowledgement(record.intent_id, "nudger", amendment.fencing_token, evidence(record, self.clock, operation="AMEND_ACK"))
+        amended = self.ledger.record_amendment_acknowledgement(record.intent_id, "nudger", amendment.fencing_token, evidence(record, self.clock, operation="AMEND_ACK", client_order_id=amendment.client_order_id, broker_order_id="broker-2"))
+        self.assertEqual(amended.broker_order_id, "broker-2")
+        changed = raw_payload()
+        changed["limitPrice"] = 1.2
+        with self.assertRaises(OrderIntentIntegrityError):
+            self.ledger.acquire_amendment_lease(record.intent_id, "nudger", lease_seconds=30, idempotency_key="amend-1", amendment_payload=changed)
+        with self.assertRaises(OrderIntentTransitionError):
+            self.ledger.acquire_amendment_lease(record.intent_id, "nudger", lease_seconds=30, idempotency_key="amend-1", amendment_payload=raw_payload())
+        with sqlite3.connect(self.path) as conn:
+            history = conn.execute("SELECT target_broker_order_id, client_order_id, payload_hash FROM amendment_history WHERE intent_id = ? AND idempotency_key = ?", (record.intent_id, "amend-1")).fetchone()
+        self.assertEqual(history[:2], ("broker-1", amendment.client_order_id))
+        self.assertEqual(len(history[2]), 64)
+
+    def test_original_intent_rejects_known_client_id_collision_with_completed_amendment(self):
+        source = self.opening(key="source")
+        submit = self.ledger.claim_submission(source.intent_id, "worker", lease_seconds=30)
+        self.begin_submission(source, "worker", submit)
+        self.ledger.record_post_acknowledgement(source.intent_id, "worker", submit.fencing_token, evidence(source, self.clock, operation="SUBMIT_ACK"))
+        amendment = self.ledger.acquire_amendment_lease(source.intent_id, "nudger", lease_seconds=30, idempotency_key="amend-13221", amendment_payload=raw_payload())
+        self.begin_amendment(source, "nudger", amendment)
+        self.ledger.record_amendment_acknowledgement(source.intent_id, "nudger", amendment.fencing_token, evidence(source, self.clock, operation="AMEND_ACK", client_order_id=amendment.client_order_id, broker_order_id="broker-amended"))
+        with self.assertRaises(OrderIntentIntegrityError):
+            self.ledger.create_intent(make_intent(key="target-210261"))
+
+    def test_amendment_is_reprice_only_and_in_doubt_lease_cannot_be_released(self):
+        record = self.opening()
+        submit = self.ledger.claim_submission(record.intent_id, "worker", lease_seconds=30)
+        self.begin_submission(record, "worker", submit)
+        self.ledger.record_post_acknowledgement(record.intent_id, "worker", submit.fencing_token, evidence(record, self.clock, operation="SUBMIT_ACK"))
+        altered = raw_payload()
+        altered["legs"][0]["strikePrice"] = 615
+        with self.assertRaises(OrderIntentValidationError):
+            self.ledger.acquire_amendment_lease(record.intent_id, "nudger", lease_seconds=30, idempotency_key="amend-1", amendment_payload=altered)
+        amendment = self.ledger.acquire_amendment_lease(record.intent_id, "nudger", lease_seconds=30, idempotency_key="amend-1", amendment_payload=raw_payload())
+        self.begin_amendment(record, "nudger", amendment)
+        with self.assertRaises(OrderIntentReconciliationRequired):
+            self.ledger.release_amendment_lease(record.intent_id, "nudger", amendment.fencing_token)
+
+    def test_amendment_fence_never_reuses_after_completed_amendment(self):
+        record = self.opening()
+        submit = self.ledger.claim_submission(record.intent_id, "worker", lease_seconds=30)
+        self.begin_submission(record, "worker", submit)
+        self.ledger.record_post_acknowledgement(record.intent_id, "worker", submit.fencing_token, evidence(record, self.clock, operation="SUBMIT_ACK"))
+        first = self.ledger.acquire_amendment_lease(record.intent_id, "worker", lease_seconds=30, idempotency_key="amend-a", amendment_payload=raw_payload())
+        self.begin_amendment(record, "worker", first)
+        self.ledger.record_amendment_acknowledgement(record.intent_id, "worker", first.fencing_token, evidence(record, self.clock, operation="AMEND_ACK", client_order_id=first.client_order_id, broker_order_id="broker-a2"))
+        replacement = raw_payload()
+        replacement["limitPrice"] = 1.2
+        second = self.ledger.acquire_amendment_lease(record.intent_id, "worker", lease_seconds=30, idempotency_key="amend-b", amendment_payload=replacement)
+        self.assertGreater(second.fencing_token, first.fencing_token)
+        with self.assertRaises(OrderIntentLeaseConflict):
+            self.ledger.begin_amendment(record.intent_id, "worker", first.fencing_token, self.ledger.prepare_amendment_payload(record.intent_id, "worker", first.fencing_token))
+
+    def test_stale_same_owner_release_cannot_delete_newer_amendment_lease(self):
+        record = self.opening()
+        submit = self.ledger.claim_submission(record.intent_id, "worker", lease_seconds=30)
+        self.begin_submission(record, "worker", submit)
+        self.ledger.record_post_acknowledgement(record.intent_id, "worker", submit.fencing_token, evidence(record, self.clock, operation="SUBMIT_ACK"))
+        first = self.ledger.acquire_amendment_lease(record.intent_id, "worker", lease_seconds=30, idempotency_key="amend-a", amendment_payload=raw_payload())
+        self.ledger.release_amendment_lease(record.intent_id, "worker", first.fencing_token)
+        replacement = raw_payload()
+        replacement["limitPrice"] = 1.2
+        second = self.ledger.acquire_amendment_lease(record.intent_id, "worker", lease_seconds=30, idempotency_key="amend-b", amendment_payload=replacement)
+        with self.assertRaises(OrderIntentLeaseConflict):
+            self.ledger.release_amendment_lease(record.intent_id, "worker", first.fencing_token)
+        prepared = self.ledger.prepare_amendment_payload(record.intent_id, "worker", second.fencing_token)
+        self.assertEqual(json.loads(prepared.payload_bytes)["client_order_id"], second.client_order_id)
+
+    def test_opening_reprice_cannot_increase_exposure_past_active_reservation(self):
+        record = self.opening()
+        submit = self.ledger.claim_submission(record.intent_id, "worker", lease_seconds=30)
+        self.begin_submission(record, "worker", submit)
+        self.ledger.record_post_acknowledgement(record.intent_id, "worker", submit.fencing_token, evidence(record, self.clock, operation="SUBMIT_ACK"))
+        risk_increasing = raw_payload()
+        risk_increasing["limitPrice"] = 0.10  # floor rises from $375 to $490.
+        with self.assertRaises(OrderIntentReservationError):
+            self.ledger.acquire_amendment_lease(record.intent_id, "nudger", lease_seconds=30, idempotency_key="increase-risk", amendment_payload=risk_increasing)
+        risk_reducing = raw_payload()
+        risk_reducing["limitPrice"] = 1.50  # floor falls to $350.
+        lease = self.ledger.acquire_amendment_lease(record.intent_id, "nudger", lease_seconds=30, idempotency_key="reduce-risk", amendment_payload=risk_reducing)
+        self.assertEqual(lease.intent_id, record.intent_id)
+
+    def test_amendment_lease_blocks_other_submissions_and_post_start_rechecks_risk(self):
+        record = self.opening()
+        submit = self.ledger.claim_submission(record.intent_id, "worker", lease_seconds=600)
+        self.begin_submission(record, "worker", submit)
+        self.ledger.record_post_acknowledgement(record.intent_id, "worker", submit.fencing_token, evidence(record, self.clock, operation="SUBMIT_ACK"))
+        amendment = self.ledger.acquire_amendment_lease(record.intent_id, "nudger", lease_seconds=600, idempotency_key="lease-block", amendment_payload=raw_payload())
+        other = self.ledger.create_intent(make_intent(key="other-opening", decision="other-opening")).intent
+        self.ledger.reserve_margin(
+            other.intent_id,
+            risk(other, self.clock, collateral="400", max_loss="400"),
+        )
+        with self.assertRaises(OrderIntentReconciliationRequired):
+            self.ledger.claim_submission(other.intent_id, "other", lease_seconds=30)
+        self.clock.advance(301)
+        with self.assertRaises(OrderIntentReservationError):
+            self.begin_amendment(record, "nudger", amendment)
+
+    def test_begin_submission_rechecks_capacity_after_claim(self):
+        record = self.opening()
+        submit = self.ledger.claim_submission(record.intent_id, "worker", lease_seconds=600)
+        self.clock.advance(1)
+        self.ledger.set_reservation_cap(capacity(self.clock, buying_power="0", risk_budget="0"))
+        with self.assertRaises(OrderIntentReservationError):
+            self.begin_submission(record, "worker", submit)
+        self.assertEqual(self.ledger.get_intent(record.intent_id).state, "CLAIMED")
+
+    def test_cancelled_and_expired_openings_hold_reservation_without_position_evidence(self):
+        for terminal in ("CANCELLED", "EXPIRED"):
+            with self.subTest(terminal=terminal):
+                self.clock.advance(1)
+                account = f"acct-{terminal.lower()}"
+                record = self.opening(key=f"{terminal}-opening", account=account)
+                submit = self.ledger.claim_submission(record.intent_id, "worker", lease_seconds=30)
+                self.begin_submission(record, "worker", submit)
+                self.ledger.record_post_acknowledgement(record.intent_id, "worker", submit.fencing_token, evidence(record, self.clock, operation="SUBMIT_ACK", broker_order_id=f"{terminal}-broker"))
+                self.ledger.reconcile_terminal(record.intent_id, terminal, evidence(record, self.clock, operation="ORDER_QUERY", outcome=terminal, broker_order_id=f"{terminal}-broker"))
+                self.assertEqual(self.ledger.get_margin_reservation(record.intent_id).state, "FILLED_PENDING_ABSORPTION")
+                blocked = self.ledger.create_intent(make_intent(account=account, key=f"{terminal}-blocked", decision=f"{terminal}-blocked")).intent
+                self.ledger.reserve_margin(blocked.intent_id, risk(blocked, self.clock))
+                with self.assertRaises(OrderIntentReservationError):
+                    self.ledger.claim_submission(blocked.intent_id, "blocked", lease_seconds=30)
+                self.clock.advance(1)
+                with self.assertRaises(OrderIntentReconciliationRequired):
+                    self.ledger.absorb_filled_reservation(
+                        record.intent_id, capacity(self.clock, account=account)
+                    )
+                with self.assertRaises(OrderIntentReconciliationRequired):
+                    self.ledger.absorb_filled_reservation(
+                        record.intent_id,
+                        capacity(self.clock, account=account, digest="d" * 64),
+                    )
+                with self.assertRaises(OrderIntentReservationError):
+                    self.ledger.claim_submission(blocked.intent_id, "still-blocked", lease_seconds=30)
+
+    def test_concurrent_amendment_race_has_one_winner(self):
+        record = self.opening()
+        submit = self.ledger.claim_submission(record.intent_id, "worker", lease_seconds=30)
+        self.begin_submission(record, "worker", submit)
+        self.ledger.record_post_acknowledgement(record.intent_id, "worker", submit.fencing_token, evidence(record, self.clock, operation="SUBMIT_ACK"))
+        barrier = threading.Barrier(2)
+        def acquire(owner):
+            barrier.wait()
+            try:
+                return self.ledger.acquire_amendment_lease(record.intent_id, owner, lease_seconds=30, idempotency_key="amend-1", amendment_payload=raw_payload()).owner
+            except OrderIntentLeaseConflict:
+                return None
+        with ThreadPoolExecutor(max_workers=2) as pool:
+            outcomes = list(pool.map(acquire, ("nudger-a", "nudger-b")))
+        self.assertEqual(sum(value is not None for value in outcomes), 1)
+
+    def test_schema_8_migrates_without_losing_the_ledger(self):
+        legacy_wire = wire_order_payload(closing_payload())
+        legacy_canonical = canonical_order_payload(json.loads(legacy_wire))
+        legacy = OrderIntent(
+            account_id="legacy-account",
+            environment="production",
+            strategy_id="legacy-close",
+            decision_id="legacy-decision",
+            idempotency_scope="legacy",
+            idempotency_key="legacy-closing",
+            intent_kind="CLOSING",
+            wire_payload=legacy_wire,
+            canonical_payload=legacy_canonical,
+            payload_hash=hashlib.sha256(
+                b"etrade-order-payload.v2\0" + legacy_canonical.encode("utf-8")
+            ).hexdigest(),
+        )
+        legacy_client_id = stable_client_order_id(legacy)
+        claimed_legacy = OrderIntent(
+            account_id=legacy.account_id,
+            environment=legacy.environment,
+            strategy_id=legacy.strategy_id,
+            decision_id="legacy-claimed-decision",
+            idempotency_scope=legacy.idempotency_scope,
+            idempotency_key="legacy-claimed",
+            intent_kind=legacy.intent_kind,
+            wire_payload=legacy.wire_payload,
+            canonical_payload=legacy.canonical_payload,
+            payload_hash=legacy.payload_hash,
+        )
+        claimed_client_id = stable_client_order_id(claimed_legacy)
+        now = int(self.clock.now.timestamp() * 1_000_000)
+        with sqlite3.connect(self.path) as conn:
+            conn.execute(
+                """
+                INSERT INTO order_intents (
+                    intent_id, account_id, environment, strategy_id, decision_id,
+                    idempotency_scope, idempotency_key, intent_kind, wire_payload,
+                    canonical_payload, payload_hash, client_order_id, state,
+                    broker_order_id, submission_fence, amendment_fence,
+                    submission_lease_owner, submission_lease_expires_at,
+                    pending_operation, pending_owner, pending_fence,
+                    last_reconciled_run, created_at, updated_at
+                ) VALUES (
+                    'legacy-closing-intent', ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?,
+                    'SUBMITTED', 'legacy-broker-order', 1, 0, NULL, NULL,
+                    NULL, NULL, NULL, 'legacy-run', ?, ?
+                )
+                """,
+                (
+                    legacy.account_id,
+                    legacy.environment,
+                    legacy.strategy_id,
+                    legacy.decision_id,
+                    legacy.idempotency_scope,
+                    legacy.idempotency_key,
+                    legacy.intent_kind,
+                    legacy.wire_payload,
+                    legacy.canonical_payload,
+                    legacy.payload_hash,
+                    legacy_client_id,
+                    now,
+                    now,
+                ),
+            )
+            conn.execute(
+                """
+                INSERT INTO order_intents (
+                    intent_id, account_id, environment, strategy_id, decision_id,
+                    idempotency_scope, idempotency_key, intent_kind, wire_payload,
+                    canonical_payload, payload_hash, client_order_id, state,
+                    broker_order_id, submission_fence, amendment_fence,
+                    submission_lease_owner, submission_lease_expires_at,
+                    pending_operation, pending_owner, pending_fence,
+                    last_reconciled_run, created_at, updated_at
+                ) VALUES (
+                    'legacy-claimed-intent', ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?,
+                    'CLAIMED', NULL, 1, 0, 'legacy-worker', ?, NULL, NULL, NULL,
+                    NULL, ?, ?
+                )
+                """,
+                (
+                    claimed_legacy.account_id,
+                    claimed_legacy.environment,
+                    claimed_legacy.strategy_id,
+                    claimed_legacy.decision_id,
+                    claimed_legacy.idempotency_scope,
+                    claimed_legacy.idempotency_key,
+                    claimed_legacy.intent_kind,
+                    claimed_legacy.wire_payload,
+                    claimed_legacy.canonical_payload,
+                    claimed_legacy.payload_hash,
+                    claimed_client_id,
+                    now + 30_000_000,
+                    now,
+                    now,
+                ),
+            )
+            conn.execute(
+                "UPDATE order_intents SET amendment_fence = 1 WHERE intent_id = 'legacy-closing-intent'"
+            )
+            conn.execute(
+                """
+                INSERT INTO amendment_leases (
+                    intent_id, broker_order_id, client_order_id, idempotency_key,
+                    wire_payload, canonical_payload, payload_hash, owner,
+                    fencing_token, state, expires_at, updated_at
+                ) VALUES (
+                    'legacy-closing-intent', 'legacy-broker-order', '1234567890',
+                    'legacy-amendment', ?, ?, ?, 'legacy-amender', 1, 'LEASED',
+                    ?, ?
+                )
+                """,
+                (
+                    legacy.wire_payload,
+                    legacy.canonical_payload,
+                    legacy.payload_hash,
+                    now + 30_000_000,
+                    now,
+                ),
+            )
+            conn.execute("DROP TRIGGER prevent_outbound_authorization_update")
+            conn.execute("DROP TRIGGER prevent_outbound_authorization_delete")
+            conn.execute("DROP TABLE outbound_authorizations")
+            conn.execute("UPDATE ledger_metadata SET schema_version = 8 WHERE singleton = 1")
+        migrated = OrderIntentLedger(self.path, clock=self.clock, run_id="run-migration")
+        with sqlite3.connect(self.path) as conn:
+            self.assertEqual(conn.execute("SELECT schema_version FROM ledger_metadata").fetchone()[0], SCHEMA_VERSION)
+            self.assertIsNotNone(conn.execute("SELECT 1 FROM sqlite_master WHERE type = 'table' AND name = 'outbound_authorizations'").fetchone())
+            self.assertIsNotNone(conn.execute("SELECT 1 FROM sqlite_master WHERE type = 'trigger' AND name = 'prevent_outbound_authorization_delete'").fetchone())
+        legacy_record = migrated.get_intent("legacy-closing-intent")
+        self.assertEqual(legacy_record.envelope.intent_kind, "CLOSING")
+        claimed_record = migrated.get_intent("legacy-claimed-intent")
+        claimed_payload = json.loads(claimed_legacy.wire_payload)
+        claimed_payload["client_order_id"] = claimed_client_id
+        claimed_bytes = json.dumps(
+            claimed_payload, sort_keys=True, separators=(",", ":"), ensure_ascii=True
+        ).encode("utf-8")
+        claimed_authorization = OutboundAuthorization(
+            intent_id=claimed_record.intent_id,
+            operation="SUBMIT",
+            owner="legacy-worker",
+            fencing_token=1,
+            client_order_id=claimed_client_id,
+            payload_bytes=claimed_bytes,
+            payload_digest=hashlib.sha256(claimed_bytes).hexdigest(),
+        )
+        with self.assertRaises(OrderIntentReservationError):
+            migrated.renew_submission_lease(
+                claimed_record.intent_id,
+                "legacy-worker",
+                1,
+                lease_seconds=30,
+            )
+        with self.assertRaises(OrderIntentReservationError):
+            migrated.prepare_submission_payload(
+                claimed_record.intent_id, "legacy-worker", 1
+            )
+        with self.assertRaises(OrderIntentReservationError):
+            migrated.begin_submission(
+                claimed_record.intent_id,
+                "legacy-worker",
+                1,
+                claimed_authorization,
+            )
+
+        amendment_payload = json.loads(legacy.wire_payload)
+        amendment_payload["client_order_id"] = "1234567890"
+        amendment_bytes = json.dumps(
+            amendment_payload, sort_keys=True, separators=(",", ":"), ensure_ascii=True
+        ).encode("utf-8")
+        amendment_authorization = OutboundAuthorization(
+            intent_id=legacy_record.intent_id,
+            operation="AMEND",
+            owner="legacy-amender",
+            fencing_token=1,
+            client_order_id="1234567890",
+            payload_bytes=amendment_bytes,
+            payload_digest=hashlib.sha256(amendment_bytes).hexdigest(),
+        )
+        with self.assertRaises(OrderIntentReservationError):
+            migrated.prepare_amendment_payload(
+                legacy_record.intent_id, "legacy-amender", 1
+            )
+        with self.assertRaises(OrderIntentReservationError):
+            migrated.begin_amendment(
+                legacy_record.intent_id,
+                "legacy-amender",
+                1,
+                amendment_authorization,
+            )
+        migrated.release_amendment_lease(
+            legacy_record.intent_id, "legacy-amender", 1
+        )
+        reconciled = migrated.mark_reconciled(
+            legacy_record.intent_id,
+            BrokerEvidence(
+                account_id=legacy.account_id,
+                environment=legacy.environment,
+                client_order_id=legacy_client_id,
+                broker_order_id="legacy-broker-order",
+                operation="ORDER_QUERY",
+                outcome="OPEN",
+                observed_at=self.clock.now,
+                http_status=200,
+                raw_response_digest="f" * 64,
+            ),
+        )
+        self.assertEqual(reconciled.state, "SUBMITTED")
+        self.assertEqual(migrated.path, self.path)
+
+    def test_owner_only_database_schema_and_identity_tamper_trigger(self):
+        self.assertEqual(os.stat(self.path.parent).st_mode & 0o777, 0o700)
+        self.assertEqual(os.stat(self.path).st_mode & 0o777, 0o600)
+        record = self.ledger.create_intent(make_intent()).intent
+        with sqlite3.connect(self.path) as conn:
+            self.assertEqual(conn.execute("SELECT schema_version FROM ledger_metadata").fetchone()[0], SCHEMA_VERSION)
+            with self.assertRaises(sqlite3.DatabaseError):
+                conn.execute("UPDATE order_intents SET wire_payload = '{}' WHERE intent_id = ?", (record.intent_id,))
+            conn.execute("INSERT INTO broker_order_history (broker_order_id, intent_id, first_seen_at) VALUES (?, ?, ?)", ("historic-broker", record.intent_id, 0))
+            with self.assertRaises(sqlite3.DatabaseError):
+                conn.execute("DELETE FROM broker_order_history WHERE broker_order_id = ?", ("historic-broker",))
+        for suffix in ("-journal", "-wal", "-shm"):
+            sidecar = Path(f"{self.path}{suffix}")
+            descriptor = os.open(sidecar, os.O_CREAT | os.O_WRONLY, 0o600)
+            os.close(descriptor)
+            os.chmod(sidecar, 0o644)
+            with self.assertRaises(OrderIntentValidationError):
+                self.ledger.get_intent(record.intent_id)
+            sidecar.unlink()
+        os.chmod(self.path, 0o644)
+        with self.assertRaises(OrderIntentValidationError):
+            OrderIntentLedger(self.path, clock=self.clock, run_id="run-b")
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

- add a durable SQLite order-intent state machine with stable idempotency and client IDs
- enforce account capacity reservations, vertical-spread exposure floors, monotonic submission/amendment fencing, and reconciliation-only ambiguous outcomes
- persist immutable semantic outbound authorizations before the broker mutation boundary
- fail closed for new closing orders and terminal reservation release until R7b adds position-level evidence
- preserve reconciliation of previously persisted closing orders across the additive schema 8 to 9 migration

## Safety scope

This is an isolated broker-agnostic foundation. No live code instantiates it, so it does not yet protect E*TRADE mutations. R7b must provide the sole private transport, construct broker evidence from real responses, bind the final route/preview/XML body, add position capacity and cancellation, reconcile on startup, and prohibit legacy direct order calls.

## Verification

- 32 focused ledger tests passed
- 197 deterministic non-integration tests passed in a clean worktree
- py_compile and diff-check passed
- independent causal and security reviews found no remaining P0/P1 in the isolated core

## Stack

Base: codex/live-risk-containment (PR #29)
