### PR TITLE
R7b: add fail-closed E*TRADE mutation transport

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -31,6 +31,16 @@ option_value_plot/
 *.csv
 *.db
 *.sqlite
+*.sqlite3
+*.db-journal
+*.db-wal
+*.db-shm
+*.sqlite-journal
+*.sqlite-wal
+*.sqlite-shm
+*.sqlite3-journal
+*.sqlite3-wal
+*.sqlite3-shm
 
 # Secrets
 .env

--- a/etrade_python_client/live_trading/etrade_broker_transport.py
+++ b/etrade_python_client/live_trading/etrade_broker_transport.py
@@ -1,0 +1,2094 @@
+"""Private, no-retry E*TRADE order-mutation transport.
+
+The durable order ledger authorizes exact JSON bytes.  This module is the
+single adapter that may transform those bytes into E*TRADE XML and issue an
+HTTP mutation.  It deliberately contains no retry, reconciliation, strategy,
+or risk-policy logic.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import hmac
+import json
+import math
+import multiprocessing
+import re
+import secrets
+import struct
+import threading
+import time
+from dataclasses import dataclass, field
+from datetime import date, datetime, timezone
+from decimal import Decimal
+from typing import Any, Literal
+from urllib.parse import quote, urlsplit
+from xml.etree import ElementTree as ET
+
+from rauth import OAuth1Session
+from rauth.utils import CaseInsensitiveDict, OAuth1Auth
+from requests import PreparedRequest, Request
+from requests.adapters import HTTPAdapter
+from requests.exceptions import Timeout
+from urllib3.util.retry import Retry
+
+from live_trading.order_intent_ledger import (
+    OrderIntentLedger,
+    OutboundAuthorization,
+    TransportRequestEvidence,
+    TransportResponseEvidence,
+    wire_order_payload,
+)
+from live_trading.runtime_safety import RuntimeSafetyBoundary
+
+
+_MAX_AUTHORIZATION_BYTES = 32 * 1024
+_MAX_RESPONSE_BYTES = 64 * 1024
+_MAX_RESPONSE_NODES = 512
+_REQUEST_TIMEOUT = (3.05, 10.0)
+_RESPONSE_WALL_TIMEOUT_SECONDS = 12.0
+_TOTAL_EXCHANGE_TIMEOUT_SECONDS = 15.0
+_EXCHANGE_RESULT_HEADER_BYTES = 39
+_EXCHANGE_RESULT_BUFFER_BYTES = (
+    _EXCHANGE_RESULT_HEADER_BYTES + _MAX_RESPONSE_BYTES + 1
+)
+_EXCHANGE_KIND_CODES = {
+    "RESPONSE": 1,
+    "TIMEOUT": 2,
+    "TRANSPORT_ERROR": 3,
+    "MALFORMED_RESPONSE": 4,
+}
+_EXCHANGE_CODE_KINDS = {
+    code: kind for kind, code in _EXCHANGE_KIND_CODES.items()
+}
+_MAX_BROKER_INT64 = 9_223_372_036_854_775_807
+_ETRADE_ORIGINS = {
+    "sandbox": "https://apisb.etrade.com",
+    "production": "https://api.etrade.com",
+}
+_TRANSPORT_OPERATIONS = frozenset(
+    {"SUBMIT_PREVIEW", "SUBMIT_PLACE", "AMEND_PREVIEW", "AMEND_PLACE"}
+)
+_OPTION_SYMBOL = re.compile(r"[A-Z][A-Z0-9.-]{0,14}\Z")
+
+
+class ETradeBrokerTransportError(RuntimeError):
+    """A local transport contract is invalid before broker I/O."""
+
+
+@dataclass(frozen=True, repr=False)
+class _PreparedExchange:
+    """Pickle-safe exact request handed to the isolated HTTP worker."""
+
+    method: Literal["POST", "PUT"]
+    url: str
+    headers: tuple[tuple[str, str], ...] = field(repr=False)
+    body: bytes = field(repr=False)
+
+    def __post_init__(self) -> None:
+        _validate_prepared_exchange(self)
+
+
+@dataclass(frozen=True, repr=False)
+class _ExchangeResult:
+    """Bounded result returned by the isolated HTTP worker."""
+
+    kind: Literal[
+        "RESPONSE", "TIMEOUT", "TRANSPORT_ERROR", "MALFORMED_RESPONSE"
+    ]
+    http_status: int | None = None
+    raw_response: bytes = field(default=b"", repr=False)
+
+    def __post_init__(self) -> None:
+        _validate_exchange_result(self)
+
+
+@dataclass(frozen=True)
+class SelectedBrokerAccount:
+    """Account identity obtained from the authenticated List Accounts result."""
+
+    account_id: str = field(repr=False)
+    account_id_key: str = field(repr=False)
+    institution_type: str
+
+    def __post_init__(self) -> None:
+        if type(self) is not SelectedBrokerAccount:
+            raise ETradeBrokerTransportError(
+                "selected account must use its exact immutable type"
+            )
+        _broker_numeric_text(self.account_id, "account id")
+        _identifier(self.account_id_key, "account key")
+        _identifier(self.institution_type, "institution type")
+
+    def runtime_mapping(self) -> dict[str, str]:
+        return {
+            "accountId": self.account_id,
+            "accountIdKey": self.account_id_key,
+            "institutionType": self.institution_type,
+        }
+
+
+@dataclass(frozen=True)
+class BoundBrokerRequest:
+    """Exact request authorized for one account, route, and ledger fence."""
+
+    account_id: str = field(repr=False)
+    account_id_key: str = field(repr=False)
+    institution_type: str
+    environment: Literal["sandbox", "production"]
+    intent_id: str
+    owner: str
+    authorization_operation: Literal["SUBMIT", "AMEND"]
+    fencing_token: int
+    transport_operation: Literal[
+        "SUBMIT_PREVIEW", "SUBMIT_PLACE", "AMEND_PREVIEW", "AMEND_PLACE"
+    ]
+    http_method: Literal["POST", "PUT"]
+    route: str = field(repr=False)
+    client_order_id: str = field(repr=False)
+    target_broker_order_id: str | None = field(repr=False)
+    preview_id: str | None = field(repr=False)
+    authorization_payload_digest: str
+    final_xml_bytes: bytes = field(repr=False)
+    final_xml_sha256: str
+    transport_seal: bytes = field(repr=False, compare=False)
+
+    def __post_init__(self) -> None:
+        if type(self) is not BoundBrokerRequest:
+            raise ETradeBrokerTransportError("bound request must use its exact type")
+        _broker_numeric_text(self.account_id, "account id")
+        _identifier(self.account_id_key, "account key")
+        _identifier(self.institution_type, "institution type")
+        _identifier(self.intent_id, "intent id")
+        _identifier(self.owner, "owner")
+        _identifier(self.client_order_id, "client order id")
+        if type(self.environment) is not str or self.environment not in {
+            "sandbox",
+            "production",
+        }:
+            raise ETradeBrokerTransportError("bound request environment is invalid")
+        if (
+            type(self.authorization_operation) is not str
+            or self.authorization_operation not in {"SUBMIT", "AMEND"}
+        ):
+            raise ETradeBrokerTransportError("bound authorization operation is invalid")
+        if type(self.fencing_token) is not int or self.fencing_token <= 0:
+            raise ETradeBrokerTransportError("bound fencing token is invalid")
+        if (
+            type(self.transport_operation) is not str
+            or self.transport_operation not in _TRANSPORT_OPERATIONS
+        ):
+            raise ETradeBrokerTransportError("bound transport operation is invalid")
+        if type(self.http_method) is not str or self.http_method not in {"POST", "PUT"}:
+            raise ETradeBrokerTransportError("bound HTTP method is invalid")
+        if type(self.route) is not str:
+            raise ETradeBrokerTransportError("bound route is invalid")
+        if self.target_broker_order_id is not None:
+            _broker_numeric_text(
+                self.target_broker_order_id, "target broker order id"
+            )
+        if self.preview_id is not None:
+            _broker_numeric_text(self.preview_id, "preview id")
+        _sha256(self.authorization_payload_digest, "authorization payload digest")
+        if type(self.final_xml_bytes) is not bytes or not self.final_xml_bytes:
+            raise ETradeBrokerTransportError("bound XML must be non-empty exact bytes")
+        _sha256(self.final_xml_sha256, "bound XML digest")
+        if not hmac.compare_digest(
+            hashlib.sha256(self.final_xml_bytes).hexdigest(), self.final_xml_sha256
+        ):
+            raise ETradeBrokerTransportError("bound XML digest does not verify")
+        if type(self.transport_seal) is not bytes or len(self.transport_seal) != 32:
+            raise ETradeBrokerTransportError("bound request seal is invalid")
+        _validate_bound_request_shape(self)
+
+
+@dataclass(frozen=True)
+class BrokerMessage:
+    code: int
+    message_type: Literal["WARNING", "INFO", "INFO_HOLD", "ERROR"]
+    description: str = field(repr=False)
+
+    def __post_init__(self) -> None:
+        if type(self) is not BrokerMessage:
+            raise ETradeBrokerTransportError("broker message must use its exact type")
+        _validate_broker_message(
+            self.description, self.code, self.message_type
+        )
+
+
+@dataclass(frozen=True)
+class BrokerReply:
+    """Bound, redacted result of exactly one broker mutation request."""
+
+    request: BoundBrokerRequest
+    disposition: Literal["ACKNOWLEDGED", "UNKNOWN"]
+    http_status: int | None
+    broker_status: str | None
+    client_order_id: str = field(repr=False)
+    echoed_client_order_id: str | None = field(repr=False)
+    broker_order_id: str | None = field(repr=False)
+    preview_id: str | None = field(repr=False)
+    broker_messages: tuple[BrokerMessage, ...]
+    raw_response_digest: str | None
+    observed_at: datetime
+    unknown_reason: str | None
+
+    def __post_init__(self) -> None:
+        if type(self) is not BrokerReply or type(self.request) is not BoundBrokerRequest:
+            raise ETradeBrokerTransportError("broker reply must use exact bound types")
+        if type(self.disposition) is not str or self.disposition not in {
+            "ACKNOWLEDGED",
+            "UNKNOWN",
+        }:
+            raise ETradeBrokerTransportError("broker reply disposition is invalid")
+        if self.http_status is not None and (
+            type(self.http_status) is not int or not 100 <= self.http_status <= 599
+        ):
+            raise ETradeBrokerTransportError("broker reply HTTP status is invalid")
+        _optional_identifier(self.broker_status, "broker status")
+        _identifier(self.client_order_id, "client order id")
+        if self.client_order_id != self.request.client_order_id:
+            raise ETradeBrokerTransportError("broker reply client id is not request-bound")
+        _optional_identifier(self.echoed_client_order_id, "echoed client order id")
+        if self.broker_order_id is not None:
+            _broker_numeric_text(self.broker_order_id, "broker order id")
+        if self.preview_id is not None:
+            _broker_numeric_text(self.preview_id, "preview id")
+        if (
+            type(self.broker_messages) is not tuple
+            or any(type(message) is not BrokerMessage for message in self.broker_messages)
+        ):
+            raise ETradeBrokerTransportError("broker reply messages are invalid")
+        if self.raw_response_digest is not None:
+            _sha256(self.raw_response_digest, "raw response digest")
+        if (
+            type(self.observed_at) is not datetime
+            or self.observed_at.tzinfo is not timezone.utc
+        ):
+            raise ETradeBrokerTransportError("broker reply time must be exact UTC")
+        if (self.disposition == "UNKNOWN") != (self.unknown_reason is not None):
+            raise ETradeBrokerTransportError("unknown reply reason is inconsistent")
+        if self.unknown_reason is not None:
+            _identifier(self.unknown_reason, "unknown reason")
+        if self.disposition == "ACKNOWLEDGED":
+            if self.broker_messages and not _messages_allow_ack(
+                self.request.transport_operation, self.broker_messages
+            ):
+                raise ETradeBrokerTransportError(
+                    "broker messages require review before acknowledgement"
+                )
+            if self.request.transport_operation.endswith("PREVIEW") and self.preview_id is None:
+                raise ETradeBrokerTransportError("preview acknowledgement lacks preview id")
+            if self.request.transport_operation.endswith("PLACE") and self.broker_order_id is None:
+                raise ETradeBrokerTransportError("place acknowledgement lacks broker order id")
+
+
+class ETradeBrokerTransport:
+    """Issue one ledger-claimed E*TRADE mutation through a pinned adapter."""
+
+    def __init__(
+        self,
+        *,
+        session: OAuth1Session,
+        ledger: OrderIntentLedger,
+        runtime_safety: RuntimeSafetyBoundary,
+        selected_account: SelectedBrokerAccount,
+    ) -> None:
+        if type(session) is not OAuth1Session:
+            raise ETradeBrokerTransportError(
+                "order transport requires an exact rauth OAuth1Session"
+            )
+        if type(ledger) is not OrderIntentLedger:
+            raise ETradeBrokerTransportError(
+                "order transport requires an exact durable ledger"
+            )
+        if type(runtime_safety) is not RuntimeSafetyBoundary:
+            raise ETradeBrokerTransportError(
+                "order transport requires an exact runtime safety boundary"
+            )
+        if type(selected_account) is not SelectedBrokerAccount:
+            raise ETradeBrokerTransportError(
+                "order transport requires an exact selected account"
+            )
+        if (
+            runtime_safety.environment not in {"sandbox", "production"}
+            or runtime_safety.expected_account_id is None
+            or runtime_safety.expected_account_id_key is None
+            or runtime_safety.expected_institution_type is None
+        ):
+            raise ETradeBrokerTransportError(
+                "order-capable runtime requires an explicitly armed account"
+            )
+        runtime_safety.assert_current()
+        runtime_safety.verify_account(selected_account.runtime_mapping())
+        credentials = (
+            session.consumer_key,
+            session.consumer_secret,
+            session.access_token,
+            session.access_token_secret,
+        )
+        if any(type(value) is not str or not value for value in credentials):
+            raise ETradeBrokerTransportError(
+                "OAuth session lacks exact consumer/access credentials"
+            )
+        self._oauth = OAuth1Session(
+            session.consumer_key,
+            session.consumer_secret,
+            access_token=session.access_token,
+            access_token_secret=session.access_token_secret,
+        )
+        self._oauth.trust_env = False
+        self._oauth.params = {}
+        self._oauth.proxies = {}
+        self._oauth.hooks = {"response": []}
+        self._oauth.cookies.clear()
+        self._oauth.verify = True
+        self._oauth.cert = None
+        self._ledger = ledger
+        self._runtime_safety = runtime_safety
+        self._selected_account = selected_account
+        self._account_id = selected_account.account_id
+        self._account_id_key = selected_account.account_id_key
+        self._institution_type = selected_account.institution_type
+        self._environment = runtime_safety.environment
+        self._binding_secret = secrets.token_bytes(32)
+        self._send_lock = threading.Lock()
+
+    def preview(self, authorization: OutboundAuthorization) -> BrokerReply:
+        request = self._build_request(
+            authorization=authorization,
+            expected_authorization_operation="SUBMIT",
+            transport_operation="SUBMIT_PREVIEW",
+            http_method="POST",
+            target_broker_order_id=None,
+            preview_id=None,
+        )
+        return self._execute(request, authorization)
+
+    def place(
+        self, authorization: OutboundAuthorization, preview: BrokerReply
+    ) -> BrokerReply:
+        preview_id = self._preview_id(
+            preview, authorization, expected_operation="SUBMIT_PREVIEW"
+        )
+        request = self._build_request(
+            authorization=authorization,
+            expected_authorization_operation="SUBMIT",
+            transport_operation="SUBMIT_PLACE",
+            http_method="POST",
+            target_broker_order_id=None,
+            preview_id=preview_id,
+        )
+        return self._execute(request, authorization)
+
+    def preview_change(
+        self, target_broker_order_id: str, authorization: OutboundAuthorization
+    ) -> BrokerReply:
+        request = self._build_request(
+            authorization=authorization,
+            expected_authorization_operation="AMEND",
+            transport_operation="AMEND_PREVIEW",
+            http_method="PUT",
+            target_broker_order_id=_broker_numeric_text(
+                target_broker_order_id, "target broker order id"
+            ),
+            preview_id=None,
+        )
+        return self._execute(request, authorization)
+
+    def place_change(
+        self,
+        target_broker_order_id: str,
+        authorization: OutboundAuthorization,
+        preview: BrokerReply,
+    ) -> BrokerReply:
+        preview_id = self._preview_id(
+            preview, authorization, expected_operation="AMEND_PREVIEW"
+        )
+        request = self._build_request(
+            authorization=authorization,
+            expected_authorization_operation="AMEND",
+            transport_operation="AMEND_PLACE",
+            http_method="PUT",
+            target_broker_order_id=_broker_numeric_text(
+                target_broker_order_id, "target broker order id"
+            ),
+            preview_id=preview_id,
+        )
+        return self._execute(request, authorization)
+
+    def _preview_id(
+        self,
+        preview: BrokerReply,
+        authorization: OutboundAuthorization,
+        *,
+        expected_operation: Literal["SUBMIT_PREVIEW", "AMEND_PREVIEW"],
+    ) -> str:
+        if (
+            type(preview) is not BrokerReply
+            or preview.disposition != "ACKNOWLEDGED"
+            or type(preview.request) is not BoundBrokerRequest
+            or preview.request.transport_operation != expected_operation
+            or preview.preview_id is None
+        ):
+            raise ETradeBrokerTransportError(
+                "place requires an acknowledged typed preview receipt"
+            )
+        self._verify_bound_request(preview.request)
+        if (
+            preview.request.account_id != self._account_id
+            or preview.request.account_id_key != self._account_id_key
+            or preview.request.environment != self._environment
+            or preview.request.intent_id != authorization.intent_id
+            or preview.request.owner != authorization.owner
+            or preview.request.fencing_token != authorization.fencing_token
+            or preview.request.authorization_payload_digest
+            != authorization.payload_digest
+            or preview.client_order_id != authorization.client_order_id
+        ):
+            raise ETradeBrokerTransportError(
+                "preview receipt does not match the place authorization"
+            )
+        return _broker_numeric_text(preview.preview_id, "preview id")
+
+    def _build_request(
+        self,
+        *,
+        authorization: OutboundAuthorization,
+        expected_authorization_operation: Literal["SUBMIT", "AMEND"],
+        transport_operation: Literal[
+            "SUBMIT_PREVIEW", "SUBMIT_PLACE", "AMEND_PREVIEW", "AMEND_PLACE"
+        ],
+        http_method: Literal["POST", "PUT"],
+        target_broker_order_id: str | None,
+        preview_id: str | None,
+    ) -> BoundBrokerRequest:
+        order = _authorized_vertical(authorization, expected_authorization_operation)
+        xml_bytes = _order_xml(
+            order,
+            place=transport_operation.endswith("PLACE"),
+            preview_id=preview_id,
+        )
+        encoded_account = quote(self._account_id_key, safe="")
+        if transport_operation in {"AMEND_PREVIEW", "AMEND_PLACE"}:
+            encoded_target = quote(target_broker_order_id or "", safe="")
+            action = "place" if transport_operation == "AMEND_PLACE" else "preview"
+            route = (
+                f"/v1/accounts/{encoded_account}/orders/"
+                f"{encoded_target}/change/{action}"
+            )
+        else:
+            suffix = "place" if transport_operation == "SUBMIT_PLACE" else "preview"
+            route = f"/v1/accounts/{encoded_account}/orders/{suffix}"
+        fields = {
+            "account_id": self._account_id,
+            "account_id_key": self._account_id_key,
+            "institution_type": self._institution_type,
+            "environment": self._environment,
+            "intent_id": authorization.intent_id,
+            "owner": authorization.owner,
+            "authorization_operation": authorization.operation,
+            "fencing_token": authorization.fencing_token,
+            "transport_operation": transport_operation,
+            "http_method": http_method,
+            "route": route,
+            "client_order_id": authorization.client_order_id,
+            "target_broker_order_id": target_broker_order_id,
+            "preview_id": preview_id,
+            "authorization_payload_digest": authorization.payload_digest,
+            "final_xml_bytes": xml_bytes,
+            "final_xml_sha256": hashlib.sha256(xml_bytes).hexdigest(),
+        }
+        transport_seal = hmac.new(
+            self._binding_secret,
+            _bound_request_material(fields),
+            hashlib.sha256,
+        ).digest()
+        return BoundBrokerRequest(
+            **fields,
+            transport_seal=transport_seal,
+        )
+
+    def _execute(
+        self,
+        request: BoundBrokerRequest,
+        authorization: OutboundAuthorization,
+    ) -> BrokerReply:
+        with self._send_lock:
+            self._verify_bound_request(request)
+            trusted_request = _copy_bound_request(request)
+            self._verify_bound_request(trusted_request)
+            origin = _ETRADE_ORIGINS[trusted_request.environment]
+            url = origin + trusted_request.route
+            oauth = self._oauth
+            prepared = _prepare_oauth_request(oauth, trusted_request, url)
+            _validate_prepared_request(prepared, trusted_request, url)
+
+            runtime_safety = self._runtime_safety
+            selected_account = self._selected_account
+            runtime_safety.assert_current()
+            runtime_safety.verify_account(selected_account.runtime_mapping())
+            evidence = _transport_evidence(trusted_request)
+            self._ledger.claim_transport_send(evidence, authorization)
+            runtime_safety.assert_current()
+            runtime_safety.verify_account(selected_account.runtime_mapping())
+            _validate_prepared_request(prepared, trusted_request, url)
+
+            try:
+                exchange = _isolated_exchange(
+                    prepared,
+                    timeout_seconds=_TOTAL_EXCHANGE_TIMEOUT_SECONDS,
+                )
+            except Exception:
+                reply = _unknown_reply(
+                    trusted_request, "TRANSPORT_ERROR"
+                )
+            else:
+                if exchange.kind == "TIMEOUT":
+                    reply = _unknown_reply(trusted_request, "TIMEOUT")
+                elif exchange.kind == "TRANSPORT_ERROR":
+                    reply = _unknown_reply(
+                        trusted_request, "TRANSPORT_ERROR"
+                    )
+                elif exchange.kind == "MALFORMED_RESPONSE":
+                    reply = _unknown_reply(
+                        trusted_request, "MALFORMED_RESPONSE"
+                    )
+                else:
+                    try:
+                        reply = _parse_reply_bytes(
+                            trusted_request,
+                            exchange.http_status,
+                            exchange.raw_response,
+                        )
+                    except Exception:
+                        reply = _unknown_reply(
+                            trusted_request, "MALFORMED_RESPONSE"
+                        )
+            try:
+                self._ledger.record_transport_response(
+                    evidence, _transport_response_evidence(reply)
+                )
+            except Exception as exc:
+                raise ETradeBrokerTransportError(
+                    "broker response could not be persisted durably"
+                ) from exc
+            return reply
+
+    def _verify_bound_request(self, request: BoundBrokerRequest) -> None:
+        if type(request) is not BoundBrokerRequest:
+            raise ETradeBrokerTransportError(
+                "transport can send only an exact bound request"
+            )
+        expected_seal = hmac.new(
+            self._binding_secret,
+            _bound_request_material(request),
+            hashlib.sha256,
+        ).digest()
+        if not hmac.compare_digest(request.transport_seal, expected_seal):
+            raise ETradeBrokerTransportError(
+                "bound request was not issued by this transport"
+            )
+        if not hmac.compare_digest(
+            hashlib.sha256(request.final_xml_bytes).hexdigest(),
+            request.final_xml_sha256,
+        ):
+            raise ETradeBrokerTransportError("bound XML digest does not verify")
+        _validate_bound_request_shape(request)
+
+
+def _transport_evidence(request: BoundBrokerRequest) -> TransportRequestEvidence:
+    return TransportRequestEvidence(
+        account_id=request.account_id,
+        account_id_key=request.account_id_key,
+        institution_type=request.institution_type,
+        environment=request.environment,
+        intent_id=request.intent_id,
+        owner=request.owner,
+        authorization_operation=request.authorization_operation,
+        fencing_token=request.fencing_token,
+        transport_operation=request.transport_operation,
+        http_method=request.http_method,
+        route=request.route,
+        client_order_id=request.client_order_id,
+        target_broker_order_id=request.target_broker_order_id,
+        preview_id=request.preview_id,
+        authorization_payload_digest=request.authorization_payload_digest,
+        final_xml_bytes=request.final_xml_bytes,
+        final_xml_sha256=request.final_xml_sha256,
+    )
+
+
+def _transport_response_evidence(
+    reply: BrokerReply,
+) -> TransportResponseEvidence:
+    return TransportResponseEvidence(
+        disposition=reply.disposition,
+        http_status=reply.http_status,
+        broker_status=reply.broker_status,
+        broker_order_id=reply.broker_order_id,
+        preview_id=reply.preview_id,
+        message_codes=tuple(
+            message.code for message in reply.broker_messages
+        ),
+        message_types=tuple(
+            message.message_type for message in reply.broker_messages
+        ),
+        message_description_digests=tuple(
+            hashlib.sha256(message.description.encode("utf-8")).hexdigest()
+            for message in reply.broker_messages
+        ),
+        raw_response_digest=reply.raw_response_digest,
+        observed_at=reply.observed_at,
+        unknown_reason=reply.unknown_reason,
+    )
+
+
+def _copy_bound_request(request: BoundBrokerRequest) -> BoundBrokerRequest:
+    return BoundBrokerRequest(
+        account_id=request.account_id,
+        account_id_key=request.account_id_key,
+        institution_type=request.institution_type,
+        environment=request.environment,
+        intent_id=request.intent_id,
+        owner=request.owner,
+        authorization_operation=request.authorization_operation,
+        fencing_token=request.fencing_token,
+        transport_operation=request.transport_operation,
+        http_method=request.http_method,
+        route=request.route,
+        client_order_id=request.client_order_id,
+        target_broker_order_id=request.target_broker_order_id,
+        preview_id=request.preview_id,
+        authorization_payload_digest=request.authorization_payload_digest,
+        final_xml_bytes=request.final_xml_bytes,
+        final_xml_sha256=request.final_xml_sha256,
+        transport_seal=request.transport_seal,
+    )
+
+
+def _require_pinned_adapter(adapter: HTTPAdapter) -> None:
+    """Reject any adapter configuration that could replay a mutation."""
+
+    if type(adapter) is not HTTPAdapter:
+        raise ETradeBrokerTransportError(
+            "order transport requires the standard no-retry HTTP adapter"
+        )
+    retries = adapter.max_retries
+    retry_fields = (
+        getattr(retries, "total", None),
+        getattr(retries, "connect", None),
+        getattr(retries, "read", None),
+        getattr(retries, "redirect", None),
+        getattr(retries, "status", None),
+        getattr(retries, "other", None),
+    )
+    if retry_fields[0] not in {0, False} or any(
+        value not in {None, 0, False} for value in retry_fields[1:]
+    ):
+        raise ETradeBrokerTransportError(
+            "order transport forbids configured HTTP retries"
+        )
+
+
+def _new_pinned_adapter() -> HTTPAdapter:
+    adapter = HTTPAdapter(
+        max_retries=Retry(
+            total=0,
+            connect=0,
+            read=0,
+            redirect=0,
+            status=0,
+            other=0,
+        )
+    )
+    _require_pinned_adapter(adapter)
+    return adapter
+
+
+def _validate_prepared_exchange(exchange: _PreparedExchange) -> None:
+    if type(exchange) is not _PreparedExchange:
+        raise ETradeBrokerTransportError("isolated exchange request type is invalid")
+    parsed = urlsplit(exchange.url)
+    if (
+        type(exchange.method) is not str
+        or exchange.method not in {"POST", "PUT"}
+        or type(exchange.url) is not str
+        or parsed.scheme != "https"
+        or not parsed.netloc
+        or parsed.query
+        or parsed.fragment
+        or type(exchange.headers) is not tuple
+        or type(exchange.body) is not bytes
+        or not exchange.body
+    ):
+        raise ETradeBrokerTransportError("isolated exchange request is invalid")
+    normalized: dict[str, str] = {}
+    for pair in exchange.headers:
+        if (
+            type(pair) is not tuple
+            or len(pair) != 2
+            or type(pair[0]) is not str
+            or type(pair[1]) is not str
+            or not pair[0]
+        ):
+            raise ETradeBrokerTransportError(
+                "isolated exchange headers are invalid"
+            )
+        name = pair[0].lower()
+        if name in normalized:
+            raise ETradeBrokerTransportError(
+                "isolated exchange headers contain duplicates"
+            )
+        normalized[name] = pair[1]
+    expected_headers = {
+        "content-type",
+        "accept",
+        "accept-encoding",
+        "consumerkey",
+        "content-length",
+        "authorization",
+    }
+    if (
+        set(normalized) != expected_headers
+        or normalized["content-type"] != "application/xml"
+        or normalized["accept"] != "application/json"
+        or normalized["accept-encoding"] != "identity"
+        or normalized["content-length"] != str(len(exchange.body))
+        or not normalized["consumerkey"]
+        or not normalized["authorization"].startswith("OAuth ")
+    ):
+        raise ETradeBrokerTransportError(
+            "isolated exchange headers changed the sealed mutation"
+        )
+
+
+def _validate_exchange_result(result: _ExchangeResult) -> None:
+    if (
+        type(result) is not _ExchangeResult
+        or type(result.kind) is not str
+        or result.kind
+        not in {
+            "RESPONSE",
+            "TIMEOUT",
+            "TRANSPORT_ERROR",
+            "MALFORMED_RESPONSE",
+        }
+        or type(result.raw_response) is not bytes
+    ):
+        raise ETradeBrokerTransportError("isolated exchange result is invalid")
+    if result.kind == "RESPONSE":
+        if (
+            type(result.http_status) is not int
+            or not 100 <= result.http_status <= 599
+            or len(result.raw_response) > _MAX_RESPONSE_BYTES + 1
+        ):
+            raise ETradeBrokerTransportError(
+                "isolated exchange response is invalid"
+            )
+    elif result.http_status is not None or result.raw_response:
+        raise ETradeBrokerTransportError(
+            "isolated exchange failure contains unexpected response data"
+        )
+
+
+def _serialized_prepared_request(prepared: Any) -> _PreparedExchange:
+    if type(prepared) is not PreparedRequest:
+        raise ETradeBrokerTransportError(
+            "isolated exchange requires an exact prepared request"
+        )
+    headers = getattr(prepared, "headers", None)
+    if not hasattr(headers, "items"):
+        raise ETradeBrokerTransportError("prepared request headers are invalid")
+    return _PreparedExchange(
+        method=prepared.method,
+        url=prepared.url,
+        headers=tuple((name, value) for name, value in headers.items()),
+        body=prepared.body,
+    )
+
+
+def _reconstruct_prepared_request(exchange: _PreparedExchange) -> PreparedRequest:
+    _validate_prepared_exchange(exchange)
+    prepared = PreparedRequest()
+    prepared.prepare(
+        method=exchange.method,
+        url=exchange.url,
+        headers=dict(exchange.headers),
+        data=exchange.body,
+    )
+    reconstructed = _serialized_prepared_request(prepared)
+    if reconstructed != exchange:
+        raise ETradeBrokerTransportError(
+            "isolated worker changed the prepared request"
+        )
+    return prepared
+
+
+def _write_exchange_result(output: Any, result: _ExchangeResult) -> None:
+    _validate_exchange_result(result)
+    if len(output) != _EXCHANGE_RESULT_BUFFER_BYTES:
+        raise ETradeBrokerTransportError(
+            "isolated exchange result buffer is invalid"
+        )
+    status = result.http_status or 0
+    header = struct.pack(
+        "!BHI32s",
+        _EXCHANGE_KIND_CODES[result.kind],
+        status,
+        len(result.raw_response),
+        hashlib.sha256(result.raw_response).digest(),
+    )
+    end = _EXCHANGE_RESULT_HEADER_BYTES + len(result.raw_response)
+    if end > len(output):
+        raise ETradeBrokerTransportError(
+            "isolated exchange result exceeds its fixed buffer"
+        )
+    output[_EXCHANGE_RESULT_HEADER_BYTES:end] = result.raw_response
+    # The authenticated header is the commit record and is written last.
+    output[:_EXCHANGE_RESULT_HEADER_BYTES] = header
+
+
+def _read_exchange_result(output: Any) -> _ExchangeResult:
+    if len(output) != _EXCHANGE_RESULT_BUFFER_BYTES:
+        raise ETradeBrokerTransportError(
+            "isolated exchange result buffer is invalid"
+        )
+    header = bytes(output[:_EXCHANGE_RESULT_HEADER_BYTES])
+    code, status, raw_length, expected_digest = struct.unpack(
+        "!BHI32s", header
+    )
+    kind = _EXCHANGE_CODE_KINDS.get(code)
+    if kind is None or raw_length > _MAX_RESPONSE_BYTES + 1:
+        raise ETradeBrokerTransportError(
+            "isolated exchange result frame is invalid"
+        )
+    end = _EXCHANGE_RESULT_HEADER_BYTES + raw_length
+    raw = bytes(output[_EXCHANGE_RESULT_HEADER_BYTES:end])
+    if not hmac.compare_digest(
+        hashlib.sha256(raw).digest(), expected_digest
+    ):
+        raise ETradeBrokerTransportError(
+            "isolated exchange result frame is incomplete"
+        )
+    result = _ExchangeResult(
+        kind,
+        http_status=status or None,
+        raw_response=raw,
+    )
+    _validate_exchange_result(result)
+    return result
+
+
+def _exchange_worker(output: Any, exchange: _PreparedExchange) -> None:
+    """Perform exactly one mutation in a disposable process."""
+
+    adapter: HTTPAdapter | None = None
+    try:
+        prepared = _reconstruct_prepared_request(exchange)
+        adapter = _new_pinned_adapter()
+        response = adapter.send(
+            prepared,
+            stream=True,
+            timeout=_REQUEST_TIMEOUT,
+            verify=True,
+            cert=None,
+            proxies={},
+        )
+        try:
+            status, raw = _read_bounded_response(response)
+        except (Timeout, TimeoutError):
+            result = _ExchangeResult("TIMEOUT")
+        except Exception:
+            result = _ExchangeResult("MALFORMED_RESPONSE")
+        else:
+            result = _ExchangeResult(
+                "RESPONSE", http_status=status, raw_response=raw
+            )
+    except (Timeout, TimeoutError):
+        result = _ExchangeResult("TIMEOUT")
+    except Exception:
+        result = _ExchangeResult("TRANSPORT_ERROR")
+    finally:
+        if adapter is not None:
+            adapter.close()
+        try:
+            _write_exchange_result(output, result)
+        except Exception:
+            pass
+
+
+def _stop_exchange_process(process: Any) -> None:
+    try:
+        process.join(timeout=0)
+        if process.is_alive():
+            process.terminate()
+            process.join(timeout=0.25)
+        if process.is_alive():
+            process.kill()
+            process.join(timeout=0.25)
+    except Exception:
+        pass
+
+
+def _isolated_exchange(
+    prepared: Any, *, timeout_seconds: float
+) -> _ExchangeResult:
+    """Enforce one hard deadline over connect, headers, and response body."""
+
+    if (
+        type(timeout_seconds) is not float
+        or not 0 < timeout_seconds <= _TOTAL_EXCHANGE_TIMEOUT_SECONDS
+    ):
+        raise ETradeBrokerTransportError("total exchange deadline is invalid")
+    exchange = _serialized_prepared_request(prepared)
+    context = multiprocessing.get_context("spawn")
+    output = context.RawArray("B", _EXCHANGE_RESULT_BUFFER_BYTES)
+    process = context.Process(
+        target=_exchange_worker,
+        args=(output, exchange),
+        daemon=True,
+    )
+    deadline = time.monotonic() + timeout_seconds
+    started = False
+    try:
+        process.start()
+        started = True
+        remaining = max(0.0, deadline - time.monotonic())
+        process.join(timeout=remaining)
+        if process.is_alive():
+            return _ExchangeResult("TIMEOUT")
+        try:
+            result = _read_exchange_result(output)
+        except Exception:
+            return _ExchangeResult("TRANSPORT_ERROR")
+        return result
+    except Exception:
+        return _ExchangeResult("TRANSPORT_ERROR")
+    finally:
+        if started:
+            _stop_exchange_process(process)
+
+
+def _prepare_oauth_request(
+    oauth: OAuth1Session,
+    request: BoundBrokerRequest,
+    url: str,
+):
+    if (
+        type(oauth) is not OAuth1Session
+        or oauth.trust_env is not False
+        or oauth.params
+        or oauth.proxies
+        or oauth.hooks != {"response": []}
+        or oauth.cookies
+        or oauth.verify is not True
+        or oauth.cert is not None
+    ):
+        raise ETradeBrokerTransportError(
+            "private OAuth signer configuration is unsafe"
+        )
+    headers = CaseInsensitiveDict(
+        {
+            "Content-Type": "application/xml",
+            "Accept": "application/json",
+            "Accept-Encoding": "identity",
+            "consumerKey": oauth.consumer_key,
+        }
+    )
+    signing_kwargs = {
+        "headers": headers,
+        "data": memoryview(request.final_xml_bytes),
+    }
+    oauth_params = oauth._get_oauth_params(signing_kwargs)
+    oauth_params["oauth_signature"] = oauth.signature.sign(
+        oauth.consumer_secret,
+        oauth.access_token_secret,
+        request.http_method,
+        url,
+        oauth_params,
+        signing_kwargs,
+    )
+    return Request(
+        method=request.http_method,
+        url=url,
+        headers=dict(headers),
+        data=request.final_xml_bytes,
+        auth=OAuth1Auth(oauth_params, ""),
+    ).prepare()
+
+
+def _validate_prepared_request(
+    prepared: Any,
+    request: BoundBrokerRequest,
+    expected_url: str,
+) -> None:
+    parsed = urlsplit(prepared.url)
+    body = prepared.body
+    headers = prepared.headers
+    if (
+        prepared.method != request.http_method
+        or prepared.url != expected_url
+        or parsed.scheme != "https"
+        or parsed.query
+        or parsed.fragment
+        or type(body) is not bytes
+        or not hmac.compare_digest(body, request.final_xml_bytes)
+        or headers.get("Content-Type") != "application/xml"
+        or headers.get("Accept") != "application/json"
+        or headers.get("Accept-Encoding") != "identity"
+        or headers.get("Content-Length") != str(len(request.final_xml_bytes))
+        or type(headers.get("Authorization")) is not str
+        or not headers["Authorization"].startswith("OAuth ")
+        or "Cookie" in headers
+        or "Transfer-Encoding" in headers
+    ):
+        raise ETradeBrokerTransportError(
+            "prepared OAuth request changed its sealed mutation"
+        )
+
+
+def _bound_request_material(value: Any) -> bytes:
+    names = (
+        "account_id",
+        "account_id_key",
+        "institution_type",
+        "environment",
+        "intent_id",
+        "owner",
+        "authorization_operation",
+        "fencing_token",
+        "transport_operation",
+        "http_method",
+        "route",
+        "client_order_id",
+        "target_broker_order_id",
+        "preview_id",
+        "authorization_payload_digest",
+        "final_xml_sha256",
+    )
+    if type(value) is dict:
+        document = {name: value[name] for name in names}
+    elif type(value) is BoundBrokerRequest:
+        document = {name: getattr(value, name) for name in names}
+    else:
+        raise ETradeBrokerTransportError("bound request material is invalid")
+    return json.dumps(
+        document,
+        sort_keys=True,
+        separators=(",", ":"),
+        ensure_ascii=True,
+    ).encode("utf-8")
+
+
+def _validate_bound_request_shape(request: BoundBrokerRequest) -> None:
+    operation = request.transport_operation
+    expected_authorization = "SUBMIT" if operation.startswith("SUBMIT") else "AMEND"
+    expected_method = "POST" if operation.startswith("SUBMIT") else "PUT"
+    if (
+        request.authorization_operation != expected_authorization
+        or request.http_method != expected_method
+    ):
+        raise ETradeBrokerTransportError(
+            "bound request operation and method are inconsistent"
+        )
+    is_amend = operation.startswith("AMEND")
+    is_place = operation.endswith("PLACE")
+    if is_amend != (request.target_broker_order_id is not None):
+        raise ETradeBrokerTransportError(
+            "bound request target is inconsistent"
+        )
+    if is_place != (request.preview_id is not None):
+        raise ETradeBrokerTransportError(
+            "bound request preview is inconsistent"
+        )
+    encoded_account = quote(request.account_id_key, safe="")
+    if is_amend:
+        encoded_target = quote(request.target_broker_order_id or "", safe="")
+        action = "place" if is_place else "preview"
+        expected_route = (
+            f"/v1/accounts/{encoded_account}/orders/"
+            f"{encoded_target}/change/{action}"
+        )
+    else:
+        action = "place" if is_place else "preview"
+        expected_route = f"/v1/accounts/{encoded_account}/orders/{action}"
+    if request.route != expected_route:
+        raise ETradeBrokerTransportError("bound request route is inconsistent")
+    try:
+        root = ET.fromstring(request.final_xml_bytes)
+    except ET.ParseError as exc:
+        raise ETradeBrokerTransportError("bound XML is invalid") from exc
+    expected_root = "PlaceOrderRequest" if is_place else "PreviewOrderRequest"
+    if (
+        root.tag != expected_root
+        or root.findtext("./orderType") != "SPREADS"
+        or root.findtext("./clientOrderId") != request.client_order_id
+    ):
+        raise ETradeBrokerTransportError("bound XML identity is inconsistent")
+    bound_preview = root.findtext("./PreviewIds/previewId")
+    if bound_preview != request.preview_id:
+        raise ETradeBrokerTransportError("bound XML preview is inconsistent")
+
+
+def _authorized_vertical(
+    authorization: OutboundAuthorization,
+    expected_operation: Literal["SUBMIT", "AMEND"],
+) -> dict[str, Any]:
+    if type(authorization) is not OutboundAuthorization:
+        raise ETradeBrokerTransportError("authorization must use its exact immutable type")
+    primitive_fields = (
+        (authorization.intent_id, str),
+        (authorization.operation, str),
+        (authorization.owner, str),
+        (authorization.fencing_token, int),
+        (authorization.client_order_id, str),
+        (authorization.payload_bytes, bytes),
+        (authorization.payload_digest, str),
+    )
+    if any(type(value) is not expected for value, expected in primitive_fields):
+        raise ETradeBrokerTransportError("authorization fields must be exact primitives")
+    _identifier(authorization.intent_id, "intent id")
+    _identifier(authorization.owner, "owner")
+    _identifier(authorization.client_order_id, "client order id")
+    if (
+        len(authorization.client_order_id) != 10
+        or not authorization.client_order_id.isascii()
+        or not authorization.client_order_id.isdigit()
+    ):
+        raise ETradeBrokerTransportError("client order id must contain ten digits")
+    if authorization.operation != expected_operation:
+        raise ETradeBrokerTransportError("authorization operation does not match request")
+    if authorization.fencing_token <= 0:
+        raise ETradeBrokerTransportError("authorization fencing token is invalid")
+    _sha256(authorization.payload_digest, "authorization payload digest")
+    if (
+        not authorization.payload_bytes
+        or len(authorization.payload_bytes) > _MAX_AUTHORIZATION_BYTES
+        or not hmac.compare_digest(
+            hashlib.sha256(authorization.payload_bytes).hexdigest(),
+            authorization.payload_digest,
+        )
+    ):
+        raise ETradeBrokerTransportError("authorization payload does not verify")
+    try:
+        payload = json.loads(
+            authorization.payload_bytes.decode("utf-8"),
+            object_pairs_hook=_strict_json_object,
+            parse_constant=_reject_json_constant,
+        )
+    except (UnicodeDecodeError, json.JSONDecodeError) as exc:
+        raise ETradeBrokerTransportError("authorization payload is invalid") from exc
+    if type(payload) is not dict:
+        raise ETradeBrokerTransportError("authorization payload must be an object")
+    canonical_bytes = json.dumps(
+        payload, sort_keys=True, separators=(",", ":"), ensure_ascii=True
+    ).encode("utf-8")
+    if not hmac.compare_digest(canonical_bytes, authorization.payload_bytes):
+        raise ETradeBrokerTransportError("authorization payload is not canonical")
+    payload = dict(payload)
+    client_order_id = payload.pop("client_order_id", None)
+    if type(client_order_id) is not str or client_order_id != authorization.client_order_id:
+        raise ETradeBrokerTransportError("authorization client order id is inconsistent")
+    _validate_opening_vertical_payload(payload)
+    try:
+        wire_order_payload(payload)
+    except Exception as exc:
+        raise ETradeBrokerTransportError("authorization order schema is invalid") from exc
+    if (
+        payload.get("securityType") != "OPTN"
+        or payload.get("orderAction") != "SPREAD"
+        or payload.get("spreadType") != "VERTICAL"
+        or type(payload.get("legs")) is not list
+        or len(payload["legs"]) != 2
+        or any(
+            type(leg) is not dict
+            or type(leg.get("orderAction")) is not str
+            or not leg["orderAction"].endswith("_OPEN")
+            for leg in payload["legs"]
+        )
+    ):
+        raise ETradeBrokerTransportError(
+            "transport currently supports opening vertical options only"
+        )
+    payload["client_order_id"] = client_order_id
+    return payload
+
+
+def _validate_opening_vertical_payload(payload: dict[str, Any]) -> None:
+    required_top_level = {
+        "securityType",
+        "orderAction",
+        "priceType",
+        "limitPrice",
+        "orderTerm",
+        "spreadType",
+        "legs",
+    }
+    if set(payload) != required_top_level:
+        raise ETradeBrokerTransportError(
+            "transport requires an exact opening-vertical payload"
+        )
+    exact_enums = (
+        (payload["securityType"], {"OPTN"}),
+        (payload["orderAction"], {"SPREAD"}),
+        (payload["priceType"], {"NET_CREDIT", "NET_DEBIT"}),
+        (payload["orderTerm"], {"GOOD_FOR_DAY"}),
+        (payload["spreadType"], {"VERTICAL"}),
+    )
+    if any(type(value) is not str or value not in allowed for value, allowed in exact_enums):
+        raise ETradeBrokerTransportError("opening-vertical enum is invalid")
+    legs = payload["legs"]
+    if type(legs) is not list or len(legs) != 2:
+        raise ETradeBrokerTransportError("opening vertical requires exactly two legs")
+    required_leg = {
+        "symbol",
+        "callPut",
+        "expiryYear",
+        "expiryMonth",
+        "expiryDay",
+        "strikePrice",
+        "orderAction",
+        "quantity",
+    }
+    identities: list[tuple[str, str, int, int, int, int]] = []
+    strikes: list[Decimal] = []
+    actions: set[str] = set()
+    for leg in legs:
+        if type(leg) is not dict or set(leg) != required_leg:
+            raise ETradeBrokerTransportError("opening-vertical leg shape is invalid")
+        symbol = leg["symbol"]
+        call_put = leg["callPut"]
+        action = leg["orderAction"]
+        expiry = (leg["expiryYear"], leg["expiryMonth"], leg["expiryDay"])
+        quantity = leg["quantity"]
+        if (
+            type(symbol) is not str
+            or _OPTION_SYMBOL.fullmatch(symbol) is None
+            or type(call_put) is not str
+            or call_put not in {"PUT", "CALL"}
+            or type(action) is not str
+            or action not in {"BUY_OPEN", "SELL_OPEN"}
+            or any(type(value) is not int for value in expiry)
+            or type(quantity) is not int
+            or quantity <= 0
+        ):
+            raise ETradeBrokerTransportError(
+                "opening-vertical leg value is invalid"
+            )
+        try:
+            date(*expiry)
+        except ValueError as exc:
+            raise ETradeBrokerTransportError(
+                "opening-vertical expiry is invalid"
+            ) from exc
+        strike = _finite_decimal(leg["strikePrice"], "strike price", positive=True)
+        identities.append((symbol, call_put, *expiry, quantity))
+        strikes.append(strike)
+        actions.add(action)
+    if identities[0] != identities[1]:
+        raise ETradeBrokerTransportError(
+            "opening-vertical leg identities are inconsistent"
+        )
+    if actions != {"BUY_OPEN", "SELL_OPEN"} or strikes[0] == strikes[1]:
+        raise ETradeBrokerTransportError(
+            "opening vertical requires one buy, one sell, and distinct strikes"
+        )
+    limit_price = _finite_decimal(
+        payload["limitPrice"],
+        "limit price",
+        positive=payload["priceType"] == "NET_DEBIT",
+    )
+    width = abs(strikes[0] - strikes[1])
+    sell_index = next(
+        index for index, leg in enumerate(legs) if leg["orderAction"] == "SELL_OPEN"
+    )
+    buy_index = 1 - sell_index
+    call_put = legs[0]["callPut"]
+    short_risk = (
+        call_put == "PUT" and strikes[sell_index] > strikes[buy_index]
+    ) or (
+        call_put == "CALL" and strikes[sell_index] < strikes[buy_index]
+    )
+    expected_price_type = "NET_CREDIT" if short_risk else "NET_DEBIT"
+    if payload["priceType"] != expected_price_type:
+        raise ETradeBrokerTransportError(
+            "opening-vertical price type does not match its risk orientation"
+        )
+    if (
+        payload["priceType"] == "NET_CREDIT"
+        and not (Decimal("0") <= limit_price < width)
+    ) or (
+        payload["priceType"] == "NET_DEBIT"
+        and not (Decimal("0") < limit_price <= width)
+    ):
+        raise ETradeBrokerTransportError(
+            "opening-vertical limit price is outside its bounded width"
+        )
+
+
+def _finite_decimal(value: Any, label: str, *, positive: bool) -> Decimal:
+    if type(value) not in {int, float} or (
+        type(value) is float and not math.isfinite(value)
+    ):
+        raise ETradeBrokerTransportError(f"{label} is invalid")
+    parsed = Decimal(str(value))
+    if not parsed.is_finite() or (parsed <= 0 if positive else parsed < 0):
+        raise ETradeBrokerTransportError(f"{label} is invalid")
+    return parsed
+
+
+def _order_xml(
+    order: dict[str, Any], *, place: bool, preview_id: str | None
+) -> bytes:
+    root = ET.Element("PlaceOrderRequest" if place else "PreviewOrderRequest")
+    _element(root, "orderType", "SPREADS")
+    _element(root, "clientOrderId", order["client_order_id"])
+    if place:
+        if preview_id is None:
+            raise ETradeBrokerTransportError("place request requires preview id")
+        preview_ids = ET.SubElement(root, "PreviewIds")
+        _element(preview_ids, "previewId", preview_id)
+    broker_order = ET.SubElement(root, "Order")
+    _element(broker_order, "allOrNone", "false")
+    _element(broker_order, "priceType", order["priceType"])
+    _element(broker_order, "limitPrice", order["limitPrice"])
+    _element(broker_order, "stopPrice", 0)
+    _element(broker_order, "orderTerm", order["orderTerm"])
+    _element(broker_order, "marketSession", "REGULAR")
+    for leg in order["legs"]:
+        instrument = ET.SubElement(broker_order, "Instrument")
+        product = ET.SubElement(instrument, "Product")
+        _element(product, "securityType", "OPTN")
+        for field in (
+            "symbol",
+            "callPut",
+            "expiryYear",
+            "expiryMonth",
+            "expiryDay",
+            "strikePrice",
+        ):
+            _element(product, field, leg[field])
+        _element(instrument, "orderAction", leg["orderAction"])
+        _element(instrument, "quantityType", "QUANTITY")
+        _element(instrument, "quantity", leg["quantity"])
+        _element(instrument, "orderedQuantity", leg["quantity"])
+    return ET.tostring(root, encoding="utf-8", xml_declaration=True)
+
+
+def _element(parent: ET.Element, tag: str, value: Any) -> None:
+    child = ET.SubElement(parent, tag)
+    child.text = str(value)
+
+
+def _parse_reply(request: BoundBrokerRequest, response: Any) -> BrokerReply:
+    try:
+        status, raw = _read_bounded_response(response)
+    except Exception:
+        return _unknown_reply(
+            request,
+            "MALFORMED_RESPONSE",
+            observed_at=datetime.now(timezone.utc),
+        )
+    return _parse_reply_bytes(request, status, raw)
+
+
+def _parse_reply_bytes(
+    request: BoundBrokerRequest,
+    status: int | None,
+    raw: bytes,
+) -> BrokerReply:
+    observed_at = datetime.now(timezone.utc)
+    if (
+        type(status) is not int
+        or not 100 <= status <= 599
+        or type(raw) is not bytes
+    ):
+        return _unknown_reply(
+            request,
+            "MALFORMED_RESPONSE",
+            observed_at=observed_at,
+        )
+    raw_digest = hashlib.sha256(raw).hexdigest()
+    if len(raw) > _MAX_RESPONSE_BYTES:
+        return _unknown_reply(
+            request,
+            "RESPONSE_TOO_LARGE",
+            http_status=status,
+            raw_response_digest=raw_digest,
+            observed_at=observed_at,
+        )
+    if status != 200:
+        return _unknown_reply(
+            request,
+            "HTTP_STATUS",
+            http_status=status,
+            raw_response_digest=raw_digest,
+            observed_at=observed_at,
+        )
+    try:
+        parsed = _parse_response(request.transport_operation, raw)
+    except Exception:
+        return _unknown_reply(
+            request,
+            "MALFORMED_RESPONSE",
+            http_status=status,
+            raw_response_digest=raw_digest,
+            observed_at=observed_at,
+        )
+    if (
+        parsed["account_id"] != request.account_id
+        or parsed["order_type"] != "SPREADS"
+    ):
+        return _unknown_reply(
+            request,
+            "MALFORMED_RESPONSE",
+            http_status=status,
+            raw_response_digest=raw_digest,
+            observed_at=observed_at,
+        )
+    broker_status = parsed["broker_status"]
+    broker_messages = parsed["broker_messages"]
+    parsed_preview = parsed["preview_id"]
+    if request.transport_operation.endswith("PREVIEW"):
+        if parsed_preview is None:
+            return _unknown_reply(
+                request,
+                "MALFORMED_RESPONSE",
+                http_status=status,
+                raw_response_digest=raw_digest,
+                observed_at=observed_at,
+            )
+        reply_preview = parsed_preview
+        broker_order_id = None
+    else:
+        broker_order_id = parsed["broker_order_id"]
+        if broker_order_id is None:
+            return _unknown_reply(
+                request,
+                "MALFORMED_RESPONSE",
+                http_status=status,
+                raw_response_digest=raw_digest,
+                observed_at=observed_at,
+            )
+        reply_preview = request.preview_id
+    if broker_messages and not _messages_allow_ack(
+        request.transport_operation, broker_messages
+    ):
+        return _unknown_reply(
+            request,
+            "REVIEW_REQUIRED",
+            http_status=status,
+            broker_status=broker_status,
+            broker_order_id=broker_order_id,
+            preview_id=reply_preview,
+            broker_messages=broker_messages,
+            raw_response_digest=raw_digest,
+            observed_at=observed_at,
+        )
+    allowed_statuses = {None, "OPEN"}
+    if broker_status not in allowed_statuses:
+        return _unknown_reply(
+            request,
+            "BROKER_STATUS_REQUIRES_RECONCILIATION",
+            http_status=status,
+            broker_status=broker_status,
+            broker_order_id=broker_order_id,
+            preview_id=reply_preview,
+            raw_response_digest=raw_digest,
+            observed_at=observed_at,
+        )
+    return BrokerReply(
+        request=request,
+        disposition="ACKNOWLEDGED",
+        http_status=status,
+        broker_status=broker_status,
+        client_order_id=request.client_order_id,
+        # E*TRADE documents that clientOrderId is not returned. Binding comes
+        # from this single no-redirect/no-retry HTTP exchange, not an echo.
+        echoed_client_order_id=None,
+        broker_order_id=broker_order_id,
+        preview_id=reply_preview,
+        broker_messages=broker_messages,
+        raw_response_digest=raw_digest,
+        observed_at=observed_at,
+        unknown_reason=None,
+    )
+
+
+def _read_bounded_response(response: Any) -> tuple[int, bytes]:
+    status = getattr(response, "status_code", None)
+    raw_stream = getattr(response, "raw", None)
+    reader = getattr(raw_stream, "read1", None)
+    read_chunk_size = 8192
+    if not callable(reader):
+        reader = getattr(raw_stream, "read", None)
+        read_chunk_size = 1
+    closer = getattr(response, "close", None)
+    if (
+        type(status) is not int
+        or not 100 <= status <= 599
+        or not callable(reader)
+        or not callable(closer)
+    ):
+        raise ETradeBrokerTransportError("broker response stream is invalid")
+    try:
+        headers = getattr(response, "headers", None)
+        if headers is not None:
+            get_header = getattr(headers, "get", None)
+            if not callable(get_header):
+                raise ETradeBrokerTransportError(
+                    "broker response headers are invalid"
+                )
+            content_encoding = get_header("Content-Encoding")
+            if content_encoding is not None and (
+                type(content_encoding) is not str
+                or content_encoding.strip().lower() != "identity"
+            ):
+                raise ETradeBrokerTransportError(
+                    "encoded broker responses are forbidden"
+                )
+            content_length = get_header("Content-Length")
+            if content_length is not None and (
+                type(content_length) is not str
+                or not content_length.isascii()
+                or not content_length.isdigit()
+                or int(content_length) > _MAX_RESPONSE_BYTES
+            ):
+                raise ETradeBrokerTransportError(
+                    "broker response length is invalid"
+                )
+        deadline = time.monotonic() + _RESPONSE_WALL_TIMEOUT_SECONDS
+        chunks: list[bytes] = []
+        total = 0
+        while total <= _MAX_RESPONSE_BYTES:
+            if time.monotonic() >= deadline:
+                raise TimeoutError("broker response wall deadline expired")
+            amount = min(
+                read_chunk_size,
+                _MAX_RESPONSE_BYTES + 1 - total,
+            )
+            try:
+                chunk = reader(amount, decode_content=False)
+            except TypeError:
+                chunk = reader(amount)
+            if type(chunk) is not bytes:
+                raise ETradeBrokerTransportError(
+                    "broker response bytes are invalid"
+                )
+            if not chunk:
+                break
+            chunks.append(chunk)
+            total += len(chunk)
+        payload = b"".join(chunks)
+    finally:
+        closer()
+    if type(payload) is not bytes:
+        raise ETradeBrokerTransportError("broker response bytes are invalid")
+    return status, payload
+
+
+def _parse_response(operation: str, raw: bytes) -> dict[str, Any]:
+    stripped = raw.lstrip()
+    if not stripped:
+        raise ETradeBrokerTransportError("broker response is empty")
+    if stripped.startswith(b"<"):
+        if b"<!doctype" in stripped.lower() or b"<!entity" in stripped.lower():
+            raise ETradeBrokerTransportError("broker XML declarations are forbidden")
+        root = ET.fromstring(raw)
+        expected_root = _response_root(operation)
+        if root.tag != expected_root:
+            raise ETradeBrokerTransportError("broker XML response root is invalid")
+        nodes = list(root.iter())
+        if (
+            len(nodes) > _MAX_RESPONSE_NODES
+            or any(
+                type(element.tag) is not str
+                or "{" in element.tag
+                or "}" in element.tag
+                or element.attrib
+                or element.tag.lower() == "error"
+                for element in nodes
+            )
+        ):
+            raise ETradeBrokerTransportError("broker XML response is unsafe")
+        broker_messages = _validate_xml_messages(root)
+        account_id = _broker_numeric_id(
+            _one_xml_text(root, "accountId"), "response account id"
+        )
+        order_type = _one_xml_text(root, "orderType")
+        if operation.endswith("PREVIEW"):
+            identifier_container = _one_xml_child(root, "PreviewIds")
+            preview_id = _broker_numeric_id(
+                _one_xml_identifier(identifier_container, "previewId"),
+                "response preview id",
+            )
+            broker_order_id = None
+        else:
+            identifier_container = _one_xml_child(root, "OrderIds")
+            broker_order_id = _broker_numeric_id(
+                _one_xml_identifier(identifier_container, "orderId"),
+                "response order id",
+            )
+            preview_id = None
+        broker_status = _xml_order_status(root)
+        return {
+            "account_id": account_id,
+            "order_type": order_type,
+            "preview_id": preview_id,
+            "broker_order_id": broker_order_id,
+            "broker_status": broker_status,
+            "broker_messages": broker_messages,
+        }
+    document = json.loads(
+        raw.decode("utf-8"),
+        object_pairs_hook=_strict_json_object,
+        parse_constant=_reject_json_constant,
+    )
+    expected_root = _response_root(operation)
+    if type(document) is not dict or set(document) != {expected_root}:
+        raise ETradeBrokerTransportError("broker JSON response must be an object")
+    root = document[expected_root]
+    if type(root) is not dict:
+        raise ETradeBrokerTransportError("broker JSON response root is invalid")
+    _validate_json_tree(root)
+    broker_messages = _validate_json_messages(root)
+    account_id = _broker_numeric_id(
+        root.get("accountId"), "response account id"
+    )
+    order_type = root.get("orderType")
+    if type(order_type) is not str:
+        raise ETradeBrokerTransportError("response order type is invalid")
+    if operation.endswith("PREVIEW"):
+        preview_id = _broker_numeric_id(
+            _one_json_identifier(root.get("PreviewIds"), "previewId"),
+            "response preview id",
+        )
+        broker_order_id = None
+    else:
+        broker_order_id = _broker_numeric_id(
+            _one_json_identifier(root.get("OrderIds"), "orderId"),
+            "response order id",
+        )
+        preview_id = None
+    return {
+        "account_id": account_id,
+        "order_type": order_type,
+        "preview_id": preview_id,
+        "broker_order_id": broker_order_id,
+        "broker_status": _json_order_status(root),
+        "broker_messages": broker_messages,
+    }
+
+
+def _response_root(operation: str) -> str:
+    if operation.endswith("PREVIEW"):
+        return "PreviewOrderResponse"
+    return "PlaceOrderResponse"
+
+
+def _strict_json_object(pairs: list[tuple[str, Any]]) -> dict[str, Any]:
+    result: dict[str, Any] = {}
+    for key, value in pairs:
+        if key in result:
+            raise ETradeBrokerTransportError("broker JSON response has duplicate keys")
+        result[key] = value
+    return result
+
+
+def _reject_json_constant(_value: str) -> Any:
+    raise ETradeBrokerTransportError(
+        "non-finite JSON numbers are forbidden"
+    )
+
+
+def _validate_json_tree(value: Any) -> None:
+    pending = [value]
+    visited = 0
+    while pending:
+        current = pending.pop()
+        visited += 1
+        if visited > _MAX_RESPONSE_NODES:
+            raise ETradeBrokerTransportError("broker response is too complex")
+        if type(current) is dict:
+            for key, child in current.items():
+                if type(key) is not str:
+                    raise ETradeBrokerTransportError("broker response key is invalid")
+                if key.lower() == "error":
+                    raise ETradeBrokerTransportError("broker response contains an error")
+                if type(child) in {dict, list}:
+                    pending.append(child)
+        elif type(current) is list:
+            pending.extend(current)
+        elif type(current) is float and not math.isfinite(current):
+            raise ETradeBrokerTransportError(
+                "broker response contains a non-finite number"
+            )
+
+
+def _one_json_identifier(value: Any, key: str) -> Any:
+    if type(value) is dict:
+        items = [value]
+    elif type(value) is list:
+        items = value
+    else:
+        raise ETradeBrokerTransportError("broker response identifier group is invalid")
+    if (
+        len(items) != 1
+        or type(items[0]) is not dict
+        or key not in items[0]
+        or set(items[0]) - {key, "cashMargin"}
+    ):
+        raise ETradeBrokerTransportError("broker response identifier is ambiguous")
+    cash_margin = items[0].get("cashMargin")
+    if cash_margin is not None and (
+        type(cash_margin) is not str
+        or cash_margin not in {"CASH", "MARGIN", "INVALID"}
+    ):
+        raise ETradeBrokerTransportError(
+            "broker response cash margin is invalid"
+        )
+    return items[0][key]
+
+
+def _json_order_status(root: dict[str, Any]) -> str | None:
+    items = _json_orders(root)
+    if not items:
+        return None
+    status = items[0].get("status")
+    if status is None:
+        return None
+    return _broker_status(status)
+
+
+def _json_orders(root: dict[str, Any]) -> list[dict[str, Any]]:
+    orders = root.get("Order")
+    if orders is None:
+        return []
+    if type(orders) is dict:
+        items = [orders]
+    elif type(orders) is list:
+        items = orders
+    else:
+        raise ETradeBrokerTransportError("broker response order is invalid")
+    if len(items) != 1 or type(items[0]) is not dict:
+        raise ETradeBrokerTransportError("broker response order is ambiguous")
+    return items
+
+
+def _validate_json_messages(
+    root: dict[str, Any],
+) -> tuple[BrokerMessage, ...]:
+    allowed_containers: list[dict[str, Any]] = []
+    if "messageList" in root:
+        container = root["messageList"]
+        if type(container) is not dict:
+            raise ETradeBrokerTransportError("broker message list is invalid")
+        allowed_containers.append(container)
+    for order in _json_orders(root):
+        if "messages" in order:
+            container = order["messages"]
+            if type(container) is not dict:
+                raise ETradeBrokerTransportError("broker messages are invalid")
+            allowed_containers.append(container)
+
+    allowed_container_ids = {id(container) for container in allowed_containers}
+    pending: list[Any] = [root]
+    while pending:
+        current = pending.pop()
+        if type(current) is dict:
+            for key, value in current.items():
+                if key in {"messageList", "messages"} and id(value) not in allowed_container_ids:
+                    raise ETradeBrokerTransportError(
+                        "broker message container is misplaced"
+                    )
+                if key == "Message" and id(current) not in allowed_container_ids:
+                    raise ETradeBrokerTransportError(
+                        "broker message entry is misplaced"
+                    )
+                if type(value) in {dict, list}:
+                    pending.append(value)
+        elif type(current) is list:
+            pending.extend(current)
+
+    result: list[BrokerMessage] = []
+    for container in allowed_containers:
+        if set(container) != {"Message"}:
+            raise ETradeBrokerTransportError("broker message container is malformed")
+        messages = container["Message"]
+        if type(messages) is dict:
+            items = [messages]
+        elif type(messages) is list:
+            items = messages
+        else:
+            raise ETradeBrokerTransportError("broker message list is malformed")
+        if not items:
+            raise ETradeBrokerTransportError("broker message list is empty")
+        for message in items:
+            if type(message) is not dict or set(message) != {
+                "description",
+                "code",
+                "type",
+            }:
+                raise ETradeBrokerTransportError("broker message is malformed")
+            result.append(
+                BrokerMessage(
+                    code=_message_code(message["code"]),
+                    message_type=message["type"],
+                    description=message["description"],
+                )
+            )
+    return tuple(result)
+
+
+def _validate_xml_messages(root: ET.Element) -> tuple[BrokerMessage, ...]:
+    orders = [child for child in list(root) if child.tag == "Order"]
+    if len(orders) > 1:
+        raise ETradeBrokerTransportError("broker XML response order is ambiguous")
+    allowed_containers = [
+        child for child in list(root) if child.tag == "messageList"
+    ]
+    if len(allowed_containers) > 1:
+        raise ETradeBrokerTransportError("broker XML message list is ambiguous")
+    if orders:
+        order_containers = [
+            child for child in list(orders[0]) if child.tag == "messages"
+        ]
+        if len(order_containers) > 1:
+            raise ETradeBrokerTransportError("broker XML messages are ambiguous")
+        allowed_containers.extend(order_containers)
+    allowed_ids = {id(container) for container in allowed_containers}
+    for node in root.iter():
+        if node.tag in {"messageList", "messages"} and id(node) not in allowed_ids:
+            raise ETradeBrokerTransportError(
+                "broker XML message container is misplaced"
+            )
+        if node.tag == "Message" and not any(
+            id(node) == id(child)
+            for container in allowed_containers
+            for child in list(container)
+        ):
+            raise ETradeBrokerTransportError("broker XML message is misplaced")
+    result: list[BrokerMessage] = []
+    for container in allowed_containers:
+        messages = list(container)
+        if not messages or any(message.tag != "Message" for message in messages):
+            raise ETradeBrokerTransportError(
+                "broker XML message container is malformed"
+            )
+        for message in messages:
+            message_tags = [child.tag for child in list(message)]
+            if len(message_tags) != 3 or set(message_tags) != {
+                "description",
+                "code",
+                "type",
+            }:
+                raise ETradeBrokerTransportError("broker XML message is malformed")
+            description = _one_xml_text(message, "description")
+            code_text = _one_xml_text(message, "code")
+            if (
+                not code_text.isascii()
+                or not code_text.isdigit()
+                or len(code_text) > 10
+            ):
+                raise ETradeBrokerTransportError(
+                    "broker message code is invalid"
+                )
+            result.append(
+                BrokerMessage(
+                    code=int(code_text),
+                    message_type=_one_xml_text(message, "type"),
+                    description=description,
+                )
+            )
+    return tuple(result)
+
+
+def _validate_broker_message(description: Any, code: Any, message_type: Any) -> None:
+    if (
+        type(description) is not str
+        or not description
+        or len(description) > 4096
+        or type(code) is not int
+        or code < 0
+        or code > 2_147_483_647
+        or type(message_type) is not str
+        or message_type not in {"WARNING", "INFO", "INFO_HOLD", "ERROR"}
+    ):
+        raise ETradeBrokerTransportError("broker message is invalid")
+
+
+def _message_code(value: Any) -> int:
+    if type(value) is int:
+        normalized = value
+    elif (
+        type(value) is str
+        and value
+        and value.isascii()
+        and value.isdigit()
+        and len(value) <= 10
+    ):
+        normalized = int(value)
+    else:
+        raise ETradeBrokerTransportError("broker message code is invalid")
+    if not 0 <= normalized <= 2_147_483_647:
+        raise ETradeBrokerTransportError("broker message code is invalid")
+    return normalized
+
+
+def _messages_allow_ack(
+    operation: str, messages: tuple[BrokerMessage, ...]
+) -> bool:
+    return (
+        operation.endswith("PLACE")
+        and bool(messages)
+        and all(
+            message.message_type == "WARNING" and message.code == 1026
+            for message in messages
+        )
+    )
+
+
+def _one_xml_child(parent: ET.Element, tag: str) -> ET.Element:
+    matches = [child for child in list(parent) if child.tag == tag]
+    if len(matches) != 1:
+        raise ETradeBrokerTransportError("broker XML response field is ambiguous")
+    return matches[0]
+
+
+def _one_xml_text(parent: ET.Element, tag: str) -> str:
+    child = _one_xml_child(parent, tag)
+    if list(child) or type(child.text) is not str:
+        raise ETradeBrokerTransportError("broker XML response scalar is invalid")
+    return child.text.strip()
+
+
+def _one_xml_identifier(parent: ET.Element, tag: str) -> str:
+    children = list(parent)
+    tags = [child.tag for child in children]
+    if (
+        tags.count(tag) != 1
+        or tags.count("cashMargin") > 1
+        or set(tags) - {tag, "cashMargin"}
+    ):
+        raise ETradeBrokerTransportError(
+            "broker XML response identifier is ambiguous"
+        )
+    if "cashMargin" in tags:
+        cash_margin = _one_xml_text(parent, "cashMargin")
+        if cash_margin not in {"CASH", "MARGIN", "INVALID"}:
+            raise ETradeBrokerTransportError(
+                "broker XML cash margin is invalid"
+            )
+    return _one_xml_text(parent, tag)
+
+
+def _xml_order_status(root: ET.Element) -> str | None:
+    orders = [child for child in list(root) if child.tag == "Order"]
+    if not orders:
+        return None
+    if len(orders) != 1:
+        raise ETradeBrokerTransportError("broker XML response order is ambiguous")
+    statuses = [child for child in list(orders[0]) if child.tag == "status"]
+    if not statuses:
+        return None
+    if len(statuses) != 1 or list(statuses[0]) or type(statuses[0].text) is not str:
+        raise ETradeBrokerTransportError("broker XML response status is invalid")
+    return _broker_status(statuses[0].text.strip())
+
+
+def _broker_status(value: Any) -> str:
+    if (
+        type(value) is not str
+        or not value
+        or value != value.upper()
+        or not value.replace("_", "").isascii()
+        or not value.replace("_", "").isalpha()
+    ):
+        raise ETradeBrokerTransportError("broker status is invalid")
+    return value
+
+
+def _unknown_reply(
+    request: BoundBrokerRequest,
+    reason: str,
+    *,
+    http_status: int | None = None,
+    broker_status: str | None = None,
+    broker_order_id: str | None = None,
+    preview_id: str | None = None,
+    broker_messages: tuple[BrokerMessage, ...] = (),
+    raw_response_digest: str | None = None,
+    observed_at: datetime | None = None,
+) -> BrokerReply:
+    return BrokerReply(
+        request=request,
+        disposition="UNKNOWN",
+        http_status=http_status,
+        broker_status=broker_status,
+        client_order_id=request.client_order_id,
+        echoed_client_order_id=None,
+        broker_order_id=broker_order_id,
+        preview_id=request.preview_id if preview_id is None else preview_id,
+        broker_messages=broker_messages,
+        raw_response_digest=raw_response_digest,
+        observed_at=observed_at or datetime.now(timezone.utc),
+        unknown_reason=reason,
+    )
+
+
+def _identifier(value: Any, label: str) -> str:
+    if (
+        type(value) is not str
+        or not value
+        or len(value) > 256
+        or any(ord(character) < 33 or ord(character) > 126 for character in value)
+    ):
+        raise ETradeBrokerTransportError(f"{label} is invalid")
+    return value
+
+
+def _optional_identifier(value: Any, label: str) -> str | None:
+    if value is None:
+        return None
+    return _identifier(value, label)
+
+
+def _broker_numeric_id(value: Any, label: str) -> str:
+    if type(value) is int:
+        if value <= 0:
+            raise ETradeBrokerTransportError(f"{label} is invalid")
+        normalized = str(value)
+    elif type(value) is str:
+        if (
+            not value
+            or len(value) > 19
+            or not value.isascii()
+            or not value.isdigit()
+            or value[0] == "0"
+        ):
+            raise ETradeBrokerTransportError(f"{label} is invalid")
+        normalized = value
+    else:
+        raise ETradeBrokerTransportError(f"{label} is invalid")
+    if len(normalized) > 19:
+        raise ETradeBrokerTransportError(f"{label} is invalid")
+    if int(normalized) > _MAX_BROKER_INT64:
+        raise ETradeBrokerTransportError(f"{label} is invalid")
+    return normalized
+
+
+def _broker_numeric_text(value: Any, label: str) -> str:
+    if type(value) is not str:
+        raise ETradeBrokerTransportError(f"{label} is invalid")
+    return _broker_numeric_id(value, label)
+
+
+def _sha256(value: Any, label: str) -> str:
+    if (
+        type(value) is not str
+        or len(value) != 64
+        or any(character not in "0123456789abcdef" for character in value)
+    ):
+        raise ETradeBrokerTransportError(f"{label} is invalid")
+    return value

--- a/etrade_python_client/live_trading/order_intent_ledger.py
+++ b/etrade_python_client/live_trading/order_intent_ledger.py
@@ -17,20 +17,26 @@ import sqlite3
 import stat
 import uuid
 from contextlib import contextmanager
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from datetime import date, datetime, timedelta, timezone
 from decimal import Decimal, InvalidOperation, localcontext
 from pathlib import Path
 from typing import Any, Callable, Iterator, Literal, Mapping
+from urllib.parse import quote
 
 
-SCHEMA_VERSION = 9
-_MIGRATABLE_SCHEMA_VERSIONS = frozenset({8})
+SCHEMA_VERSION = 10
+_MIGRATABLE_SCHEMA_VERSIONS = frozenset({8, 9})
 _BUSY_TIMEOUT_MS = 5_000
 _EVIDENCE_MAX_AGE_SECONDS = 300
 _DECIMAL_PRECISION = 50
 _PAYLOAD_HASH_DOMAIN = b"etrade-order-payload.v2\0"
 _CLIENT_ID_DOMAIN = b"etrade-client-order-id.v2\0"
+_MAX_TRANSPORT_REQUEST_BYTES = 64 * 1024
+_PREVIEW_RECEIPT_MAX_AGE_SECONDS = 180
+_TRANSPORT_OPERATIONS = frozenset(
+    {"SUBMIT_PREVIEW", "SUBMIT_PLACE", "AMEND_PREVIEW", "AMEND_PLACE"}
+)
 _INTENT_KINDS = frozenset({"OPENING", "CLOSING"})
 _ENVIRONMENTS = frozenset({"sandbox", "production"})
 _TERMINAL_STATES = frozenset({"FILLED", "CANCELLED", "REJECTED", "EXPIRED", "FAILED"})
@@ -246,9 +252,65 @@ class OutboundAuthorization:
     operation: Literal["SUBMIT", "AMEND"]
     owner: str
     fencing_token: int
-    client_order_id: str
-    payload_bytes: bytes
+    client_order_id: str = field(repr=False)
+    payload_bytes: bytes = field(repr=False)
     payload_digest: str
+
+
+@dataclass(frozen=True)
+class TransportRequestEvidence:
+    """Exact broker request claimed durably before one network attempt."""
+
+    account_id: str = field(repr=False)
+    account_id_key: str = field(repr=False)
+    institution_type: str
+    environment: Literal["sandbox", "production"]
+    intent_id: str
+    owner: str
+    authorization_operation: Literal["SUBMIT", "AMEND"]
+    fencing_token: int
+    transport_operation: Literal[
+        "SUBMIT_PREVIEW", "SUBMIT_PLACE", "AMEND_PREVIEW", "AMEND_PLACE"
+    ]
+    http_method: Literal["POST", "PUT"]
+    route: str = field(repr=False)
+    client_order_id: str = field(repr=False)
+    target_broker_order_id: str | None = field(repr=False)
+    preview_id: str | None = field(repr=False)
+    authorization_payload_digest: str
+    final_xml_bytes: bytes = field(repr=False)
+    final_xml_sha256: str
+
+
+@dataclass(frozen=True)
+class TransportResponseEvidence:
+    """Parsed response bound to one exact transport send attempt."""
+
+    disposition: Literal["ACKNOWLEDGED", "UNKNOWN"]
+    http_status: int | None
+    broker_status: str | None
+    broker_order_id: str | None = field(repr=False)
+    preview_id: str | None = field(repr=False)
+    message_codes: tuple[int, ...]
+    message_types: tuple[str, ...]
+    message_description_digests: tuple[str, ...]
+    raw_response_digest: str | None
+    observed_at: datetime
+    unknown_reason: str | None
+
+
+@dataclass(frozen=True)
+class TransportResponseReceipt:
+    """Immutable typed response available to restart reconciliation."""
+
+    intent_id: str
+    authorization_operation: Literal["SUBMIT", "AMEND"]
+    fencing_token: int
+    transport_operation: Literal[
+        "SUBMIT_PREVIEW", "SUBMIT_PLACE", "AMEND_PREVIEW", "AMEND_PLACE"
+    ]
+    response: TransportResponseEvidence
+    recorded_at: datetime
 
 
 @dataclass(frozen=True)
@@ -561,6 +623,34 @@ class OrderIntentLedger:
             row = conn.execute("SELECT * FROM order_intents WHERE intent_id = ?", (intent_id,)).fetchone()
         return self._intent_from_row(row) if row else None
 
+    def transport_response_receipts(
+        self, intent_id: str
+    ) -> tuple[TransportResponseReceipt, ...]:
+        """Return durable parsed mutation responses for reconciliation."""
+
+        _validate_identity("intent_id", intent_id)
+        with self._connection() as conn:
+            self._require_intent(conn, intent_id)
+            rows = conn.execute(
+                """
+                SELECT * FROM transport_response_receipts
+                WHERE intent_id = ?
+                ORDER BY
+                    CASE authorization_operation
+                        WHEN 'SUBMIT' THEN 0 ELSE 1
+                    END,
+                    fencing_token,
+                    recorded_at,
+                    CASE
+                        WHEN transport_operation LIKE '%_PREVIEW' THEN 0
+                        ELSE 1
+                    END,
+                    transport_operation
+                """,
+                (intent_id,),
+            ).fetchall()
+        return tuple(_transport_response_receipt(row) for row in rows)
+
     def set_reservation_cap(self, evidence: AccountCapacityEvidence) -> Decimal:
         if type(evidence) is not AccountCapacityEvidence:
             raise OrderIntentValidationError("set_reservation_cap requires typed AccountCapacityEvidence")
@@ -779,6 +869,383 @@ class OrderIntentLedger:
             raise OrderIntentReconciliationRequired("expired claimed lease is in-doubt; do not POST")
         assert authorization is not None
         return authorization
+
+    def claim_transport_send(
+        self,
+        evidence: TransportRequestEvidence,
+        authorization: OutboundAuthorization,
+    ) -> None:
+        """Persist one exact broker send and transition place calls in-doubt.
+
+        The unique attempt row is the durable exactly-once fence. A process
+        crash after this method returns is reconciled and never retransmitted.
+        """
+
+        _validate_transport_request_evidence(evidence)
+        if type(authorization) is not OutboundAuthorization:
+            raise OrderIntentValidationError(
+                "transport send requires exact outbound authorization"
+            )
+        now = self._now_us()
+        expired = False
+        with self._transaction() as conn:
+            intent = self._require_intent(conn, evidence.intent_id)
+            if (
+                intent["account_id"] != evidence.account_id
+                or intent["environment"] != evidence.environment
+                or (
+                    evidence.authorization_operation == "SUBMIT"
+                    and intent["client_order_id"] != evidence.client_order_id
+                )
+            ):
+                raise OrderIntentIntegrityError(
+                    "transport account or client identity does not match intent"
+                )
+            if conn.execute(
+                """
+                SELECT 1 FROM transport_send_attempts
+                WHERE intent_id = ? AND authorization_operation = ?
+                  AND fencing_token = ? AND transport_operation = ?
+                """,
+                (
+                    evidence.intent_id,
+                    evidence.authorization_operation,
+                    evidence.fencing_token,
+                    evidence.transport_operation,
+                ),
+            ).fetchone() is not None:
+                raise OrderIntentReconciliationRequired(
+                    "exact transport stage already has a durable send attempt"
+                )
+
+            if evidence.authorization_operation == "SUBMIT":
+                if evidence.target_broker_order_id is not None:
+                    raise OrderIntentIntegrityError(
+                        "submission transport cannot target a broker order"
+                    )
+                if self._claim_expired(intent, now):
+                    self._mark_claim_in_doubt(conn, intent, now)
+                    expired = True
+                else:
+                    self._require_submission_fence(
+                        intent, evidence.owner, evidence.fencing_token
+                    )
+                    payload = json.loads(intent["wire_payload"])
+                    if type(payload) is not dict:
+                        raise OrderIntentIntegrityError(
+                            "stored submission payload is invalid"
+                        )
+                    payload["client_order_id"] = intent["client_order_id"]
+                    validated = self._require_outbound_authorization(
+                        authorization,
+                        intent_id=evidence.intent_id,
+                        operation="SUBMIT",
+                        owner=evidence.owner,
+                        fencing_token=evidence.fencing_token,
+                        client_order_id=evidence.client_order_id,
+                        payload=payload,
+                    )
+                    self._require_active_opening_reservation(conn, intent, now)
+                    if self._amendment_blocker_rows(
+                        conn,
+                        intent["account_id"],
+                        intent["environment"],
+                    ):
+                        raise OrderIntentReconciliationRequired(
+                            "account/environment has an unresolved amendment"
+                        )
+                    self._record_outbound_authorization(conn, validated, now)
+                    if evidence.transport_operation == "SUBMIT_PLACE":
+                        self._require_preview_receipt(conn, evidence, now)
+                        conn.execute(
+                            """
+                            UPDATE order_intents
+                            SET state = 'SUBMISSION_UNKNOWN',
+                                submission_lease_owner = NULL,
+                                submission_lease_expires_at = NULL,
+                                pending_operation = 'SUBMIT', pending_owner = ?,
+                                pending_fence = ?, last_reconciled_run = NULL,
+                                updated_at = ?
+                            WHERE intent_id = ?
+                            """,
+                            (
+                                evidence.owner,
+                                evidence.fencing_token,
+                                now,
+                                evidence.intent_id,
+                            ),
+                        )
+                        self._append_event(
+                            conn,
+                            evidence.intent_id,
+                            "POST_STARTED",
+                            "CLAIMED",
+                            "SUBMISSION_UNKNOWN",
+                            evidence.owner,
+                            "POST_STARTED",
+                            now,
+                        )
+            else:
+                amendment = conn.execute(
+                    "SELECT * FROM amendment_leases WHERE intent_id = ?",
+                    (evidence.intent_id,),
+                ).fetchone()
+                if (
+                    amendment is None
+                    or amendment["state"] != "LEASED"
+                    or amendment["owner"] != evidence.owner
+                    or int(amendment["fencing_token"]) != evidence.fencing_token
+                ):
+                    raise OrderIntentLeaseConflict(
+                        "amendment transport is not owned by this fence"
+                    )
+                if int(amendment["expires_at"]) <= now:
+                    self._mark_amendment_in_doubt(conn, intent, amendment, now)
+                    expired = True
+                elif (
+                    evidence.target_broker_order_id != amendment["broker_order_id"]
+                    or evidence.client_order_id != amendment["client_order_id"]
+                ):
+                    raise OrderIntentIntegrityError(
+                        "amendment transport target is not lease-bound"
+                    )
+                else:
+                    payload = json.loads(amendment["wire_payload"])
+                    if type(payload) is not dict:
+                        raise OrderIntentIntegrityError(
+                            "stored amendment payload is invalid"
+                        )
+                    payload["client_order_id"] = amendment["client_order_id"]
+                    validated = self._require_outbound_authorization(
+                        authorization,
+                        intent_id=evidence.intent_id,
+                        operation="AMEND",
+                        owner=evidence.owner,
+                        fencing_token=evidence.fencing_token,
+                        client_order_id=evidence.client_order_id,
+                        payload=payload,
+                    )
+                    if self._blocker_rows(
+                        conn,
+                        intent["account_id"],
+                        intent["environment"],
+                        exclude_intent_id=evidence.intent_id,
+                    ) or self._amendment_blocker_rows(
+                        conn,
+                        intent["account_id"],
+                        intent["environment"],
+                        exclude_intent_id=evidence.intent_id,
+                    ):
+                        raise OrderIntentReconciliationRequired(
+                            "account/environment has unresolved broker work"
+                        )
+                    self._require_opening_amendment_reservation(
+                        conn, intent, amendment["wire_payload"], now
+                    )
+                    self._record_outbound_authorization(conn, validated, now)
+                    if evidence.transport_operation == "AMEND_PLACE":
+                        self._require_preview_receipt(conn, evidence, now)
+                        conn.execute(
+                            "UPDATE amendment_leases SET state = 'IN_DOUBT', updated_at = ? WHERE intent_id = ?",
+                            (now, evidence.intent_id),
+                        )
+                        conn.execute(
+                            """
+                            UPDATE order_intents
+                            SET pending_operation = 'AMEND', pending_owner = ?,
+                                pending_fence = ?, last_reconciled_run = NULL,
+                                updated_at = ?
+                            WHERE intent_id = ?
+                            """,
+                            (
+                                evidence.owner,
+                                evidence.fencing_token,
+                                now,
+                                evidence.intent_id,
+                            ),
+                        )
+                        self._append_event(
+                            conn,
+                            evidence.intent_id,
+                            "AMENDMENT_STARTED",
+                            "SUBMITTED",
+                            "SUBMITTED",
+                            evidence.owner,
+                            "POST_STARTED",
+                            now,
+                            broker_order_id=intent["broker_order_id"],
+                        )
+
+            if not expired:
+                conn.execute(
+                    """
+                    INSERT INTO transport_send_attempts (
+                        intent_id, authorization_operation, fencing_token,
+                        transport_operation, owner, account_id, account_id_key,
+                        institution_type, environment, http_method, route,
+                        client_order_id, target_broker_order_id, preview_id,
+                        authorization_payload_digest, final_xml_bytes,
+                        final_xml_sha256, claimed_at
+                    ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+                    """,
+                    (
+                        evidence.intent_id,
+                        evidence.authorization_operation,
+                        evidence.fencing_token,
+                        evidence.transport_operation,
+                        evidence.owner,
+                        evidence.account_id,
+                        evidence.account_id_key,
+                        evidence.institution_type,
+                        evidence.environment,
+                        evidence.http_method,
+                        evidence.route,
+                        evidence.client_order_id,
+                        evidence.target_broker_order_id,
+                        evidence.preview_id,
+                        evidence.authorization_payload_digest,
+                        evidence.final_xml_bytes,
+                        evidence.final_xml_sha256,
+                        now,
+                    ),
+                )
+        if expired:
+            raise OrderIntentReconciliationRequired(
+                "expired transport lease is in-doubt and cannot be sent"
+            )
+
+    def record_transport_response(
+        self,
+        request: TransportRequestEvidence,
+        response: TransportResponseEvidence,
+    ) -> IntentRecord:
+        """Persist the first parsed response and atomically apply an ACK."""
+
+        _validate_transport_request_evidence(request)
+        _validate_transport_response_evidence(response)
+        _validate_acknowledged_transport_response(request, response)
+        now = self._now_us()
+        observed = _to_us(response.observed_at)
+        messages_json = json.dumps(
+            [
+                {
+                    "code": code,
+                    "type": message_type,
+                    "description_sha256": description_digest,
+                }
+                for code, message_type, description_digest in zip(
+                    response.message_codes,
+                    response.message_types,
+                    response.message_description_digests,
+                    strict=True,
+                )
+            ],
+            sort_keys=True,
+            separators=(",", ":"),
+        )
+        with self._transaction() as conn:
+            attempt = conn.execute(
+                """
+                SELECT * FROM transport_send_attempts
+                WHERE intent_id = ? AND authorization_operation = ?
+                  AND fencing_token = ? AND transport_operation = ?
+                """,
+                (
+                    request.intent_id,
+                    request.authorization_operation,
+                    request.fencing_token,
+                    request.transport_operation,
+                ),
+            ).fetchone()
+            if attempt is None or any(
+                attempt[field] != expected
+                for field, expected in (
+                    ("owner", request.owner),
+                    ("account_id", request.account_id),
+                    ("account_id_key", request.account_id_key),
+                    ("institution_type", request.institution_type),
+                    ("environment", request.environment),
+                    ("http_method", request.http_method),
+                    ("route", request.route),
+                    ("client_order_id", request.client_order_id),
+                    ("target_broker_order_id", request.target_broker_order_id),
+                    ("preview_id", request.preview_id),
+                    (
+                        "authorization_payload_digest",
+                        request.authorization_payload_digest,
+                    ),
+                    ("final_xml_sha256", request.final_xml_sha256),
+                )
+            ):
+                raise OrderIntentIntegrityError(
+                    "transport response does not match its durable send attempt"
+                )
+            if observed < int(attempt["claimed_at"]) or observed > now + 5_000_000:
+                raise OrderIntentIntegrityError(
+                    "transport response time is not causally bound to its send"
+                )
+            conn.execute(
+                """
+                INSERT INTO transport_response_receipts (
+                    intent_id, authorization_operation, fencing_token,
+                    transport_operation, disposition, http_status,
+                    broker_status, broker_order_id, preview_id, messages_json,
+                    raw_response_digest, observed_at, unknown_reason, recorded_at
+                ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+                """,
+                (
+                    request.intent_id,
+                    request.authorization_operation,
+                    request.fencing_token,
+                    request.transport_operation,
+                    response.disposition,
+                    response.http_status,
+                    response.broker_status,
+                    response.broker_order_id,
+                    response.preview_id,
+                    messages_json,
+                    response.raw_response_digest,
+                    observed,
+                    response.unknown_reason,
+                    now,
+                ),
+            )
+            if (
+                response.disposition == "ACKNOWLEDGED"
+                and request.transport_operation.endswith("PREVIEW")
+            ):
+                conn.execute(
+                    """
+                    INSERT INTO broker_preview_receipts (
+                        intent_id, authorization_operation, fencing_token,
+                        account_id, environment, client_order_id,
+                        target_broker_order_id, authorization_payload_digest,
+                        preview_id, raw_response_digest, observed_at, recorded_at
+                    ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+                    """,
+                    (
+                        request.intent_id,
+                        request.authorization_operation,
+                        request.fencing_token,
+                        request.account_id,
+                        request.environment,
+                        request.client_order_id,
+                        request.target_broker_order_id,
+                        request.authorization_payload_digest,
+                        response.preview_id,
+                        response.raw_response_digest,
+                        observed,
+                        now,
+                    ),
+                )
+            if (
+                response.disposition == "ACKNOWLEDGED"
+                and request.transport_operation.endswith("PLACE")
+            ):
+                self._apply_transport_ack(conn, request, response, now)
+            return self._intent_from_row(
+                self._require_intent(conn, request.intent_id)
+            )
 
     def begin_submission(
         self, intent_id: str, owner: str, fencing_token: int, authorization: OutboundAuthorization
@@ -1446,6 +1913,69 @@ class OrderIntentLedger:
                     PRIMARY KEY (intent_id, operation, fencing_token),
                     CHECK (length(payload_bytes) > 0 AND length(payload_digest) = 64)
                 );
+                CREATE TABLE IF NOT EXISTS transport_send_attempts (
+                    intent_id TEXT NOT NULL REFERENCES order_intents(intent_id),
+                    authorization_operation TEXT NOT NULL CHECK (authorization_operation IN ('SUBMIT', 'AMEND')),
+                    fencing_token INTEGER NOT NULL CHECK (fencing_token > 0),
+                    transport_operation TEXT NOT NULL CHECK (transport_operation IN ('SUBMIT_PREVIEW', 'SUBMIT_PLACE', 'AMEND_PREVIEW', 'AMEND_PLACE')),
+                    owner TEXT NOT NULL,
+                    account_id TEXT NOT NULL,
+                    account_id_key TEXT NOT NULL,
+                    institution_type TEXT NOT NULL,
+                    environment TEXT NOT NULL CHECK (environment IN ('sandbox', 'production')),
+                    http_method TEXT NOT NULL CHECK (http_method IN ('POST', 'PUT')),
+                    route TEXT NOT NULL,
+                    client_order_id TEXT NOT NULL,
+                    target_broker_order_id TEXT,
+                    preview_id TEXT,
+                    authorization_payload_digest TEXT NOT NULL,
+                    final_xml_bytes BLOB NOT NULL,
+                    final_xml_sha256 TEXT NOT NULL,
+                    claimed_at INTEGER NOT NULL,
+                    PRIMARY KEY (intent_id, authorization_operation, fencing_token, transport_operation),
+                    CHECK (length(authorization_payload_digest) = 64),
+                    CHECK (length(final_xml_bytes) > 0 AND length(final_xml_sha256) = 64),
+                    CHECK ((transport_operation LIKE 'AMEND_%') = (target_broker_order_id IS NOT NULL)),
+                    CHECK ((transport_operation LIKE '%_PLACE') = (preview_id IS NOT NULL))
+                );
+                CREATE TABLE IF NOT EXISTS broker_preview_receipts (
+                    intent_id TEXT NOT NULL REFERENCES order_intents(intent_id),
+                    authorization_operation TEXT NOT NULL CHECK (authorization_operation IN ('SUBMIT', 'AMEND')),
+                    fencing_token INTEGER NOT NULL CHECK (fencing_token > 0),
+                    account_id TEXT NOT NULL,
+                    environment TEXT NOT NULL CHECK (environment IN ('sandbox', 'production')),
+                    client_order_id TEXT NOT NULL,
+                    target_broker_order_id TEXT,
+                    authorization_payload_digest TEXT NOT NULL,
+                    preview_id TEXT NOT NULL,
+                    raw_response_digest TEXT NOT NULL,
+                    observed_at INTEGER NOT NULL,
+                    recorded_at INTEGER NOT NULL,
+                    PRIMARY KEY (intent_id, authorization_operation, fencing_token),
+                    UNIQUE (account_id, environment, preview_id),
+                    CHECK (length(authorization_payload_digest) = 64),
+                    CHECK (length(raw_response_digest) = 64)
+                );
+                CREATE TABLE IF NOT EXISTS transport_response_receipts (
+                    intent_id TEXT NOT NULL REFERENCES order_intents(intent_id),
+                    authorization_operation TEXT NOT NULL CHECK (authorization_operation IN ('SUBMIT', 'AMEND')),
+                    fencing_token INTEGER NOT NULL CHECK (fencing_token > 0),
+                    transport_operation TEXT NOT NULL CHECK (transport_operation IN ('SUBMIT_PREVIEW', 'SUBMIT_PLACE', 'AMEND_PREVIEW', 'AMEND_PLACE')),
+                    disposition TEXT NOT NULL CHECK (disposition IN ('ACKNOWLEDGED', 'UNKNOWN')),
+                    http_status INTEGER,
+                    broker_status TEXT,
+                    broker_order_id TEXT,
+                    preview_id TEXT,
+                    messages_json TEXT NOT NULL,
+                    raw_response_digest TEXT,
+                    observed_at INTEGER NOT NULL,
+                    unknown_reason TEXT,
+                    recorded_at INTEGER NOT NULL,
+                    PRIMARY KEY (intent_id, authorization_operation, fencing_token, transport_operation),
+                    CHECK (http_status IS NULL OR http_status BETWEEN 100 AND 599),
+                    CHECK (raw_response_digest IS NULL OR length(raw_response_digest) = 64),
+                    CHECK ((disposition = 'UNKNOWN') = (unknown_reason IS NOT NULL))
+                );
                 CREATE TABLE IF NOT EXISTS order_events (
                     sequence INTEGER PRIMARY KEY AUTOINCREMENT,
                     intent_id TEXT NOT NULL REFERENCES order_intents(intent_id),
@@ -1485,6 +2015,12 @@ class OrderIntentLedger:
                 CREATE TRIGGER IF NOT EXISTS prevent_amendment_history_delete BEFORE DELETE ON amendment_history BEGIN SELECT RAISE(ABORT, 'amendment history is immutable'); END;
                 CREATE TRIGGER IF NOT EXISTS prevent_outbound_authorization_update BEFORE UPDATE ON outbound_authorizations BEGIN SELECT RAISE(ABORT, 'outbound authorizations are immutable'); END;
                 CREATE TRIGGER IF NOT EXISTS prevent_outbound_authorization_delete BEFORE DELETE ON outbound_authorizations BEGIN SELECT RAISE(ABORT, 'outbound authorizations are immutable'); END;
+                CREATE TRIGGER IF NOT EXISTS prevent_transport_send_attempt_update BEFORE UPDATE ON transport_send_attempts BEGIN SELECT RAISE(ABORT, 'transport send attempts are immutable'); END;
+                CREATE TRIGGER IF NOT EXISTS prevent_transport_send_attempt_delete BEFORE DELETE ON transport_send_attempts BEGIN SELECT RAISE(ABORT, 'transport send attempts are immutable'); END;
+                CREATE TRIGGER IF NOT EXISTS prevent_broker_preview_receipt_update BEFORE UPDATE ON broker_preview_receipts BEGIN SELECT RAISE(ABORT, 'broker preview receipts are immutable'); END;
+                CREATE TRIGGER IF NOT EXISTS prevent_broker_preview_receipt_delete BEFORE DELETE ON broker_preview_receipts BEGIN SELECT RAISE(ABORT, 'broker preview receipts are immutable'); END;
+                CREATE TRIGGER IF NOT EXISTS prevent_transport_response_receipt_update BEFORE UPDATE ON transport_response_receipts BEGIN SELECT RAISE(ABORT, 'transport response receipts are immutable'); END;
+                CREATE TRIGGER IF NOT EXISTS prevent_transport_response_receipt_delete BEFORE DELETE ON transport_response_receipts BEGIN SELECT RAISE(ABORT, 'transport response receipts are immutable'); END;
                 CREATE TRIGGER IF NOT EXISTS prevent_broker_order_history_update BEFORE UPDATE ON broker_order_history BEGIN SELECT RAISE(ABORT, 'broker order history is immutable'); END;
                 CREATE TRIGGER IF NOT EXISTS prevent_broker_order_history_delete BEFORE DELETE ON broker_order_history BEGIN SELECT RAISE(ABORT, 'broker order history is immutable'); END;
                 CREATE TRIGGER IF NOT EXISTS prevent_intent_identity_mutation BEFORE UPDATE ON order_intents
@@ -1560,6 +2096,38 @@ class OrderIntentLedger:
     def _mark_claim_in_doubt(self, conn: sqlite3.Connection, intent: sqlite3.Row, now: int) -> None:
         if intent["state"] != "CLAIMED":
             return
+        place_attempt = conn.execute(
+            """
+            SELECT 1 FROM transport_send_attempts
+            WHERE intent_id = ? AND authorization_operation = 'SUBMIT'
+              AND fencing_token = ? AND transport_operation = 'SUBMIT_PLACE'
+            """,
+            (intent["intent_id"], intent["submission_fence"]),
+        ).fetchone()
+        if place_attempt is None:
+            conn.execute(
+                """
+                UPDATE order_intents SET state = 'INTENT',
+                    submission_lease_owner = NULL,
+                    submission_lease_expires_at = NULL,
+                    pending_operation = NULL, pending_owner = NULL,
+                    pending_fence = NULL, last_reconciled_run = NULL,
+                    updated_at = ?
+                WHERE intent_id = ?
+                """,
+                (now, intent["intent_id"]),
+            )
+            self._append_event(
+                conn,
+                intent["intent_id"],
+                "PREVIEW_ONLY_EXPIRED",
+                "CLAIMED",
+                "INTENT",
+                "system",
+                "LEASE_EXPIRED_IN_DOUBT",
+                now,
+            )
+            return
         conn.execute(
             """
             UPDATE order_intents SET state = 'SUBMISSION_UNKNOWN', submission_lease_owner = NULL,
@@ -1572,6 +2140,31 @@ class OrderIntentLedger:
 
     def _mark_amendment_in_doubt(self, conn: sqlite3.Connection, intent: sqlite3.Row, amendment: sqlite3.Row, now: int) -> None:
         if amendment["state"] != "LEASED":
+            return
+        place_attempt = conn.execute(
+            """
+            SELECT 1 FROM transport_send_attempts
+            WHERE intent_id = ? AND authorization_operation = 'AMEND'
+              AND fencing_token = ? AND transport_operation = 'AMEND_PLACE'
+            """,
+            (intent["intent_id"], amendment["fencing_token"]),
+        ).fetchone()
+        if place_attempt is None:
+            conn.execute(
+                "DELETE FROM amendment_leases WHERE intent_id = ?",
+                (intent["intent_id"],),
+            )
+            self._append_event(
+                conn,
+                intent["intent_id"],
+                "AMENDMENT_PREVIEW_ONLY_EXPIRED",
+                "SUBMITTED",
+                "SUBMITTED",
+                "system",
+                "LEASE_EXPIRED_IN_DOUBT",
+                now,
+                broker_order_id=intent["broker_order_id"],
+            )
             return
         conn.execute("UPDATE amendment_leases SET state = 'IN_DOUBT', updated_at = ? WHERE intent_id = ?", (now, intent["intent_id"]))
         conn.execute("UPDATE order_intents SET pending_operation = 'AMEND', pending_owner = ?, pending_fence = ?, last_reconciled_run = NULL, updated_at = ? WHERE intent_id = ?", (amendment["owner"], amendment["fencing_token"], now, intent["intent_id"]))
@@ -1641,6 +2234,238 @@ class OrderIntentLedger:
             raise OrderIntentReservationError("active reservations exceed account/environment cap")
 
     @staticmethod
+    def _require_preview_receipt(
+        conn: sqlite3.Connection,
+        evidence: TransportRequestEvidence,
+        now: int,
+    ) -> None:
+        preview_operation = evidence.transport_operation.replace("PLACE", "PREVIEW")
+        receipt = conn.execute(
+            """
+            SELECT * FROM broker_preview_receipts
+            WHERE intent_id = ? AND authorization_operation = ?
+              AND fencing_token = ?
+            """,
+            (
+                evidence.intent_id,
+                evidence.authorization_operation,
+                evidence.fencing_token,
+            ),
+        ).fetchone()
+        if receipt is None or any(
+            receipt[field] != expected
+            for field, expected in (
+                ("account_id", evidence.account_id),
+                ("environment", evidence.environment),
+                ("client_order_id", evidence.client_order_id),
+                ("target_broker_order_id", evidence.target_broker_order_id),
+                (
+                    "authorization_payload_digest",
+                    evidence.authorization_payload_digest,
+                ),
+                ("preview_id", evidence.preview_id),
+            )
+        ):
+            raise OrderIntentIntegrityError(
+                "place request lacks its exact broker preview receipt"
+            )
+        preview_attempt = conn.execute(
+            """
+            SELECT * FROM transport_send_attempts
+            WHERE intent_id = ? AND authorization_operation = ?
+              AND fencing_token = ? AND transport_operation = ?
+            """,
+            (
+                evidence.intent_id,
+                evidence.authorization_operation,
+                evidence.fencing_token,
+                preview_operation,
+            ),
+        ).fetchone()
+        expected_preview_route = (
+            evidence.route.removesuffix("place") + "preview"
+        )
+        if preview_attempt is None or any(
+            preview_attempt[field] != expected
+            for field, expected in (
+                ("owner", evidence.owner),
+                ("account_id", evidence.account_id),
+                ("account_id_key", evidence.account_id_key),
+                ("institution_type", evidence.institution_type),
+                ("environment", evidence.environment),
+                ("http_method", evidence.http_method),
+                ("route", expected_preview_route),
+                ("client_order_id", evidence.client_order_id),
+                ("target_broker_order_id", evidence.target_broker_order_id),
+                ("preview_id", None),
+                (
+                    "authorization_payload_digest",
+                    evidence.authorization_payload_digest,
+                ),
+            )
+        ):
+            raise OrderIntentIntegrityError(
+                "place request lacks its exact durable preview send attempt"
+            )
+        observed_at = int(receipt["observed_at"])
+        if (
+            observed_at > now + 5_000_000
+            or now - observed_at > _PREVIEW_RECEIPT_MAX_AGE_SECONDS * 1_000_000
+        ):
+            raise OrderIntentReconciliationRequired(
+                "broker preview receipt is stale; do not place"
+            )
+
+    def _apply_transport_ack(
+        self,
+        conn: sqlite3.Connection,
+        request: TransportRequestEvidence,
+        response: TransportResponseEvidence,
+        now: int,
+    ) -> None:
+        if (
+            response.http_status != 200
+            or response.broker_order_id is None
+            or response.raw_response_digest is None
+            or response.broker_status not in {None, "OPEN"}
+            or response.unknown_reason is not None
+            or (
+                response.message_codes
+                and any(
+                    code != 1026 or message_type != "WARNING"
+                    for code, message_type in zip(
+                        response.message_codes,
+                        response.message_types,
+                        strict=True,
+                    )
+                )
+            )
+        ):
+            raise OrderIntentValidationError(
+                "transport acknowledgement is not definitive"
+            )
+        operation = (
+            "SUBMIT_ACK"
+            if request.authorization_operation == "SUBMIT"
+            else "AMEND_ACK"
+        )
+        broker_evidence = BrokerEvidence(
+            account_id=request.account_id,
+            environment=request.environment,
+            client_order_id=request.client_order_id,
+            broker_order_id=response.broker_order_id,
+            operation=operation,
+            outcome="OPEN",
+            observed_at=response.observed_at,
+            http_status=response.http_status,
+            raw_response_digest=response.raw_response_digest,
+        )
+        BrokerEvidence.validate(broker_evidence, _from_us(now))
+        intent = self._require_intent(conn, request.intent_id)
+        if request.authorization_operation == "SUBMIT":
+            self._validate_broker_evidence(
+                conn,
+                intent,
+                broker_evidence,
+                allowed_operations={"SUBMIT_ACK"},
+                allowed_outcomes={"OPEN"},
+            )
+            if (
+                intent["state"] != "SUBMISSION_UNKNOWN"
+                or intent["pending_operation"] != "SUBMIT"
+                or intent["pending_owner"] != request.owner
+                or int(intent["pending_fence"] or -1) != request.fencing_token
+            ):
+                raise OrderIntentTransitionError(
+                    "transport acknowledgement requires its pending submission"
+                )
+            self._bind_broker_order_history(
+                conn, response.broker_order_id, request.intent_id, now
+            )
+            conn.execute(
+                """
+                UPDATE order_intents
+                SET state = 'SUBMITTED', broker_order_id = ?,
+                    pending_operation = NULL, pending_owner = NULL,
+                    pending_fence = NULL, last_reconciled_run = ?, updated_at = ?
+                WHERE intent_id = ?
+                """,
+                (
+                    response.broker_order_id,
+                    self.run_id,
+                    now,
+                    request.intent_id,
+                ),
+            )
+            self._append_reconciliation_event(
+                conn,
+                request.intent_id,
+                "SUBMISSION_UNKNOWN",
+                "SUBMITTED",
+                "POST_ACKNOWLEDGED",
+                "POST_ACKNOWLEDGED",
+                broker_evidence,
+                now,
+            )
+            return
+        amendment = conn.execute(
+            "SELECT * FROM amendment_leases WHERE intent_id = ?",
+            (request.intent_id,),
+        ).fetchone()
+        self._validate_broker_evidence(
+            conn,
+            intent,
+            broker_evidence,
+            allowed_operations={"AMEND_ACK"},
+            allowed_outcomes={"OPEN"},
+        )
+        if (
+            amendment is None
+            or amendment["state"] != "IN_DOUBT"
+            or amendment["owner"] != request.owner
+            or int(amendment["fencing_token"]) != request.fencing_token
+            or intent["pending_operation"] != "AMEND"
+            or intent["pending_owner"] != request.owner
+            or int(intent["pending_fence"] or -1) != request.fencing_token
+        ):
+            raise OrderIntentLeaseConflict(
+                "transport acknowledgement is not fenced to its amendment"
+            )
+        self._bind_broker_order_history(
+            conn, response.broker_order_id, request.intent_id, now
+        )
+        conn.execute(
+            """
+            UPDATE order_intents
+            SET broker_order_id = ?, pending_operation = NULL,
+                pending_owner = NULL, pending_fence = NULL,
+                last_reconciled_run = ?, updated_at = ?
+            WHERE intent_id = ?
+            """,
+            (
+                response.broker_order_id,
+                self.run_id,
+                now,
+                request.intent_id,
+            ),
+        )
+        self._archive_amendment(conn, amendment, "ACKNOWLEDGED", now)
+        conn.execute(
+            "DELETE FROM amendment_leases WHERE intent_id = ?",
+            (request.intent_id,),
+        )
+        self._append_reconciliation_event(
+            conn,
+            request.intent_id,
+            "SUBMITTED",
+            "SUBMITTED",
+            "AMENDMENT_ACKNOWLEDGED",
+            "POST_ACKNOWLEDGED",
+            broker_evidence,
+            now,
+        )
+
+    @staticmethod
     def _require_outbound_authorization(
         authorization: OutboundAuthorization,
         *,
@@ -1697,6 +2522,30 @@ class OrderIntentLedger:
     def _record_outbound_authorization(
         conn: sqlite3.Connection, authorization: OutboundAuthorization, now: int
     ) -> None:
+        existing = conn.execute(
+            """
+            SELECT * FROM outbound_authorizations
+            WHERE intent_id = ? AND operation = ? AND fencing_token = ?
+            """,
+            (
+                authorization.intent_id,
+                authorization.operation,
+                authorization.fencing_token,
+            ),
+        ).fetchone()
+        if existing is not None:
+            if any(
+                existing[field] != expected
+                for field, expected in (
+                    ("client_order_id", authorization.client_order_id),
+                    ("payload_bytes", authorization.payload_bytes),
+                    ("payload_digest", authorization.payload_digest),
+                )
+            ):
+                raise OrderIntentIntegrityError(
+                    "durable outbound authorization conflicts with this fence"
+                )
+            return
         conn.execute(
             """
             INSERT INTO outbound_authorizations
@@ -1877,6 +2726,72 @@ class OrderIntentLedger:
         return IntentEvent(sequence=int(row["sequence"]), intent_id=row["intent_id"], account_id=row["account_id"], environment=row["environment"], client_order_id=row["client_order_id"], event_type=row["event_type"], from_state=row["from_state"], to_state=row["to_state"], actor=row["actor"], reason_code=row["reason_code"], broker_status=row["broker_status"], broker_order_id=row["broker_order_id"], observed_at=_from_us(row["observed_at"]) if row["observed_at"] is not None else None, evidence_operation=row["evidence_operation"], http_status=row["http_status"], raw_response_digest=row["raw_response_digest"], created_at=_from_us(row["created_at"]))
 
 
+def _transport_response_receipt(
+    row: sqlite3.Row,
+) -> TransportResponseReceipt:
+    try:
+        messages = json.loads(row["messages_json"])
+    except (TypeError, json.JSONDecodeError) as exc:
+        raise OrderIntentIntegrityError(
+            "stored transport response messages are invalid"
+        ) from exc
+    if (
+        type(messages) is not list
+        or any(
+            type(message) is not dict
+            or set(message)
+            != {"code", "type", "description_sha256"}
+            for message in messages
+        )
+        or json.dumps(
+            messages, sort_keys=True, separators=(",", ":")
+        )
+        != row["messages_json"]
+    ):
+        raise OrderIntentIntegrityError(
+            "stored transport response messages are not canonical"
+        )
+    response = TransportResponseEvidence(
+        disposition=row["disposition"],
+        http_status=row["http_status"],
+        broker_status=row["broker_status"],
+        broker_order_id=row["broker_order_id"],
+        preview_id=row["preview_id"],
+        message_codes=tuple(message["code"] for message in messages),
+        message_types=tuple(message["type"] for message in messages),
+        message_description_digests=tuple(
+            message["description_sha256"] for message in messages
+        ),
+        raw_response_digest=row["raw_response_digest"],
+        observed_at=_from_us(row["observed_at"]),
+        unknown_reason=row["unknown_reason"],
+    )
+    _validate_transport_response_evidence(response)
+    intent_id = row["intent_id"]
+    authorization_operation = row["authorization_operation"]
+    fencing_token = int(row["fencing_token"])
+    transport_operation = row["transport_operation"]
+    _validate_identity("intent_id", intent_id)
+    _validate_fencing_token(fencing_token)
+    if (
+        authorization_operation not in {"SUBMIT", "AMEND"}
+        or transport_operation not in _TRANSPORT_OPERATIONS
+        or transport_operation.split("_", 1)[0]
+        != authorization_operation
+    ):
+        raise OrderIntentIntegrityError(
+            "stored transport response operation is invalid"
+        )
+    return TransportResponseReceipt(
+        intent_id=intent_id,
+        authorization_operation=authorization_operation,
+        fencing_token=fencing_token,
+        transport_operation=transport_operation,
+        response=response,
+        recorded_at=_from_us(row["recorded_at"]),
+    )
+
+
 def _validate_envelope(envelope: OrderIntent) -> None:
     if type(envelope) is not OrderIntent:
         raise OrderIntentValidationError("intent envelope must use the exact OrderIntent type")
@@ -1897,6 +2812,203 @@ def _validate_envelope(envelope: OrderIntent) -> None:
         raise OrderIntentIntegrityError("wire payload is invalid JSON") from exc
     if wire_order_payload(wire_payload) != envelope.wire_payload or canonical_order_payload(wire_payload) != envelope.canonical_payload or _derive_intent_kind(wire_payload) != envelope.intent_kind:
         raise OrderIntentIntegrityError("wire payload does not satisfy strict canonical identity")
+
+
+def _validate_transport_request_evidence(
+    evidence: TransportRequestEvidence,
+) -> None:
+    if type(evidence) is not TransportRequestEvidence:
+        raise OrderIntentValidationError(
+            "transport request evidence must use its exact immutable type"
+        )
+    for name in (
+        "account_id",
+        "account_id_key",
+        "institution_type",
+        "intent_id",
+        "owner",
+        "client_order_id",
+    ):
+        _validate_identity(name, getattr(evidence, name))
+    _validate_environment(evidence.environment)
+    _validate_fencing_token(evidence.fencing_token)
+    if (
+        type(evidence.authorization_operation) is not str
+        or evidence.authorization_operation not in {"SUBMIT", "AMEND"}
+        or type(evidence.transport_operation) is not str
+        or evidence.transport_operation not in _TRANSPORT_OPERATIONS
+        or type(evidence.http_method) is not str
+        or evidence.http_method not in {"POST", "PUT"}
+    ):
+        raise OrderIntentValidationError(
+            "transport operation metadata is invalid"
+        )
+    expected_authorization = (
+        "SUBMIT"
+        if evidence.transport_operation.startswith("SUBMIT")
+        else "AMEND"
+    )
+    expected_method = (
+        "POST"
+        if evidence.transport_operation.startswith("SUBMIT")
+        else "PUT"
+    )
+    if (
+        evidence.authorization_operation != expected_authorization
+        or evidence.http_method != expected_method
+    ):
+        raise OrderIntentIntegrityError(
+            "transport operation is inconsistent with authorization"
+        )
+    is_amend = expected_authorization == "AMEND"
+    is_place = evidence.transport_operation.endswith("PLACE")
+    if is_amend != (evidence.target_broker_order_id is not None):
+        raise OrderIntentIntegrityError("transport target binding is inconsistent")
+    if is_place != (evidence.preview_id is not None):
+        raise OrderIntentIntegrityError("transport preview binding is inconsistent")
+    if evidence.target_broker_order_id is not None:
+        _validate_identity(
+            "target_broker_order_id", evidence.target_broker_order_id
+        )
+    if evidence.preview_id is not None:
+        _validate_identity("preview_id", evidence.preview_id)
+    _validate_sha256(
+        "authorization_payload_digest",
+        evidence.authorization_payload_digest,
+    )
+    _validate_sha256("final_xml_sha256", evidence.final_xml_sha256)
+    if (
+        type(evidence.final_xml_bytes) is not bytes
+        or not evidence.final_xml_bytes
+        or len(evidence.final_xml_bytes) > _MAX_TRANSPORT_REQUEST_BYTES
+        or not hmac.compare_digest(
+            hashlib.sha256(evidence.final_xml_bytes).hexdigest(),
+            evidence.final_xml_sha256,
+        )
+    ):
+        raise OrderIntentIntegrityError(
+            "transport request body does not verify"
+        )
+    encoded_account = quote(evidence.account_id_key, safe="")
+    if is_amend:
+        encoded_target = quote(evidence.target_broker_order_id or "", safe="")
+        action = "place" if is_place else "preview"
+        expected_route = (
+            f"/v1/accounts/{encoded_account}/orders/"
+            f"{encoded_target}/change/{action}"
+        )
+    else:
+        action = "place" if is_place else "preview"
+        expected_route = f"/v1/accounts/{encoded_account}/orders/{action}"
+    if type(evidence.route) is not str or evidence.route != expected_route:
+        raise OrderIntentIntegrityError("transport route binding is invalid")
+
+
+def _validate_transport_response_evidence(
+    evidence: TransportResponseEvidence,
+) -> None:
+    if type(evidence) is not TransportResponseEvidence:
+        raise OrderIntentValidationError(
+            "transport response evidence must use its exact immutable type"
+        )
+    if (
+        type(evidence.disposition) is not str
+        or evidence.disposition not in {"ACKNOWLEDGED", "UNKNOWN"}
+        or (
+            evidence.http_status is not None
+            and (
+                type(evidence.http_status) is not int
+                or not 100 <= evidence.http_status <= 599
+            )
+        )
+    ):
+        raise OrderIntentValidationError(
+            "transport response disposition is invalid"
+        )
+    for name, value in (
+        ("broker_status", evidence.broker_status),
+        ("broker_order_id", evidence.broker_order_id),
+        ("preview_id", evidence.preview_id),
+        ("unknown_reason", evidence.unknown_reason),
+    ):
+        if value is not None:
+            _validate_identity(name, value)
+    tuples = (
+        evidence.message_codes,
+        evidence.message_types,
+        evidence.message_description_digests,
+    )
+    if (
+        any(type(value) is not tuple for value in tuples)
+        or len({len(value) for value in tuples}) != 1
+        or len(evidence.message_codes) > 64
+        or any(
+            type(code) is not int or not 0 <= code <= 2_147_483_647
+            for code in evidence.message_codes
+        )
+        or any(
+            type(message_type) is not str
+            or message_type not in {"WARNING", "INFO", "INFO_HOLD", "ERROR"}
+            for message_type in evidence.message_types
+        )
+    ):
+        raise OrderIntentValidationError(
+            "transport response messages are invalid"
+        )
+    for digest in evidence.message_description_digests:
+        _validate_sha256("message_description_digest", digest)
+    if evidence.raw_response_digest is not None:
+        _validate_sha256(
+            "raw_response_digest", evidence.raw_response_digest
+        )
+    _validate_timestamp(evidence.observed_at)
+    if (evidence.disposition == "UNKNOWN") != (
+        evidence.unknown_reason is not None
+    ):
+        raise OrderIntentValidationError(
+            "transport response unknown reason is inconsistent"
+        )
+
+
+def _validate_acknowledged_transport_response(
+    request: TransportRequestEvidence,
+    response: TransportResponseEvidence,
+) -> None:
+    if response.disposition != "ACKNOWLEDGED":
+        return
+    if (
+        response.http_status != 200
+        or response.raw_response_digest is None
+        or response.broker_status not in {None, "OPEN"}
+    ):
+        raise OrderIntentValidationError(
+            "transport acknowledgement lacks definitive broker evidence"
+        )
+    if request.transport_operation.endswith("PREVIEW"):
+        if (
+            response.preview_id is None
+            or response.broker_order_id is not None
+            or response.message_codes
+        ):
+            raise OrderIntentValidationError(
+                "preview acknowledgement is not safe for placement"
+            )
+        return
+    if (
+        response.broker_order_id is None
+        or response.preview_id != request.preview_id
+        or any(
+            code != 1026 or message_type != "WARNING"
+            for code, message_type in zip(
+                response.message_codes,
+                response.message_types,
+                strict=True,
+            )
+        )
+    ):
+        raise OrderIntentValidationError(
+            "place acknowledgement is not definitive"
+        )
 
 
 def _payload_hash(canonical_payload: str) -> str:

--- a/etrade_python_client/tests/test_etrade_broker_transport.py
+++ b/etrade_python_client/tests/test_etrade_broker_transport.py
@@ -1,0 +1,986 @@
+from __future__ import annotations
+
+import hashlib
+import io
+import json
+import os
+import sqlite3
+import struct
+import tempfile
+import unittest
+from dataclasses import dataclass
+from datetime import datetime, timedelta, timezone
+from decimal import Decimal
+from pathlib import Path
+from unittest.mock import patch
+
+from rauth import OAuth1Session
+from requests.adapters import HTTPAdapter
+from requests.exceptions import Timeout
+from xml.etree import ElementTree as ET
+
+from live_trading.etrade_broker_transport import (
+    BrokerReply,
+    ETradeBrokerTransport,
+    ETradeBrokerTransportError,
+    SelectedBrokerAccount,
+    _EXCHANGE_RESULT_BUFFER_BYTES,
+    _ExchangeResult,
+    _exchange_worker,
+    _isolated_exchange,
+    _read_bounded_response,
+    _read_exchange_result,
+    _serialized_prepared_request,
+    _transport_evidence,
+    _transport_response_evidence,
+    _write_exchange_result,
+)
+from live_trading.order_intent_ledger import (
+    AccountCapacityEvidence,
+    BrokerEvidence,
+    OrderIntent,
+    OrderIntentLedger,
+    OrderIntentReconciliationRequired,
+    OutboundAuthorization,
+    RiskEvidence,
+)
+from live_trading.runtime_safety import RuntimeSafetyBoundary
+
+
+ACCOUNT_ID = "842468410"
+ACCOUNT_KEY = "account/key"
+INSTITUTION_TYPE = "BROKERAGE"
+OWNER = "worker-1"
+
+
+def vertical_payload(*, limit_price=1.25, symbol="SPY"):
+    return {
+        "securityType": "OPTN",
+        "orderAction": "SPREAD",
+        "priceType": "NET_CREDIT",
+        "limitPrice": limit_price,
+        "orderTerm": "GOOD_FOR_DAY",
+        "spreadType": "VERTICAL",
+        "legs": [
+            {
+                "symbol": symbol,
+                "callPut": "PUT",
+                "expiryYear": 2026,
+                "expiryMonth": 8,
+                "expiryDay": 21,
+                "strikePrice": 620,
+                "orderAction": "SELL_OPEN",
+                "quantity": 1,
+            },
+            {
+                "symbol": symbol,
+                "callPut": "PUT",
+                "expiryYear": 2026,
+                "expiryMonth": 8,
+                "expiryDay": 21,
+                "strikePrice": 615,
+                "orderAction": "BUY_OPEN",
+                "quantity": 1,
+            },
+        ],
+    }
+
+
+class FakeResponse:
+    def __init__(self, status_code=200, *, body=None, raw=None, headers=None):
+        self.status_code = status_code
+        self.content = (
+            raw
+            if raw is not None
+            else json.dumps(
+                body, sort_keys=True, separators=(",", ":")
+            ).encode("utf-8")
+        )
+        self.raw = io.BytesIO(self.content)
+        self.headers = headers or {}
+        self.closed = False
+
+    def close(self):
+        self.closed = True
+        self.raw.close()
+
+
+def preview_response(*, preview_id="1020563279", account_id=ACCOUNT_ID):
+    return FakeResponse(
+        body={
+            "PreviewOrderResponse": {
+                "accountId": account_id,
+                "orderType": "SPREADS",
+                "PreviewIds": [{"previewId": preview_id}],
+                "Order": [{"status": "OPEN"}],
+            }
+        }
+    )
+
+
+def place_response(*, order_id="94", account_id=ACCOUNT_ID, status="OPEN"):
+    return FakeResponse(
+        body={
+            "PlaceOrderResponse": {
+                "accountId": account_id,
+                "orderType": "SPREADS",
+                "OrderIds": [{"orderId": order_id}],
+                "Order": [{"status": status}],
+            }
+        }
+    )
+
+
+class AdapterHarness:
+    def __init__(self, outcomes):
+        self.outcomes = list(outcomes)
+        self.calls = []
+
+    def exchange(self, prepared, *, timeout_seconds):
+        self.calls.append(
+            (prepared, {"timeout_seconds": timeout_seconds})
+        )
+        if not self.outcomes:
+            raise AssertionError("unexpected broker request")
+        outcome = self.outcomes.pop(0)
+        if isinstance(outcome, (Timeout, TimeoutError)):
+            return _ExchangeResult("TIMEOUT")
+        if isinstance(outcome, BaseException):
+            return _ExchangeResult("TRANSPORT_ERROR")
+        try:
+            status, raw = _read_bounded_response(outcome)
+        except (Timeout, TimeoutError):
+            return _ExchangeResult("TIMEOUT")
+        except Exception:
+            return _ExchangeResult("MALFORMED_RESPONSE")
+        return _ExchangeResult(
+            "RESPONSE", http_status=status, raw_response=raw
+        )
+
+
+@dataclass
+class TransportCase:
+    temporary: tempfile.TemporaryDirectory
+    ledger: OrderIntentLedger
+    transport: ETradeBrokerTransport
+    adapter: AdapterHarness
+    record: object
+    authorization: OutboundAuthorization
+    patcher: object
+
+
+class ETradeBrokerTransportTests(unittest.TestCase):
+    def setUp(self):
+        self.cases = []
+
+    def tearDown(self):
+        for case in reversed(self.cases):
+            case.patcher.stop()
+            case.temporary.cleanup()
+
+    def case(
+        self,
+        outcomes,
+        *,
+        payload=None,
+        source_session=None,
+        account_id=ACCOUNT_ID,
+        account_key=ACCOUNT_KEY,
+    ):
+        temporary = tempfile.TemporaryDirectory()
+        os.chmod(temporary.name, 0o700)
+        ledger = OrderIntentLedger(
+            Path(temporary.name) / "runtime" / "orders.sqlite3",
+            clock=lambda: datetime.now(timezone.utc),
+            run_id="transport-test",
+        )
+        payload = payload or vertical_payload()
+        intent = OrderIntent.build(
+            account_id=account_id,
+            environment="production",
+            strategy_id="credit-spread",
+            decision_id="decision-1",
+            idempotency_scope="decision",
+            idempotency_key="key-1",
+            intent_kind="OPENING",
+            order_payload=payload,
+        )
+        record = ledger.create_intent(intent, intent_id="intent-1").intent
+        observed_at = datetime.now(timezone.utc)
+        ledger.set_reservation_cap(
+            AccountCapacityEvidence(
+                account_id=account_id,
+                environment="production",
+                broker_buying_power=Decimal("1000"),
+                risk_budget=Decimal("1000"),
+                observed_at=observed_at,
+                portfolio_snapshot_digest="b" * 64,
+            )
+        )
+        ledger.reserve_margin(
+            record.intent_id,
+            RiskEvidence(
+                decision_id=record.envelope.decision_id,
+                max_loss_amount=Decimal("400"),
+                collateral_amount=Decimal("500"),
+                quote_observed_at=observed_at,
+                quote_digest="a" * 64,
+                portfolio_observed_at=observed_at,
+                portfolio_snapshot_digest="b" * 64,
+            ),
+        )
+        lease = ledger.claim_submission(
+            record.intent_id, OWNER, lease_seconds=60
+        )
+        authorization = ledger.prepare_submission_payload(
+            record.intent_id, OWNER, lease.fencing_token
+        )
+        now = datetime.now(timezone.utc)
+        runtime = RuntimeSafetyBoundary(
+            environment="production",
+            expected_account_id=account_id,
+            expected_account_id_key=account_key,
+            expected_institution_type=INSTITUTION_TYPE,
+            arm_issued_at=now - timedelta(seconds=1),
+            arm_expires_at=now + timedelta(minutes=10),
+        )
+        session = source_session or OAuth1Session(
+            "consumer-key",
+            "consumer-secret",
+            access_token="access-token",
+            access_token_secret="access-secret",
+        )
+        transport = ETradeBrokerTransport(
+            session=session,
+            ledger=ledger,
+            runtime_safety=runtime,
+            selected_account=SelectedBrokerAccount(
+                account_id, account_key, INSTITUTION_TYPE
+            ),
+        )
+        adapter = AdapterHarness(outcomes)
+        patcher = patch(
+            "live_trading.etrade_broker_transport._isolated_exchange",
+            side_effect=adapter.exchange,
+        )
+        patcher.start()
+        result = TransportCase(
+            temporary,
+            ledger,
+            transport,
+            adapter,
+            record,
+            authorization,
+            patcher,
+        )
+        self.cases.append(result)
+        return result
+
+    def amendment_case(self, outcomes):
+        case = self.case(outcomes)
+        case.ledger.begin_submission(
+            case.record.intent_id,
+            OWNER,
+            case.authorization.fencing_token,
+            case.authorization,
+        )
+        case.ledger.record_post_acknowledgement(
+            case.record.intent_id,
+            OWNER,
+            case.authorization.fencing_token,
+            BrokerEvidence(
+                account_id=ACCOUNT_ID,
+                environment="production",
+                client_order_id=case.record.client_order_id,
+                broker_order_id="93",
+                operation="SUBMIT_ACK",
+                outcome="OPEN",
+                observed_at=datetime.now(timezone.utc),
+                http_status=200,
+                raw_response_digest="c" * 64,
+            ),
+        )
+        amended_payload = vertical_payload(limit_price=1.5)
+        lease = case.ledger.acquire_amendment_lease(
+            case.record.intent_id,
+            OWNER,
+            lease_seconds=60,
+            idempotency_key="amend-1",
+            amendment_payload=amended_payload,
+        )
+        case.authorization = case.ledger.prepare_amendment_payload(
+            case.record.intent_id, OWNER, lease.fencing_token
+        )
+        return case
+
+    @staticmethod
+    def table_count(case, table):
+        with sqlite3.connect(case.ledger.path) as connection:
+            return connection.execute(
+                f"SELECT COUNT(*) FROM {table}"
+            ).fetchone()[0]
+
+    def test_preview_then_place_is_durably_bound_and_sent_once(self):
+        case = self.case([preview_response(), place_response()])
+
+        preview = case.transport.preview(case.authorization)
+        placed = case.transport.place(case.authorization, preview)
+
+        self.assertEqual(preview.disposition, "ACKNOWLEDGED")
+        self.assertEqual(placed.disposition, "ACKNOWLEDGED")
+        self.assertEqual(placed.broker_order_id, "94")
+        self.assertEqual(len(case.adapter.calls), 2)
+        self.assertEqual(self.table_count(case, "transport_send_attempts"), 2)
+        self.assertEqual(self.table_count(case, "broker_preview_receipts"), 1)
+        self.assertEqual(
+            self.table_count(case, "transport_response_receipts"), 2
+        )
+        self.assertEqual(
+            [
+                receipt.transport_operation
+                for receipt in case.ledger.transport_response_receipts(
+                    case.record.intent_id
+                )
+            ],
+            ["SUBMIT_PREVIEW", "SUBMIT_PLACE"],
+        )
+        prepared, kwargs = case.adapter.calls[1]
+        self.assertEqual(
+            prepared.url,
+            "https://api.etrade.com/v1/accounts/account%2Fkey/orders/place",
+        )
+        self.assertEqual(bytes(prepared.body), placed.request.final_xml_bytes)
+        root = ET.fromstring(placed.request.final_xml_bytes)
+        self.assertEqual(root.findtext("./Order/stopPrice"), "0")
+        self.assertEqual(
+            [
+                node.text
+                for node in root.findall(
+                    "./Order/Instrument/orderedQuantity"
+                )
+            ],
+            ["1", "1"],
+        )
+        self.assertNotIn("?", prepared.url)
+        self.assertNotIn("Cookie", prepared.headers)
+        self.assertEqual(prepared.headers["Accept-Encoding"], "identity")
+        self.assertEqual(kwargs["timeout_seconds"], 15.0)
+        self.assertEqual(
+            case.ledger.get_intent(case.record.intent_id).state,
+            "SUBMITTED",
+        )
+
+        with self.assertRaises(Exception):
+            case.transport.place(case.authorization, preview)
+        self.assertEqual(len(case.adapter.calls), 2)
+
+    def test_direct_place_without_stored_preview_is_blocked_before_io(self):
+        case = self.case([place_response()])
+        request = case.transport._build_request(
+            authorization=case.authorization,
+            expected_authorization_operation="SUBMIT",
+            transport_operation="SUBMIT_PLACE",
+            http_method="POST",
+            target_broker_order_id=None,
+            preview_id="1020563279",
+        )
+
+        with self.assertRaises(Exception):
+            case.transport._execute(request, case.authorization)
+
+        self.assertEqual(case.adapter.calls, [])
+        self.assertEqual(self.table_count(case, "transport_send_attempts"), 0)
+        self.assertEqual(
+            case.ledger.get_intent(case.record.intent_id).state, "CLAIMED"
+        )
+
+    def test_forged_authorization_owner_is_rejected_by_ledger(self):
+        case = self.case([preview_response()])
+        forged = OutboundAuthorization(
+            intent_id=case.authorization.intent_id,
+            operation=case.authorization.operation,
+            owner="not-the-lease-owner",
+            fencing_token=case.authorization.fencing_token,
+            client_order_id=case.authorization.client_order_id,
+            payload_bytes=case.authorization.payload_bytes,
+            payload_digest=case.authorization.payload_digest,
+        )
+
+        with self.assertRaises(Exception):
+            case.transport.preview(forged)
+
+        self.assertEqual(case.adapter.calls, [])
+        self.assertEqual(self.table_count(case, "transport_send_attempts"), 0)
+
+    def test_authorization_cannot_cross_account_identity(self):
+        case = self.case([preview_response()])
+        now = datetime.now(timezone.utc)
+        other_runtime = RuntimeSafetyBoundary(
+            "production",
+            "999999999",
+            "other-key",
+            INSTITUTION_TYPE,
+            now - timedelta(seconds=1),
+            now + timedelta(minutes=10),
+        )
+        other = ETradeBrokerTransport(
+            session=OAuth1Session(
+                "consumer-key",
+                "consumer-secret",
+                access_token="access-token",
+                access_token_secret="access-secret",
+            ),
+            ledger=case.ledger,
+            runtime_safety=other_runtime,
+            selected_account=SelectedBrokerAccount(
+                "999999999", "other-key", INSTITUTION_TYPE
+            ),
+        )
+        adapter = AdapterHarness([preview_response(account_id="999999999")])
+
+        with self.assertRaises(Exception):
+            other.preview(case.authorization)
+
+        self.assertEqual(adapter.calls, [])
+
+    def test_amendment_target_and_preview_receipt_are_ledger_bound(self):
+        case = self.amendment_case([preview_response(), place_response(order_id="95")])
+
+        preview = case.transport.preview_change("93", case.authorization)
+        with self.assertRaises(Exception):
+            case.transport.place_change("999", case.authorization, preview)
+        self.assertEqual(len(case.adapter.calls), 1)
+
+        placed = case.transport.place_change("93", case.authorization, preview)
+
+        self.assertEqual(placed.broker_order_id, "95")
+        self.assertEqual(
+            placed.request.route,
+            "/v1/accounts/account%2Fkey/orders/93/change/place",
+        )
+        self.assertEqual([call[0].method for call in case.adapter.calls], ["PUT", "PUT"])
+
+    def test_source_session_ambient_state_cannot_reach_private_send(self):
+        source = OAuth1Session(
+            "consumer-key",
+            "consumer-secret",
+            access_token="access-token",
+            access_token_secret="access-secret",
+        )
+        source.params = {"unexpected": "1"}
+        source.proxies = {"https": "http://untrusted.invalid"}
+        source.hooks["response"].append(lambda response, **_kwargs: response)
+        source.cookies.set("session", "ambient")
+        source.verify = False
+        case = self.case([preview_response()], source_session=source)
+
+        reply = case.transport.preview(case.authorization)
+
+        self.assertEqual(reply.disposition, "ACKNOWLEDGED")
+        prepared, kwargs = case.adapter.calls[0]
+        self.assertNotIn("?", prepared.url)
+        self.assertNotIn("Cookie", prepared.headers)
+        self.assertEqual(kwargs["timeout_seconds"], 15.0)
+
+    def test_isolated_worker_uses_one_pinned_no_retry_exchange(self):
+        case = self.case([preview_response()])
+        case.transport.preview(case.authorization)
+        prepared = case.adapter.calls[0][0]
+
+        output = bytearray(_EXCHANGE_RESULT_BUFFER_BYTES)
+        response = preview_response()
+        with patch.object(
+            HTTPAdapter,
+            "send",
+            autospec=True,
+            return_value=response,
+        ) as send:
+            _exchange_worker(
+                output, _serialized_prepared_request(prepared)
+            )
+
+        self.assertEqual(send.call_count, 1)
+        adapter = send.call_args.args[0]
+        self.assertEqual(adapter.max_retries.total, 0)
+        self.assertEqual(adapter.max_retries.connect, 0)
+        self.assertEqual(adapter.max_retries.read, 0)
+        self.assertEqual(adapter.max_retries.redirect, 0)
+        kwargs = send.call_args.kwargs
+        self.assertIs(kwargs["stream"], True)
+        self.assertEqual(kwargs["timeout"], (3.05, 10.0))
+        self.assertIs(kwargs["verify"], True)
+        self.assertIsNone(kwargs["cert"])
+        self.assertEqual(kwargs["proxies"], {})
+        self.assertEqual(_read_exchange_result(output).kind, "RESPONSE")
+
+    def test_timeout_is_unknown_and_durable_attempt_is_not_retried(self):
+        case = self.case([Timeout("after possible send"), preview_response()])
+
+        reply = case.transport.preview(case.authorization)
+
+        self.assertEqual(
+            (reply.disposition, reply.unknown_reason), ("UNKNOWN", "TIMEOUT")
+        )
+        self.assertEqual(len(case.adapter.calls), 1)
+        self.assertEqual(
+            self.table_count(case, "transport_response_receipts"), 1
+        )
+        with self.assertRaises(OrderIntentReconciliationRequired):
+            case.transport.preview(case.authorization)
+        self.assertEqual(len(case.adapter.calls), 1)
+
+    def test_transport_error_is_unknown_and_persisted_once(self):
+        case = self.case([RuntimeError("socket failure")])
+
+        reply = case.transport.preview(case.authorization)
+
+        self.assertEqual(
+            (reply.disposition, reply.unknown_reason),
+            ("UNKNOWN", "TRANSPORT_ERROR"),
+        )
+        self.assertEqual(len(case.adapter.calls), 1)
+        self.assertEqual(
+            self.table_count(case, "transport_response_receipts"), 1
+        )
+
+    def test_wrong_security_values_are_never_string_coerced(self):
+        case = self.case([preview_response()])
+        for payload in (
+            vertical_payload(symbol=True),
+            vertical_payload(symbol="spy"),
+            vertical_payload(symbol="A/B"),
+            vertical_payload(symbol="A" * 16),
+        ):
+            payload["client_order_id"] = case.authorization.client_order_id
+            payload_bytes = json.dumps(
+                payload,
+                sort_keys=True,
+                separators=(",", ":"),
+                ensure_ascii=True,
+            ).encode("utf-8")
+            forged = OutboundAuthorization(
+                intent_id=case.authorization.intent_id,
+                operation="SUBMIT",
+                owner=OWNER,
+                fencing_token=case.authorization.fencing_token,
+                client_order_id=case.authorization.client_order_id,
+                payload_bytes=payload_bytes,
+                payload_digest=hashlib.sha256(payload_bytes).hexdigest(),
+            )
+            with self.subTest(symbol=payload["legs"][0]["symbol"]):
+                with self.assertRaises(ETradeBrokerTransportError):
+                    case.transport.preview(forged)
+        self.assertEqual(case.adapter.calls, [])
+
+    def test_warning_or_info_message_requires_review_and_blocks_place(self):
+        response = FakeResponse(
+            body={
+                "PreviewOrderResponse": {
+                    "accountId": ACCOUNT_ID,
+                    "orderType": "SPREADS",
+                    "PreviewIds": [{"previewId": "1020563279"}],
+                    "Order": [
+                        {
+                            "status": "OPEN",
+                            "messages": {
+                                "Message": [
+                                    {
+                                        "description": "possible duplicate order",
+                                        "code": 1042,
+                                        "type": "WARNING",
+                                    }
+                                ]
+                            },
+                        }
+                    ],
+                }
+            }
+        )
+        case = self.case([response])
+
+        reply = case.transport.preview(case.authorization)
+
+        self.assertEqual(
+            (reply.disposition, reply.unknown_reason),
+            ("UNKNOWN", "REVIEW_REQUIRED"),
+        )
+        self.assertEqual(reply.preview_id, "1020563279")
+        self.assertEqual(reply.broker_messages[0].code, 1042)
+        self.assertNotIn("possible duplicate", repr(reply))
+        self.assertEqual(self.table_count(case, "broker_preview_receipts"), 0)
+        self.assertEqual(
+            self.table_count(case, "transport_response_receipts"), 1
+        )
+        with self.assertRaises(ETradeBrokerTransportError):
+            case.transport.place(case.authorization, reply)
+
+    def test_place_hold_preserves_reconciliation_identifiers(self):
+        held = FakeResponse(
+            body={
+                "PlaceOrderResponse": {
+                    "accountId": ACCOUNT_ID,
+                    "orderType": "SPREADS",
+                    "OrderIds": [{"orderId": "94"}],
+                    "Order": [
+                        {
+                            "status": "OPEN",
+                            "messages": {
+                                "Message": {
+                                    "description": "manual review",
+                                    "code": 4002,
+                                    "type": "INFO_HOLD",
+                                }
+                            },
+                        }
+                    ],
+                }
+            }
+        )
+        case = self.case([preview_response(), held])
+        preview = case.transport.preview(case.authorization)
+
+        reply = case.transport.place(case.authorization, preview)
+
+        self.assertEqual(
+            (reply.disposition, reply.unknown_reason),
+            ("UNKNOWN", "REVIEW_REQUIRED"),
+        )
+        self.assertEqual(reply.broker_order_id, "94")
+        self.assertEqual(reply.broker_status, "OPEN")
+        self.assertEqual(reply.broker_messages[0].message_type, "INFO_HOLD")
+        receipt = case.ledger.transport_response_receipts(
+            case.record.intent_id
+        )[-1]
+        self.assertEqual(receipt.transport_operation, "SUBMIT_PLACE")
+        self.assertEqual(receipt.response.broker_order_id, "94")
+        self.assertEqual(receipt.response.broker_status, "OPEN")
+        self.assertEqual(receipt.response.message_codes, (4002,))
+
+    def test_reviewed_place_success_warning_is_retained_and_acknowledged(self):
+        successful_warning = FakeResponse(
+            body={
+                "PlaceOrderResponse": {
+                    "accountId": ACCOUNT_ID,
+                    "orderType": "SPREADS",
+                    "OrderIds": [
+                        {"orderId": "94", "cashMargin": "MARGIN"}
+                    ],
+                    "Order": [
+                        {
+                            "status": "OPEN",
+                            "messages": {
+                                "Message": {
+                                    "description": "successfully entered",
+                                    "code": "1026",
+                                    "type": "WARNING",
+                                }
+                            },
+                        }
+                    ],
+                }
+            }
+        )
+        case = self.case([preview_response(), successful_warning])
+        preview = case.transport.preview(case.authorization)
+
+        reply = case.transport.place(case.authorization, preview)
+
+        self.assertEqual(reply.disposition, "ACKNOWLEDGED")
+        self.assertEqual(reply.broker_order_id, "94")
+        self.assertEqual(reply.broker_messages[0].code, 1026)
+
+    def test_preview_identifier_accepts_only_documented_cash_margin(self):
+        valid = FakeResponse(
+            body={
+                "PreviewOrderResponse": {
+                    "accountId": ACCOUNT_ID,
+                    "orderType": "SPREADS",
+                    "PreviewIds": [
+                        {
+                            "previewId": "1020563279",
+                            "cashMargin": "MARGIN",
+                        }
+                    ],
+                    "Order": [{"status": "OPEN"}],
+                }
+            }
+        )
+        case = self.case([valid])
+        self.assertEqual(
+            case.transport.preview(case.authorization).disposition,
+            "ACKNOWLEDGED",
+        )
+
+        invalid = FakeResponse(
+            body={
+                "PreviewOrderResponse": {
+                    "accountId": ACCOUNT_ID,
+                    "orderType": "SPREADS",
+                    "PreviewIds": [
+                        {
+                            "previewId": "1020563279",
+                            "cashMargin": "BORROWED",
+                        }
+                    ],
+                }
+            }
+        )
+        case = self.case([invalid])
+        self.assertEqual(
+            case.transport.preview(case.authorization).disposition,
+            "UNKNOWN",
+        )
+
+    def test_non_acknowledged_status_preserves_order_id(self):
+        for status in ("REJECTED", "EXECUTED", "INDIVIDUAL_FILLS"):
+            with self.subTest(status=status):
+                case = self.case(
+                    [preview_response(), place_response(status=status)]
+                )
+                preview = case.transport.preview(case.authorization)
+
+                reply = case.transport.place(case.authorization, preview)
+
+                self.assertEqual(
+                    reply.unknown_reason,
+                    "BROKER_STATUS_REQUIRES_RECONCILIATION",
+                )
+                self.assertEqual(reply.broker_order_id, "94")
+                self.assertEqual(reply.broker_status, status)
+                self.assertEqual(
+                    case.ledger.get_intent(case.record.intent_id).state,
+                    "SUBMISSION_UNKNOWN",
+                )
+                self.assertEqual(
+                    self.table_count(
+                        case, "transport_response_receipts"
+                    ),
+                    2,
+                )
+
+    def test_nonfinite_duplicate_and_overflow_responses_never_acknowledge(self):
+        responses = (
+            FakeResponse(
+                raw=(
+                    b'{"PreviewOrderResponse":{"accountId":"842468410",'
+                    b'"orderType":"SPREADS","PreviewIds":[{"previewId":"1020563279"}],'
+                    b'"totalOrderValue":NaN}}'
+                )
+            ),
+            FakeResponse(
+                raw=(
+                    b'{"PreviewOrderResponse":{"accountId":"842468410",'
+                    b'"accountId":"842468410","orderType":"SPREADS",'
+                    b'"PreviewIds":[{"previewId":"1020563279"}]}}'
+                )
+            ),
+            preview_response(preview_id="9999999999999999999"),
+        )
+        for response in responses:
+            with self.subTest(body=response.content[:80]):
+                case = self.case([response])
+                reply = case.transport.preview(case.authorization)
+                self.assertEqual(reply.disposition, "UNKNOWN")
+                self.assertEqual(reply.unknown_reason, "MALFORMED_RESPONSE")
+                self.assertTrue(response.closed)
+
+    def test_account_mismatch_and_http_redirect_are_unknown_without_follow(self):
+        for response, reason in (
+            (preview_response(account_id="999999999"), "MALFORMED_RESPONSE"),
+            (
+                FakeResponse(
+                    status_code=307,
+                    raw=b"redirect",
+                    headers={"Location": "https://attacker.invalid"},
+                ),
+                "HTTP_STATUS",
+            ),
+        ):
+            with self.subTest(reason=reason):
+                case = self.case([response])
+                reply = case.transport.preview(case.authorization)
+                self.assertEqual(reply.unknown_reason, reason)
+                self.assertEqual(len(case.adapter.calls), 1)
+                self.assertTrue(response.closed)
+
+    def test_encoded_response_is_rejected_without_decoding(self):
+        class GuardedRaw:
+            def __init__(self):
+                self.calls = []
+                self.closed = False
+
+            def read1(self, amount, *, decode_content):
+                self.calls.append((amount, decode_content))
+                raise AssertionError("encoded response must not be read")
+
+            def close(self):
+                self.closed = True
+
+        response = preview_response()
+        guarded = GuardedRaw()
+        response.raw = guarded
+        response.headers = {"Content-Encoding": "gzip"}
+        case = self.case([response])
+
+        reply = case.transport.preview(case.authorization)
+
+        self.assertEqual(reply.unknown_reason, "MALFORMED_RESPONSE")
+        self.assertEqual(guarded.calls, [])
+        self.assertTrue(response.closed)
+
+    def test_response_wall_deadline_closes_stream(self):
+        response = preview_response()
+        with patch(
+            "live_trading.etrade_broker_transport.time.monotonic",
+            side_effect=[0.0, 13.0],
+        ):
+            with self.assertRaises(TimeoutError):
+                _read_bounded_response(response)
+        self.assertTrue(response.closed)
+
+    def test_parent_watchdog_covers_the_entire_exchange(self):
+        case = self.case([preview_response()])
+        case.transport.preview(case.authorization)
+        prepared = case.adapter.calls[0][0]
+
+        class Process:
+            def __init__(self):
+                self.started = False
+                self.alive = False
+                self.terminated = False
+                self.join_timeouts = []
+
+            def start(self):
+                self.started = True
+                self.alive = True
+
+            def join(self, timeout):
+                self.join_timeouts.append(timeout)
+
+            def is_alive(self):
+                return self.alive
+
+            def terminate(self):
+                self.terminated = True
+                self.alive = False
+
+            def kill(self):
+                self.alive = False
+
+        class Context:
+            def __init__(self):
+                self.process = Process()
+
+            def RawArray(self, typecode, size):
+                self.typecode = typecode
+                self.size = size
+                return bytearray(size)
+
+            def Process(self, *, target, args, daemon):
+                self.target = target
+                self.args = args
+                self.daemon = daemon
+                return self.process
+
+        context = Context()
+        with patch(
+            "live_trading.etrade_broker_transport.multiprocessing.get_context",
+            return_value=context,
+        ):
+            result = _isolated_exchange(
+                prepared, timeout_seconds=0.01
+            )
+
+        self.assertEqual(result.kind, "TIMEOUT")
+        self.assertEqual(context.typecode, "B")
+        self.assertEqual(context.size, _EXCHANGE_RESULT_BUFFER_BYTES)
+        self.assertTrue(context.daemon)
+        self.assertTrue(context.process.started)
+        self.assertTrue(context.process.terminated)
+        self.assertLessEqual(context.process.join_timeouts[0], 0.01)
+
+    def test_fixed_exchange_frame_rejects_partial_writer_and_accepts_max_body(self):
+        incomplete = bytearray(_EXCHANGE_RESULT_BUFFER_BYTES)
+        declared = b"x" * 1024
+        incomplete[:39] = struct.pack(
+            "!BHI32s",
+            1,
+            200,
+            len(declared),
+            hashlib.sha256(declared).digest(),
+        )
+        with self.assertRaises(ETradeBrokerTransportError):
+            _read_exchange_result(incomplete)
+
+        maximum = b"y" * (64 * 1024 + 1)
+        complete = bytearray(_EXCHANGE_RESULT_BUFFER_BYTES)
+        _write_exchange_result(
+            complete,
+            _ExchangeResult(
+                "RESPONSE",
+                http_status=200,
+                raw_response=maximum,
+            ),
+        )
+        decoded = _read_exchange_result(complete)
+        self.assertEqual(decoded.http_status, 200)
+        self.assertEqual(decoded.raw_response, maximum)
+
+    def test_bound_request_and_reply_repr_are_redacted(self):
+        case = self.case([preview_response()])
+
+        reply = case.transport.preview(case.authorization)
+
+        rendered = repr(reply)
+        self.assertNotIn(ACCOUNT_ID, rendered)
+        self.assertNotIn(ACCOUNT_KEY, rendered)
+        self.assertNotIn(case.record.client_order_id, rendered)
+        self.assertNotIn("PreviewOrderRequest", rendered)
+        self.assertNotIn("consumer-secret", rendered)
+
+        request_evidence = _transport_evidence(reply.request)
+        response_evidence = _transport_response_evidence(reply)
+        evidence_repr = repr((request_evidence, response_evidence))
+        self.assertNotIn(ACCOUNT_ID, evidence_repr)
+        self.assertNotIn(ACCOUNT_KEY, evidence_repr)
+        self.assertNotIn(case.record.client_order_id, evidence_repr)
+        self.assertNotIn(reply.preview_id, evidence_repr)
+        self.assertNotIn("PreviewOrderRequest", evidence_repr)
+
+    def test_exact_runtime_account_is_mandatory(self):
+        temporary = tempfile.TemporaryDirectory()
+        self.addCleanup(temporary.cleanup)
+        os.chmod(temporary.name, 0o700)
+        ledger = OrderIntentLedger(
+            Path(temporary.name) / "runtime" / "orders.sqlite3"
+        )
+        runtime = RuntimeSafetyBoundary("sandbox", None, None, None)
+
+        with self.assertRaises(ETradeBrokerTransportError):
+            ETradeBrokerTransport(
+                session=OAuth1Session(
+                    "consumer-key",
+                    "consumer-secret",
+                    access_token="access-token",
+                    access_token_secret="access-secret",
+                ),
+                ledger=ledger,
+                runtime_safety=runtime,
+                selected_account=SelectedBrokerAccount(
+                    ACCOUNT_ID, ACCOUNT_KEY, INSTITUTION_TYPE
+                ),
+            )
+
+    def test_transport_requires_exact_oauth_session(self):
+        case = self.case([])
+        with self.assertRaises(ETradeBrokerTransportError):
+            ETradeBrokerTransport(
+                session=object(),
+                ledger=case.ledger,
+                runtime_safety=case.transport._runtime_safety,
+                selected_account=case.transport._selected_account,
+            )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/etrade_python_client/tests/test_order_intent_ledger.py
+++ b/etrade_python_client/tests/test_order_intent_ledger.py
@@ -17,6 +17,8 @@ from live_trading.order_intent_ledger import (
     BrokerEvidence,
     AccountCapacityEvidence,
     OutboundAuthorization,
+    TransportRequestEvidence,
+    TransportResponseEvidence,
     OrderIntent,
     OrderIntentIntegrityError,
     OrderIntentLedger,
@@ -201,6 +203,53 @@ def evidence(record, clock, *, operation="ORDER_QUERY", outcome="OPEN", broker_o
     )
 
 
+def transport_request(
+    authorization,
+    *,
+    operation="SUBMIT_PREVIEW",
+    account_id="acct-1",
+    account_id_key="account-key",
+    institution_type="BROKERAGE",
+    target_broker_order_id=None,
+    preview_id=None,
+):
+    body = f"<{operation}/>".encode("ascii")
+    if operation.startswith("AMEND"):
+        route = (
+            f"/v1/accounts/{account_id_key}/orders/"
+            f"{target_broker_order_id}/change/"
+            f"{'place' if operation.endswith('PLACE') else 'preview'}"
+        )
+        method = "PUT"
+        authorization_operation = "AMEND"
+    else:
+        route = (
+            f"/v1/accounts/{account_id_key}/orders/"
+            f"{'place' if operation.endswith('PLACE') else 'preview'}"
+        )
+        method = "POST"
+        authorization_operation = "SUBMIT"
+    return TransportRequestEvidence(
+        account_id=account_id,
+        account_id_key=account_id_key,
+        institution_type=institution_type,
+        environment="production",
+        intent_id=authorization.intent_id,
+        owner=authorization.owner,
+        authorization_operation=authorization_operation,
+        fencing_token=authorization.fencing_token,
+        transport_operation=operation,
+        http_method=method,
+        route=route,
+        client_order_id=authorization.client_order_id,
+        target_broker_order_id=target_broker_order_id,
+        preview_id=preview_id,
+        authorization_payload_digest=authorization.payload_digest,
+        final_xml_bytes=body,
+        final_xml_sha256=hashlib.sha256(body).hexdigest(),
+    )
+
+
 class OrderIntentLedgerTests(unittest.TestCase):
     def setUp(self):
         self.tmp = tempfile.TemporaryDirectory()
@@ -237,6 +286,62 @@ class OrderIntentLedgerTests(unittest.TestCase):
         self.assertEqual(payload["client_order_id"], record.client_order_id)
         self.assertNotIn("__number__", str(prepared))
         self.assertIn("__number__", record.envelope.canonical_payload)
+
+    def test_outbound_and_transport_evidence_repr_redacts_order_identity(self):
+        authorization = OutboundAuthorization(
+            intent_id="intent-safe",
+            operation="AMEND",
+            owner="worker-safe",
+            fencing_token=7,
+            client_order_id="client-secret",
+            payload_bytes=b'{"order":"payload-secret"}',
+            payload_digest="a" * 64,
+        )
+        request = TransportRequestEvidence(
+            account_id="account-secret",
+            account_id_key="account-key-secret",
+            institution_type="BROKERAGE",
+            environment="production",
+            intent_id="intent-safe",
+            owner="worker-safe",
+            authorization_operation="AMEND",
+            fencing_token=7,
+            transport_operation="AMEND_PLACE",
+            http_method="PUT",
+            route="/route/account-key-secret/target-secret",
+            client_order_id="client-secret",
+            target_broker_order_id="target-secret",
+            preview_id="preview-secret",
+            authorization_payload_digest="a" * 64,
+            final_xml_bytes=b"<payload-secret/>",
+            final_xml_sha256="b" * 64,
+        )
+        response = TransportResponseEvidence(
+            disposition="UNKNOWN",
+            http_status=200,
+            broker_status="EXECUTED",
+            broker_order_id="broker-secret",
+            preview_id="preview-secret",
+            message_codes=(),
+            message_types=(),
+            message_description_digests=(),
+            raw_response_digest="c" * 64,
+            observed_at=self.clock.now,
+            unknown_reason="RECONCILIATION_REQUIRED",
+        )
+
+        rendered = repr((authorization, request, response))
+
+        for secret in (
+            "client-secret",
+            "payload-secret",
+            "account-secret",
+            "account-key-secret",
+            "target-secret",
+            "preview-secret",
+            "broker-secret",
+        ):
+            self.assertNotIn(secret, rendered)
 
     def test_generated_vertical_payload_is_normalized_without_hashing_ignored_fields(self):
         generated = raw_payload()
@@ -520,15 +625,223 @@ class OrderIntentLedgerTests(unittest.TestCase):
         with self.assertRaises(OrderIntentIntegrityError):
             self.ledger.reserve_margin(record.intent_id, risk(record, self.clock))
 
-    def test_expired_claim_is_durable_in_doubt_and_stale_worker_cannot_post_or_fail(self):
+    def test_expired_claim_without_place_attempt_returns_to_intent_with_new_fence(self):
         record = self.opening()
         lease = self.ledger.claim_submission(record.intent_id, "worker", lease_seconds=5)
         self.clock.advance(5)
         with self.assertRaises(OrderIntentReconciliationRequired):
             self.ledger.prepare_submission_payload(record.intent_id, "worker", lease.fencing_token)
-        self.assertEqual(self.ledger.get_intent(record.intent_id).state, "SUBMISSION_UNKNOWN")
-        with self.assertRaises(OrderIntentReconciliationRequired):
-            self.ledger.claim_submission(record.intent_id, "other", lease_seconds=5)
+        self.assertEqual(self.ledger.get_intent(record.intent_id).state, "INTENT")
+        replacement = self.ledger.claim_submission(
+            record.intent_id, "other", lease_seconds=5
+        )
+        self.assertGreater(replacement.fencing_token, lease.fencing_token)
+
+    def test_expired_preview_only_submission_returns_to_intent(self):
+        record = self.opening()
+        lease = self.ledger.claim_submission(
+            record.intent_id, "worker", lease_seconds=5
+        )
+        authorization = self.ledger.prepare_submission_payload(
+            record.intent_id, "worker", lease.fencing_token
+        )
+        self.ledger.claim_transport_send(
+            transport_request(authorization), authorization
+        )
+
+        self.clock.advance(6)
+
+        self.assertEqual(
+            self.ledger.reconciliation_blockers("acct-1", "production"), ()
+        )
+        self.assertEqual(self.ledger.get_intent(record.intent_id).state, "INTENT")
+        replacement = self.ledger.claim_submission(
+            record.intent_id, "other", lease_seconds=5
+        )
+        self.assertGreater(replacement.fencing_token, lease.fencing_token)
+
+    def test_place_must_reuse_exact_preview_account_route_identity(self):
+        record = self.opening()
+        lease = self.ledger.claim_submission(
+            record.intent_id, "worker", lease_seconds=30
+        )
+        authorization = self.ledger.prepare_submission_payload(
+            record.intent_id, "worker", lease.fencing_token
+        )
+        preview = transport_request(authorization)
+        self.ledger.claim_transport_send(preview, authorization)
+        self.ledger.record_transport_response(
+            preview,
+            TransportResponseEvidence(
+                disposition="ACKNOWLEDGED",
+                http_status=200,
+                broker_status="OPEN",
+                broker_order_id=None,
+                preview_id="preview-1",
+                message_codes=(),
+                message_types=(),
+                message_description_digests=(),
+                raw_response_digest="c" * 64,
+                observed_at=self.clock.now,
+                unknown_reason=None,
+            ),
+        )
+        rebound_place = transport_request(
+            authorization,
+            operation="SUBMIT_PLACE",
+            account_id_key="other-account-key",
+            institution_type="OTHER_BROKER",
+            preview_id="preview-1",
+        )
+
+        with self.assertRaises(OrderIntentIntegrityError):
+            self.ledger.claim_transport_send(
+                rebound_place, authorization
+            )
+
+        self.assertEqual(self.ledger.get_intent(record.intent_id).state, "CLAIMED")
+
+    def test_preview_receipt_requires_independently_validated_ack(self):
+        record = self.opening()
+        lease = self.ledger.claim_submission(
+            record.intent_id, "worker", lease_seconds=30
+        )
+        authorization = self.ledger.prepare_submission_payload(
+            record.intent_id, "worker", lease.fencing_token
+        )
+        preview = transport_request(authorization)
+        self.ledger.claim_transport_send(preview, authorization)
+        invalid_responses = (
+            TransportResponseEvidence(
+                disposition="ACKNOWLEDGED",
+                http_status=200,
+                broker_status="REJECTED",
+                broker_order_id=None,
+                preview_id="preview-1",
+                message_codes=(),
+                message_types=(),
+                message_description_digests=(),
+                raw_response_digest="c" * 64,
+                observed_at=self.clock.now,
+                unknown_reason=None,
+            ),
+            TransportResponseEvidence(
+                disposition="ACKNOWLEDGED",
+                http_status=200,
+                broker_status="OPEN",
+                broker_order_id=None,
+                preview_id="preview-1",
+                message_codes=(1042,),
+                message_types=("WARNING",),
+                message_description_digests=("d" * 64,),
+                raw_response_digest="c" * 64,
+                observed_at=self.clock.now,
+                unknown_reason=None,
+            ),
+        )
+
+        for invalid in invalid_responses:
+            with self.subTest(
+                status=invalid.broker_status,
+                messages=invalid.message_codes,
+            ):
+                with self.assertRaises(OrderIntentValidationError):
+                    self.ledger.record_transport_response(
+                        preview, invalid
+                    )
+
+        with sqlite3.connect(self.path) as conn:
+            self.assertEqual(
+                conn.execute(
+                    "SELECT COUNT(*) FROM broker_preview_receipts"
+                ).fetchone()[0],
+                0,
+            )
+            self.assertEqual(
+                conn.execute(
+                    "SELECT COUNT(*) FROM transport_response_receipts"
+                ).fetchone()[0],
+                0,
+            )
+
+    def test_expired_unattempted_amendment_releases_lease(self):
+        record = self.opening()
+        submit = self.ledger.claim_submission(
+            record.intent_id, "worker", lease_seconds=30
+        )
+        self.begin_submission(record, "worker", submit)
+        submitted = self.ledger.record_post_acknowledgement(
+            record.intent_id,
+            "worker",
+            submit.fencing_token,
+            evidence(record, self.clock, operation="SUBMIT_ACK"),
+        )
+        amendment = self.ledger.acquire_amendment_lease(
+            submitted.intent_id,
+            "nudger",
+            lease_seconds=5,
+            idempotency_key="amend-unattempted",
+            amendment_payload=raw_payload(),
+        )
+
+        self.clock.advance(6)
+
+        self.assertEqual(
+            self.ledger.reconciliation_blockers("acct-1", "production"), ()
+        )
+        replacement = self.ledger.acquire_amendment_lease(
+            submitted.intent_id,
+            "other",
+            lease_seconds=5,
+            idempotency_key="amend-unattempted",
+            amendment_payload=raw_payload(),
+        )
+        self.assertGreater(replacement.fencing_token, amendment.fencing_token)
+
+    def test_expired_preview_only_amendment_releases_lease(self):
+        record = self.opening()
+        submit = self.ledger.claim_submission(
+            record.intent_id, "worker", lease_seconds=30
+        )
+        self.begin_submission(record, "worker", submit)
+        submitted = self.ledger.record_post_acknowledgement(
+            record.intent_id,
+            "worker",
+            submit.fencing_token,
+            evidence(record, self.clock, operation="SUBMIT_ACK"),
+        )
+        amendment = self.ledger.acquire_amendment_lease(
+            submitted.intent_id,
+            "nudger",
+            lease_seconds=5,
+            idempotency_key="amend-preview",
+            amendment_payload=raw_payload(),
+        )
+        authorization = self.ledger.prepare_amendment_payload(
+            submitted.intent_id, "nudger", amendment.fencing_token
+        )
+        self.ledger.claim_transport_send(
+            transport_request(
+                authorization,
+                operation="AMEND_PREVIEW",
+                target_broker_order_id=submitted.broker_order_id,
+            ),
+            authorization,
+        )
+
+        self.clock.advance(6)
+
+        self.assertEqual(
+            self.ledger.reconciliation_blockers("acct-1", "production"), ()
+        )
+        replacement = self.ledger.acquire_amendment_lease(
+            submitted.intent_id,
+            "other",
+            lease_seconds=5,
+            idempotency_key="amend-preview",
+            amendment_payload=raw_payload(),
+        )
+        self.assertGreater(replacement.fencing_token, amendment.fencing_token)
 
     def test_submission_begin_rejects_economic_or_client_id_authorization_tampering(self):
         record = self.opening()
@@ -1066,6 +1379,11 @@ class OrderIntentLedgerTests(unittest.TestCase):
             self.assertEqual(conn.execute("SELECT schema_version FROM ledger_metadata").fetchone()[0], SCHEMA_VERSION)
             self.assertIsNotNone(conn.execute("SELECT 1 FROM sqlite_master WHERE type = 'table' AND name = 'outbound_authorizations'").fetchone())
             self.assertIsNotNone(conn.execute("SELECT 1 FROM sqlite_master WHERE type = 'trigger' AND name = 'prevent_outbound_authorization_delete'").fetchone())
+            self.assertIsNotNone(conn.execute("SELECT 1 FROM sqlite_master WHERE type = 'table' AND name = 'transport_send_attempts'").fetchone())
+            self.assertIsNotNone(conn.execute("SELECT 1 FROM sqlite_master WHERE type = 'table' AND name = 'broker_preview_receipts'").fetchone())
+            self.assertIsNotNone(conn.execute("SELECT 1 FROM sqlite_master WHERE type = 'table' AND name = 'transport_response_receipts'").fetchone())
+            self.assertIsNotNone(conn.execute("SELECT 1 FROM sqlite_master WHERE type = 'trigger' AND name = 'prevent_transport_send_attempt_delete'").fetchone())
+            self.assertIsNotNone(conn.execute("SELECT 1 FROM sqlite_master WHERE type = 'trigger' AND name = 'prevent_transport_response_receipt_delete'").fetchone())
         legacy_record = migrated.get_intent("legacy-closing-intent")
         self.assertEqual(legacy_record.envelope.intent_kind, "CLOSING")
         claimed_record = migrated.get_intent("legacy-claimed-intent")
@@ -1169,6 +1487,55 @@ class OrderIntentLedgerTests(unittest.TestCase):
         os.chmod(self.path, 0o644)
         with self.assertRaises(OrderIntentValidationError):
             OrderIntentLedger(self.path, clock=self.clock, run_id="run-b")
+
+    def test_schema_9_adds_response_receipts_and_keeps_expiry_live(self):
+        with sqlite3.connect(self.path) as conn:
+            conn.execute(
+                "DROP TRIGGER prevent_transport_response_receipt_update"
+            )
+            conn.execute(
+                "DROP TRIGGER prevent_transport_response_receipt_delete"
+            )
+            conn.execute("DROP TABLE transport_response_receipts")
+            conn.execute(
+                "UPDATE ledger_metadata SET schema_version = 9 WHERE singleton = 1"
+            )
+
+        migrated = OrderIntentLedger(
+            self.path, clock=self.clock, run_id="run-schema-9-migration"
+        )
+
+        with sqlite3.connect(self.path) as conn:
+            self.assertEqual(
+                conn.execute(
+                    "SELECT schema_version FROM ledger_metadata"
+                ).fetchone()[0],
+                SCHEMA_VERSION,
+            )
+            self.assertIsNotNone(
+                conn.execute(
+                    "SELECT 1 FROM sqlite_master WHERE type = 'table' AND name = 'transport_response_receipts'"
+                ).fetchone()
+            )
+            self.assertIsNotNone(
+                conn.execute(
+                    "SELECT 1 FROM sqlite_master WHERE type = 'trigger' AND name = 'prevent_transport_response_receipt_delete'"
+                ).fetchone()
+            )
+        record = migrated.create_intent(
+            make_intent(key="migration-live", decision="migration-live")
+        ).intent
+        migrated.set_reservation_cap(capacity(self.clock))
+        migrated.reserve_margin(record.intent_id, risk(record, self.clock))
+        lease = migrated.claim_submission(
+            record.intent_id, "worker", lease_seconds=5
+        )
+        self.clock.advance(6)
+        with self.assertRaises(OrderIntentReconciliationRequired):
+            migrated.prepare_submission_payload(
+                record.intent_id, "worker", lease.fencing_token
+            )
+        self.assertEqual(migrated.get_intent(record.intent_id).state, "INTENT")
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary

- add a private, exact-type E*TRADE preview/place and change-order transport
- durably claim every exact XML mutation before I/O and persist every parsed response
- make place requests depend on the exact durable preview/account/fence receipt
- enforce one no-retry exchange in an isolated process with a total deadline and bounded digest-committed response frame
- fail closed on warnings, holds, ambiguous statuses, timeouts, malformed responses, redirects, and transport failures
- apply definitive place acknowledgements atomically and expose typed receipts for restart reconciliation
- recover preview-only and pre-preview lease crashes without creating permanent false blockers
- redact account, order, XML, and broker identifiers from evidence representations
- ignore SQLite ledger databases and sidecars

## Safety properties

- no mutation retry or redirect path
- no ambient proxy, cookie, hook, or TLS override inheritance
- exact runtime account/environment binding
- durable append-only request and response evidence
- `EXECUTED` and `INDIVIDUAL_FILLS` remain reconciliation-required until typed broker reconciliation is wired
- legacy gateway integration is intentionally deferred to the next stacked PR

## Verification

- `python -m py_compile live_trading/etrade_broker_transport.py live_trading/order_intent_ledger.py`
- `python -m pytest -q tests/test_etrade_broker_transport.py tests/test_order_intent_ledger.py` — 63 passed in a clean worktree
- `python -m pytest -q tests` — 242 passed in the working repository
- independent adversarial transport/schema review: GO, no remaining P0/P1 findings in this slice
