### PR TITLE
R7c: add durable E*TRADE order gateway

### DIFF
--- a/etrade_python_client/RELIABILITY.md
+++ b/etrade_python_client/RELIABILITY.md
@@ -73,6 +73,14 @@ For every reliability incident:
   identity. The arm and identity must be revalidated after account refresh and
   immediately before every order API call. R7 must preserve that invariant
   while replacing the compatibility guard with one durable mutation gateway.
+- Every broker mutation must have one durable, uniquely fenced send claim
+  before I/O and one parsed response receipt before acknowledgement. An
+  ambiguous send is reconciliation-only and is never retried. A broker query
+  may clear it only for a durably known broker order ID whose exact account,
+  environment, and canonical economic terms match the authorization.
+- Account opening capacity must use an immutable gateway/operator risk ceiling,
+  not a strategy-command value. Incomplete, stale, unstable, or non-durable
+  balance/position/open-order evidence cannot authorize exposure.
 - An order-capable dashboard binds to loopback by default. Public tunneling is a
   separately supervised operator action, and wildcard CORS is forbidden.
 - Dashboard credentials must reject defaults and weak values. Settings, arm
@@ -488,6 +496,19 @@ finding.
     redacts authorization-bearing headers, and records only SHA-256/size
     metadata for order payloads, account/order response bodies, and
     account-bearing URLs.
+- `live_trading/order_intent_ledger.py`,
+  `live_trading/etrade_broker_transport.py`, and
+  `live_trading/etrade_order_gateway.py`
+  - Persist immutable intent, reservation, authorization, exact send, preview,
+    and parsed-response evidence.
+  - Permit only opening vertical submission and price-only amendment through a
+    no-retry, no-redirect, isolated mutation exchange.
+  - Keep every unknown no-ID result permanently blocked and require a known
+    broker ID plus exact canonical order-term hash before reconciliation.
+  - Revalidate the exact runtime/account/environment around each mutation and
+    enforce a gateway-owned account risk ceiling.
+  - Remain intentionally disconnected from the live agent until the read side
+    and migration gates below are complete.
 - `live_trading/etrade_check_option.py` and
   `live_trading/etrade_option_chains.py`
   - Remove hardcoded OAuth credentials from the current source and require
@@ -496,17 +517,15 @@ finding.
 ### Remaining risk
 
 This is containment in the current source, not production readiness. The
-compatibility order client now rejects calls without the current arm/account
-boundary. R7a adds an isolated schema 9 order-intent ledger with stable
-identity, account capacity reservations, monotonic fences, immutable outbound
-authorization, and reconciliation-only ambiguous outcomes. It performs no
-network I/O and no live code instantiates it. New closing intents and terminal
-reservation release fail closed until position/open-order evidence exists.
+compatibility order client still owns current live calls. The isolated R7a–R7c
+stack now provides a schema 10 intent ledger, hardened mutation transport, and
+opening/reprice coordinator, but no live code instantiates it.
 
-R7b must still make one private E*TRADE gateway the sole mutation owner,
-preserve the placement-time arm/account check, construct broker evidence from
-actual responses, reconcile durable blockers at startup, implement durable
-per-intent cancellation, and reject every direct legacy mutation path.
+The next gate is a concrete private E*TRADE reader with complete pagination,
+stable two-pass capacity snapshots, origin-bound durable raw/parser receipts,
+and atomic reconciliation evidence. Position absorption, closing capacity,
+durable per-intent cancellation, a single production composition root, and a
+static ban on every direct legacy mutation path also remain required.
 
 The exposed OAuth keys still require external revocation and rotation. A later
 coordinated history purge must remove them from all refs and arrange cleanup of
@@ -528,13 +547,15 @@ deployed dashboard has not been reloaded or visually inspected with R6.
   files, guarded response/request logging, order calls without a boundary,
   placement-time arm expiry, dashboard credential rejection, and loopback/CORS
   behavior.
-- R7a includes 32 deterministic order-ledger tests for immutable identity,
-  stable identifiers, exact outbound authorization, capacity/reservation
-  arithmetic, exact evidence types, stale evidence, concurrency, fencing ABA,
-  ambiguous outcomes, restart reconciliation, terminal-risk retention,
-  append-only histories, legacy-closing reconciliation, and the additive schema
-  8 to 9 migration. Independent causal and security reviews found no remaining
-  reproducible P0 in the isolated core.
+- The current R7 ledger/transport/coordinator focused suite includes 88
+  deterministic tests for immutable identity, exact authorization/XML,
+  transport deadlines, send fencing, parsed receipts, crash/timeout recovery,
+  capacity arithmetic, gateway-owned risk ceilings, environment/account
+  binding, exact order-term reconciliation, amendment replay, terminal-risk
+  retention, and additive schema 8→9→10 migration. Independent adversarial
+  reviews found no remaining reproducible P0/P1 mutation-state defect in the
+  isolated stack; they explicitly retain a no-go on live wiring until the
+  durable reader and remaining protocols are delivered.
 - Deployment verification is deliberately recorded as incomplete. This
   incident remains open until the remaining-risk conditions above are
   satisfied.

--- a/etrade_python_client/docs/order_intent_ledger.md
+++ b/etrade_python_client/docs/order_intent_ledger.md
@@ -1,14 +1,16 @@
 # Durable Order Intent Ledger
 
-**Delivery status:** R7a isolated foundation
+**Delivery status:** R7a ledger + R7b transport + R7c coordinator, isolated
 
 **Production status:** not connected to live E*TRADE mutation paths
 
 `live_trading/order_intent_ledger.py` is the durable, broker-agnostic state
 machine for order identity, capacity reservation, fencing, and ambiguous broker
-outcomes. It performs no network I/O. R7a deliberately does not instantiate the
-ledger from the live agent, so it provides no protection to the current order
-paths until R7b makes one E*TRADE gateway the sole mutation owner.
+outcomes. It performs no network I/O. `etrade_broker_transport.py` now owns the
+reviewed no-retry mutation exchange, and `etrade_order_gateway.py` coordinates
+opening submissions, price-only amendments, and restart reconciliation. The
+live agent still instantiates none of them, so this stack does not yet protect
+the current legacy order paths.
 
 ## Supported scope
 
@@ -16,7 +18,7 @@ paths until R7b makes one E*TRADE gateway the sole mutation owner.
 - Two-leg vertical option spreads with one buy leg and one sell leg.
 - Opening credit and debit spreads whose price direction and maximum exposure
   can be derived from immutable order fields.
-- No new closing orders until R7b supplies typed position and open-order
+- No new closing orders until a later slice supplies typed position and open-order
   capacity evidence. Previously persisted closing orders remain readable and
   reconcilable after migration, but cannot be newly claimed or amended.
 - No equity orders, naked opening options, arbitrary multi-leg spreads, bulk
@@ -43,10 +45,14 @@ stateDiagram-v2
     SUBMITTED --> EXPIRED: broker query
 ```
 
-The gateway must persist `SUBMISSION_UNKNOWN` or an in-doubt amendment
-immediately before the corresponding broker mutation. A timeout, malformed
-response, process crash, or expired post-capable lease never returns the intent
-to a retryable state. A broker query must reconcile it first.
+The transport persists the exact send attempt and transitions to
+`SUBMISSION_UNKNOWN` or an in-doubt amendment immediately before the
+corresponding broker mutation. A timeout, malformed response, process crash, or
+expired post-capable lease never returns the intent to a retryable state. A
+broker query for a durably known broker order ID must prove the exact authorized
+economic payload before reconciliation. Because E*TRADE does not echo
+`clientOrderId`, an ambiguous placement without a durable broker order ID
+remains blocked rather than guessed or retried.
 
 ## Enforced invariants
 
@@ -71,49 +77,57 @@ to a retryable state. A broker query must reconcile it first.
   byte, and `Decimal` fields must use exact built-in types. Subclass overrides
   cannot replace validation or comparison behavior.
 - Preparation returns a frozen `OutboundAuthorization` containing immutable
-  serialized broker-schema bytes. `begin_submission` and `begin_amendment`
-  recompute the durable payload, client ID, operation, owner, and fence, then
-  persist the exact authorization in the same transaction that enters the
-  in-doubt state. R7b must deterministically derive the final E*TRADE XML from
-  these bytes and the broker preview ID.
-- Order events, broker-order history, amendment history, and outbound
-  authorizations are append-only.
+  serialized broker-schema bytes. The transport deterministically derives the
+  final E*TRADE XML from those bytes and a durably recorded preview ID. Every
+  preview/place send is uniquely claimed before I/O; every parsed response is
+  recorded before it can update or leave the durable state machine.
+- The coordinator requires one immutable account-level opening-risk ceiling.
+  Strategy commands cannot raise it. Reconciliation requires the reader's
+  normalized order payload to match the durable original, pending amendment, or
+  latest completed amendment hash.
+- Order events, broker-order history, amendment history, outbound
+  authorizations, transport attempts, preview receipts, and response receipts
+  are append-only.
 - The ledger database must live in an owner-only `0700` directory and remain an
   owner-only regular `0600` file. SQLite sidecars receive the same validation.
 
 ## Schema policy
 
-Schema 9 adds append-only outbound authorizations. The only supported migration
-is the additive schema 8 to 9 transition, which is restart-safe and tested.
-Unknown versions fail closed. Before any future production migration, the
-operator runbook must add an atomic backup, integrity check, rollback exercise,
-and an explicit version-by-version migration.
+Schema 10 adds append-only transport attempts, broker-preview receipts, and
+parsed transport-response receipts. Additive schema 8→9→10 migration is
+restart-safe and tested. Unknown versions fail closed. Before any production
+migration, the operator runbook must add an atomic backup, integrity check,
+rollback exercise, and an explicit version-by-version migration.
 
-## R7b release gates
+## Remaining production release gates
 
-R7a must not be used as evidence that live execution is production-ready. R7b
-must satisfy all of the following before any order-capable process is enabled:
+The isolated R7 stack must not be used as evidence that live execution is
+production-ready. The following remain required before any order-capable
+process is enabled:
 
-1. A private E*TRADE transport is the only module allowed to call order
-   `POST`, `PUT`, or `DELETE` endpoints.
-2. The transport derives the exact request body only from the immutable
-   authorization plus the broker preview ID; strategy code never receives a
-   mutable executable payload.
-3. Broker response parsing and `BrokerEvidence` construction are private to the
-   gateway. Application callers cannot assert their own reconciliation result.
-4. Startup reconciles every durable blocker before accepting a new mutation.
-5. Submission, closing-position capacity, terminal position absorption,
-   repricing, and per-intent cancellation have durable, crash-tested protocols.
-   Bulk cancellation remains disabled.
-6. The R6 production arm and exact account identity are revalidated immediately
-   before each broker mutation.
-7. Static enforcement rejects direct legacy order mutations outside the private
-   transport.
-8. Broker-fixture tests cover duplicate commands, crash-before/after-POST,
-   unknown responses, malformed replies, stale arm/account/capacity evidence,
-   amendment/cancel races, partial fills, and restart reconciliation.
+1. A concrete private reader must pin the exact E*TRADE origin, runtime
+   boundary, environment, and account; completely paginate account/order data;
+   persist origin-bound raw/parser receipts; and atomically bind durable read
+   evidence to reconciliation and capacity decisions.
+2. Position-level fill evidence must safely absorb terminal opening
+   reservations, including partial fills, replacements, assignment/exercise,
+   and zero-fill proof for cancelled/rejected/expired orders.
+3. Closing-position capacity and one-shot per-intent cancellation need durable,
+   crash-tested protocols. Bulk cancellation remains disabled.
+4. The live composition root must construct the exact ledger, reader,
+   transport, and coordinator, and static enforcement must reject direct legacy
+   order mutations outside that root.
+5. Sandbox restart/crash fixtures must cover pagination drift, stale evidence,
+   every nonterminal/terminal broker status, replacement chains, cancellation,
+   closing, and process death at each durable/I/O boundary.
+6. Operational migration needs a private database backup, integrity check,
+   rollback drill, credential rotation/history purge, deployment restart, and
+   observation of the exact served/live artifacts.
 
-The R7a focused suite contains 32 deterministic tests. Independent causal and
-security reviews found no remaining reproducible core path to double-submit,
-exceed the reservation cap, release opening exposure early, reuse an identifier,
-or substitute a different authorized economic payload.
+The current focused ledger/transport/coordinator suite contains 88 deterministic
+tests. Independent adversarial reviews found no remaining reproducible
+mutation-core path to double-submit, exceed the gateway-owned reservation
+ceiling, release opening exposure early, reuse an identifier, substitute a
+different authorized economic payload, or clear an amendment merely because
+the old broker order is still open. This is source verification only; the
+durable reader and live migration gates above remain open.

--- a/etrade_python_client/docs/project_overview.md
+++ b/etrade_python_client/docs/project_overview.md
@@ -150,7 +150,9 @@ flowchart LR
     DASH["Loopback-Only Dashboard<br/>No Automatic Tunnel / No Wildcard CORS"]
     DIRECT["Compatibility Order Client<br/>(Per-Call Arm + Account Guard)"]
     LEDGER["R7a Order Intent Ledger<br/>(Implemented, Isolated)"]
-    GATE["R7b E*TRADE Gateway<br/>(Planned Single Mutation Owner)"]
+    TRANSPORT["R7b Mutation Transport<br/>(Implemented, Isolated)"]
+    GATE["R7c Order Gateway<br/>(Implemented, Isolated)"]
+    READER["Durable E*TRADE Reader<br/>(Required Before Live Wiring)"]
     BROKER["E*TRADE"]
 
     CLI --> SAFE
@@ -160,19 +162,25 @@ flowchart LR
     DASHCFG --> DASH
     ACCOUNT --> DIRECT
     DIRECT -->|"current, guarded but non-durable"| BROKER
-    DIRECT -.->|"R7b migration"| GATE
+    DIRECT -.->|"future migration"| GATE
     LEDGER --> GATE
-    GATE -.->|"not connected yet"| BROKER
+    LEDGER --> TRANSPORT
+    READER -.->|"not implemented yet"| GATE
+    GATE --> TRANSPORT
+    TRANSPORT -.->|"not connected yet"| BROKER
 ```
 
 This is source-level containment, not a production-readiness claim. The
 compatibility order client now enforces the arm/account check for every order
-API call. R7a adds an isolated durable ledger for intent identity, reservations,
-fencing, immutable outbound authorization, and ambiguous-outcome state. No live
-code instantiates it yet: R7b must make a private E*TRADE gateway the sole
-broker-mutation owner and construct reconciliation evidence from broker
-responses. The deployed service has not been restarted or inspected with R6 or
-R7a.
+API call. R7a adds the durable intent ledger. R7b adds a private, no-retry
+mutation transport that claims every send before broker I/O and persists parsed
+responses. R7c composes those components into an opening/reprice coordinator
+with a gateway-owned risk ceiling, exact environment/account binding,
+restart reconciliation, and exact economic-term comparison. No live code
+instantiates this stack. A concrete origin-bound reader with durable raw and
+parsed receipts, position absorption, cancellation/closing protocols, and
+removal of legacy mutation paths remain mandatory before live wiring. The
+deployed service has not been restarted or inspected with R6 or R7.
 
 ---
 
@@ -216,7 +224,9 @@ shadow/research-only and cannot affect E*TRADE order eligibility.
 
 *   **Runtime Safety Boundary** ([`runtime_safety.py`](file:///Users/btian/EtradePythonClient/etrade_python_client/live_trading/runtime_safety.py)): Resolves an explicit `sandbox` or `production` environment before OAuth construction. Production requires an exact account identity plus a versioned, signed arm file with a bounded lifetime; unsafe, missing, mismatched, future, or expired proof fails closed. The operator CLI writes the arm atomically as an owner-only file without accepting the signing secret as a command-line argument.
 *   **Account Identity Revalidation** ([`accounts_bo.py`](file:///Users/btian/EtradePythonClient/etrade_python_client/accounts/accounts_bo.py), [`order_bo.py`](file:///Users/btian/EtradePythonClient/etrade_python_client/order/order_bo.py)): Selects production accounts by exact account ID, account key, and institution type instead of a mutable list index. The live process revalidates the armed identity after startup and account refresh, and the compatibility order client repeats it immediately before every order API call. R7 must preserve the check inside the durable single mutation gateway.
-*   **Durable Order Intent Ledger** ([`order_intent_ledger.py`](file:///Users/btian/EtradePythonClient/etrade_python_client/live_trading/order_intent_ledger.py), [`order_intent_ledger.md`](file:///Users/btian/EtradePythonClient/etrade_python_client/docs/order_intent_ledger.md)): R7a provides strict vertical-spread validation, account capacity reservations, stable identifiers, monotonic submission/amendment fences, immutable outbound authorizations, and reconciliation-only handling after an ambiguous mutation. It is intentionally broker-agnostic and not yet called by the live agent; R7b remains the production integration gate.
+*   **Durable Order Intent Ledger** ([`order_intent_ledger.py`](file:///Users/btian/EtradePythonClient/etrade_python_client/live_trading/order_intent_ledger.py), [`order_intent_ledger.md`](file:///Users/btian/EtradePythonClient/etrade_python_client/docs/order_intent_ledger.md)): R7a provides strict vertical-spread validation, account capacity reservations, stable identifiers, monotonic submission/amendment fences, immutable outbound authorizations, exact send/response receipts, and reconciliation-only handling after an ambiguous mutation.
+*   **Hardened Mutation Transport** ([`etrade_broker_transport.py`](file:///Users/btian/EtradePythonClient/etrade_python_client/live_trading/etrade_broker_transport.py)): R7b is the only reviewed adapter permitted to derive E*TRADE mutation XML from a durable authorization. It disables ambient proxies, cookies, hooks, redirects, and retries; revalidates the armed account; claims the exact send before I/O; bounds the exchange in an isolated process; and records the parsed result before returning.
+*   **Order Gateway** ([`etrade_order_gateway.py`](file:///Users/btian/EtradePythonClient/etrade_python_client/live_trading/etrade_order_gateway.py)): R7c coordinates opening submissions and price-only amendments through the exact transport. Startup stays read-only until every known broker order is reconciled, unknown responses without a broker ID remain permanent blockers, returned order terms must hash to the durable authorization, and an immutable gateway policy—not a strategy command—sets the account risk ceiling. This component remains intentionally unreachable from the live agent until the durable broker reader and remaining execution protocols are delivered.
 *   **Dashboard Containment** ([`etrade_cover_call_new.py`](file:///Users/btian/EtradePythonClient/etrade_python_client/live_trading/etrade_cover_call_new.py)): Serves the order-capable dashboard on loopback only, does not start ngrok automatically, and does not grant wildcard CORS. Startup rejects default or weak dashboard credentials, while local settings and touched logs use owner-only file handling.
 *   **Credential Source Cleanup** ([`etrade_check_option.py`](file:///Users/btian/EtradePythonClient/etrade_python_client/live_trading/etrade_check_option.py), [`etrade_option_chains.py`](file:///Users/btian/EtradePythonClient/etrade_python_client/live_trading/etrade_option_chains.py)): Removes hardcoded OAuth credentials from the current source and requires local configuration or environment variables. Because the repository is currently public and those values remain in Git history, the affected keys must be treated as compromised until they are revoked and rotated externally; a coordinated history purge remains separate follow-up work.
 

--- a/etrade_python_client/live_trading/etrade_broker_transport.py
+++ b/etrade_python_client/live_trading/etrade_broker_transport.py
@@ -21,7 +21,7 @@ import time
 from dataclasses import dataclass, field
 from datetime import date, datetime, timezone
 from decimal import Decimal
-from typing import Any, Literal
+from typing import Any, Callable, Literal
 from urllib.parse import quote, urlsplit
 from xml.etree import ElementTree as ET
 
@@ -293,6 +293,7 @@ class ETradeBrokerTransport:
         ledger: OrderIntentLedger,
         runtime_safety: RuntimeSafetyBoundary,
         selected_account: SelectedBrokerAccount,
+        clock: Callable[[], datetime] | None = None,
     ) -> None:
         if type(session) is not OAuth1Session:
             raise ETradeBrokerTransportError(
@@ -319,8 +320,12 @@ class ETradeBrokerTransport:
             raise ETradeBrokerTransportError(
                 "order-capable runtime requires an explicitly armed account"
             )
-        runtime_safety.assert_current()
-        runtime_safety.verify_account(selected_account.runtime_mapping())
+        self._clock = clock or (lambda: datetime.now(timezone.utc))
+        now = self._now()
+        runtime_safety.assert_current(now)
+        runtime_safety.verify_account(
+            selected_account.runtime_mapping(), now=now
+        )
         credentials = (
             session.consumer_key,
             session.consumer_secret,
@@ -353,6 +358,32 @@ class ETradeBrokerTransport:
         self._environment = runtime_safety.environment
         self._binding_secret = secrets.token_bytes(32)
         self._send_lock = threading.Lock()
+
+    def selected_account(self) -> SelectedBrokerAccount:
+        """Return a redacted immutable copy of the runtime-bound account."""
+
+        return SelectedBrokerAccount(
+            self._account_id,
+            self._account_id_key,
+            self._institution_type,
+        )
+
+    def assert_gateway_binding(
+        self,
+        ledger: OrderIntentLedger,
+        runtime_safety: RuntimeSafetyBoundary,
+    ) -> None:
+        """Prove the coordinator and transport share exact safety state."""
+
+        if ledger is not self._ledger or runtime_safety is not self._runtime_safety:
+            raise ETradeBrokerTransportError(
+                "gateway and transport must share exact ledger and runtime boundaries"
+            )
+        now = self._now()
+        runtime_safety.assert_current(now)
+        runtime_safety.verify_account(
+            self._selected_account.runtime_mapping(), now=now
+        )
 
     def preview(self, authorization: OutboundAuthorization) -> BrokerReply:
         request = self._build_request(
@@ -526,12 +557,18 @@ class ETradeBrokerTransport:
 
             runtime_safety = self._runtime_safety
             selected_account = self._selected_account
-            runtime_safety.assert_current()
-            runtime_safety.verify_account(selected_account.runtime_mapping())
+            now = self._now()
+            runtime_safety.assert_current(now)
+            runtime_safety.verify_account(
+                selected_account.runtime_mapping(), now=now
+            )
             evidence = _transport_evidence(trusted_request)
             self._ledger.claim_transport_send(evidence, authorization)
-            runtime_safety.assert_current()
-            runtime_safety.verify_account(selected_account.runtime_mapping())
+            now = self._now()
+            runtime_safety.assert_current(now)
+            runtime_safety.verify_account(
+                selected_account.runtime_mapping(), now=now
+            )
             _validate_prepared_request(prepared, trusted_request, url)
 
             try:
@@ -541,18 +578,29 @@ class ETradeBrokerTransport:
                 )
             except Exception:
                 reply = _unknown_reply(
-                    trusted_request, "TRANSPORT_ERROR"
+                    trusted_request,
+                    "TRANSPORT_ERROR",
+                    observed_at=self._now(),
                 )
             else:
+                observed_at = self._now()
                 if exchange.kind == "TIMEOUT":
-                    reply = _unknown_reply(trusted_request, "TIMEOUT")
+                    reply = _unknown_reply(
+                        trusted_request,
+                        "TIMEOUT",
+                        observed_at=observed_at,
+                    )
                 elif exchange.kind == "TRANSPORT_ERROR":
                     reply = _unknown_reply(
-                        trusted_request, "TRANSPORT_ERROR"
+                        trusted_request,
+                        "TRANSPORT_ERROR",
+                        observed_at=observed_at,
                     )
                 elif exchange.kind == "MALFORMED_RESPONSE":
                     reply = _unknown_reply(
-                        trusted_request, "MALFORMED_RESPONSE"
+                        trusted_request,
+                        "MALFORMED_RESPONSE",
+                        observed_at=observed_at,
                     )
                 else:
                     try:
@@ -560,10 +608,13 @@ class ETradeBrokerTransport:
                             trusted_request,
                             exchange.http_status,
                             exchange.raw_response,
+                            observed_at=observed_at,
                         )
                     except Exception:
                         reply = _unknown_reply(
-                            trusted_request, "MALFORMED_RESPONSE"
+                            trusted_request,
+                            "MALFORMED_RESPONSE",
+                            observed_at=observed_at,
                         )
             try:
                 self._ledger.record_transport_response(
@@ -574,6 +625,14 @@ class ETradeBrokerTransport:
                     "broker response could not be persisted durably"
                 ) from exc
             return reply
+
+    def _now(self) -> datetime:
+        value = self._clock()
+        if type(value) is not datetime or value.tzinfo is not timezone.utc:
+            raise ETradeBrokerTransportError(
+                "transport clock must use the exact UTC timezone"
+            )
+        return value
 
     def _verify_bound_request(self, request: BoundBrokerRequest) -> None:
         if type(request) is not BoundBrokerRequest:
@@ -1397,8 +1456,17 @@ def _parse_reply_bytes(
     request: BoundBrokerRequest,
     status: int | None,
     raw: bytes,
+    *,
+    observed_at: datetime | None = None,
 ) -> BrokerReply:
-    observed_at = datetime.now(timezone.utc)
+    observed_at = observed_at or datetime.now(timezone.utc)
+    if (
+        type(observed_at) is not datetime
+        or observed_at.tzinfo is not timezone.utc
+    ):
+        raise ETradeBrokerTransportError(
+            "response observation time must use the exact UTC timezone"
+        )
     if (
         type(status) is not int
         or not 100 <= status <= 599

--- a/etrade_python_client/live_trading/etrade_order_gateway.py
+++ b/etrade_python_client/live_trading/etrade_order_gateway.py
@@ -1,0 +1,1051 @@
+"""Durable coordinator for the hardened E*TRADE mutation transport.
+
+The gateway owns orchestration only.  The transport owns exact XML, the
+single broker exchange, and durable response persistence.  The ledger owns
+all state transitions and replay fences.  Broker reads are injected through
+an explicitly read-only protocol and can never authorize a mutation.
+"""
+
+from __future__ import annotations
+
+import json
+from dataclasses import dataclass, field
+from datetime import datetime, timezone
+from decimal import Decimal
+from typing import Any, Literal, Protocol, runtime_checkable
+
+from live_trading.etrade_broker_transport import (
+    BrokerReply,
+    ETradeBrokerTransport,
+    ETradeBrokerTransportError,
+    SelectedBrokerAccount,
+)
+from live_trading.order_intent_ledger import (
+    AccountCapacityEvidence,
+    BrokerEvidence,
+    IntentRecord,
+    OrderIntent,
+    OrderIntentIntegrityError,
+    OrderIntentLedger,
+    OrderIntentLedgerError,
+    OrderIntentReconciliationRequired,
+    OrderIntentTransitionError,
+    RiskEvidence,
+    TransportResponseReceipt,
+    canonical_order_payload_hash,
+)
+from live_trading.runtime_safety import RuntimeSafetyBoundary, RuntimeSafetyError
+
+
+_MAX_COMMAND_BYTES = 32 * 1024
+_MAX_EVIDENCE_AGE_SECONDS = 300
+_MAX_LEASE_SECONDS = 300
+
+
+class EtradeOrderGatewayError(RuntimeError):
+    """Base error for the durable order coordinator."""
+
+
+class GatewayValidationError(EtradeOrderGatewayError):
+    """A command or typed read response violated the closed contract."""
+
+
+class GatewayReconciliationRequired(EtradeOrderGatewayError):
+    """New mutations are blocked by unresolved durable broker work."""
+
+
+@dataclass(frozen=True)
+class BrokerCapacitySnapshot:
+    """Complete account risk snapshot produced by a read-only adapter."""
+
+    account: SelectedBrokerAccount
+    environment: Literal["sandbox", "production"]
+    broker_buying_power: Decimal
+    observed_at: datetime
+    portfolio_snapshot_digest: str
+    positions_complete: bool
+    open_orders_complete: bool
+    source_response_digests: tuple[str, ...]
+
+
+@dataclass(frozen=True)
+class BrokerOrderSnapshot:
+    """Exact normalized status for one known broker order id."""
+
+    account: SelectedBrokerAccount
+    environment: Literal["sandbox", "production"]
+    broker_order_id: str = field(repr=False)
+    outcome: Literal[
+        "OPEN",
+        "FILLED",
+        "CANCELLED",
+        "REJECTED",
+        "EXPIRED",
+        "UNRESOLVED",
+    ]
+    observed_at: datetime
+    http_status: int
+    raw_response_digest: str
+    order_payload_hash: str
+    complete: bool
+
+
+@dataclass(frozen=True)
+class BrokerOrderNotFound:
+    """Complete negative lookup for one known broker order id."""
+
+    account: SelectedBrokerAccount
+    environment: Literal["sandbox", "production"]
+    broker_order_id: str = field(repr=False)
+    observed_at: datetime
+    http_status: int
+    raw_response_digest: str
+    complete: bool
+
+
+@runtime_checkable
+class EtradeBrokerReader(Protocol):
+    """Read-only evidence required by the order coordinator."""
+
+    def assert_gateway_binding(
+        self, runtime_safety: RuntimeSafetyBoundary
+    ) -> None: ...
+
+    def selected_account(self) -> SelectedBrokerAccount: ...
+
+    def read_capacity(
+        self, account: SelectedBrokerAccount
+    ) -> BrokerCapacitySnapshot: ...
+
+    def query_order(
+        self,
+        account: SelectedBrokerAccount,
+        broker_order_id: str,
+    ) -> BrokerOrderSnapshot | BrokerOrderNotFound: ...
+
+
+@dataclass(frozen=True)
+class SubmitOpeningCommand:
+    strategy_id: str
+    decision_id: str
+    idempotency_scope: str
+    idempotency_key: str
+    payload_bytes: bytes = field(repr=False)
+    max_loss_amount: Decimal
+    collateral_amount: Decimal
+    quote_observed_at: datetime
+    quote_digest: str
+    owner: str
+    lease_seconds: int = 30
+
+
+@dataclass(frozen=True)
+class RepriceOpeningCommand:
+    intent_id: str
+    idempotency_key: str
+    payload_bytes: bytes = field(repr=False)
+    owner: str
+    lease_seconds: int = 30
+
+
+@dataclass(frozen=True)
+class GatewayMutationResult:
+    intent_id: str
+    client_order_id: str = field(repr=False)
+    state: Literal[
+        "SUBMITTED", "SUBMISSION_UNKNOWN", "AMENDMENT_UNKNOWN", "FAILED"
+    ]
+    created: bool
+    broker_order_id: str | None = field(repr=False)
+    preview_id: str | None = field(repr=False)
+    reason_code: str | None
+
+
+@dataclass(frozen=True)
+class _ReconciliationContext:
+    operation: Literal["ORDER_QUERY", "AMEND_QUERY"]
+    client_order_id: str = field(repr=False)
+    broker_order_id: str = field(repr=False)
+    expected_order_payload_hash: str
+
+
+class EtradeOrderGateway:
+    """Compose runtime arming, durable state, typed reads, and one transport."""
+
+    def __init__(
+        self,
+        *,
+        runtime_safety: RuntimeSafetyBoundary,
+        ledger: OrderIntentLedger,
+        transport: ETradeBrokerTransport,
+        reader: EtradeBrokerReader,
+        opening_risk_budget: Decimal,
+        clock=None,
+    ) -> None:
+        if type(runtime_safety) is not RuntimeSafetyBoundary:
+            raise GatewayValidationError(
+                "runtime_safety must be an exact RuntimeSafetyBoundary"
+            )
+        if type(ledger) is not OrderIntentLedger:
+            raise GatewayValidationError(
+                "ledger must be an exact OrderIntentLedger"
+            )
+        if type(transport) is not ETradeBrokerTransport:
+            raise GatewayValidationError(
+                "gateway requires the exact hardened ETradeBrokerTransport"
+            )
+        if not isinstance(reader, EtradeBrokerReader):
+            raise GatewayValidationError(
+                "reader does not implement the read-only broker protocol"
+            )
+        try:
+            transport.assert_gateway_binding(ledger, runtime_safety)
+            reader.assert_gateway_binding(runtime_safety)
+        except (ETradeBrokerTransportError, RuntimeSafetyError) as exc:
+            raise GatewayValidationError(
+                "gateway adapters and runtime safety boundary do not match"
+            ) from exc
+        _exact_decimal(
+            opening_risk_budget,
+            "opening_risk_budget",
+            allow_zero=True,
+        )
+        self.runtime_safety = runtime_safety
+        self.ledger = ledger
+        self.transport = transport
+        self.reader = reader
+        self._opening_risk_budget = opening_risk_budget
+        self._clock = clock or (lambda: datetime.now(timezone.utc))
+        self._started = False
+        self._account: SelectedBrokerAccount | None = None
+
+    def start(self) -> None:
+        """Reconcile every resolvable prior order before enabling mutation."""
+
+        self._started = False
+        account = self._checked_account()
+        self._account = account
+        blockers = self.ledger.reconciliation_blockers(
+            account.account_id, self.runtime_safety.environment
+        )
+        for blocker in blockers:
+            self._reconcile_once(blocker, account)
+        remaining = self.ledger.reconciliation_blockers(
+            account.account_id, self.runtime_safety.environment
+        )
+        unabsorbed = self.ledger.unabsorbed_filled_reservation_count(
+            account.account_id, self.runtime_safety.environment
+        )
+        if remaining or unabsorbed:
+            raise GatewayReconciliationRequired(
+                "gateway remains read-only: "
+                f"{len(remaining)} broker operation(s), "
+                f"{unabsorbed} unabsorbed fill reservation(s)"
+            )
+        self._checked_account()
+        self._started = True
+
+    def submit_opening(
+        self, command: SubmitOpeningCommand
+    ) -> GatewayMutationResult:
+        """Submit one opening vertical through preview and one fenced place."""
+
+        self._require_started()
+        command = _validate_submit_command(command)
+        account = self._checked_account()
+        self._require_no_blockers(account)
+        envelope = OrderIntent.build(
+            account_id=account.account_id,
+            environment=self.runtime_safety.environment,
+            strategy_id=command.strategy_id,
+            decision_id=command.decision_id,
+            idempotency_scope=command.idempotency_scope,
+            idempotency_key=command.idempotency_key,
+            intent_kind="OPENING",
+            order_payload=_decode_payload(command.payload_bytes),
+        )
+        created = self.ledger.create_intent(envelope)
+        record = created.intent
+        existing = self._existing_submission_result(
+            record, created.created
+        )
+        if existing is not None:
+            return existing
+        if self.ledger.get_margin_reservation(record.intent_id) is None:
+            capacity = self._read_capacity(account)
+            self.ledger.set_reservation_cap(capacity)
+            self.ledger.reserve_margin(
+                record.intent_id,
+                RiskEvidence(
+                    decision_id=command.decision_id,
+                    max_loss_amount=command.max_loss_amount,
+                    collateral_amount=command.collateral_amount,
+                    quote_observed_at=command.quote_observed_at,
+                    quote_digest=command.quote_digest,
+                    portfolio_observed_at=capacity.observed_at,
+                    portfolio_snapshot_digest=(
+                        capacity.portfolio_snapshot_digest
+                    ),
+                ),
+            )
+        lease = self.ledger.claim_submission(
+            record.intent_id,
+            command.owner,
+            lease_seconds=command.lease_seconds,
+        )
+        authorization = self.ledger.prepare_submission_payload(
+            record.intent_id, command.owner, lease.fencing_token
+        )
+        try:
+            preview = self.transport.preview(authorization)
+        except Exception:
+            self._fail_unplaced_submission(
+                record.intent_id, command.owner, lease.fencing_token
+            )
+            raise
+        if preview.disposition == "UNKNOWN":
+            failed = self.ledger.mark_pre_post_failed(
+                record.intent_id,
+                command.owner,
+                lease.fencing_token,
+            )
+            return self._result(
+                failed,
+                created.created,
+                "FAILED",
+                preview.broker_order_id,
+                preview.preview_id,
+                f"PREVIEW_{preview.unknown_reason}",
+            )
+        try:
+            self._checked_account()
+        except Exception:
+            self._fail_unplaced_submission(
+                record.intent_id, command.owner, lease.fencing_token
+            )
+            raise
+        try:
+            placed = self.transport.place(authorization, preview)
+        except ETradeBrokerTransportError:
+            current = self._require_intent(record.intent_id)
+            if current.state == "SUBMISSION_UNKNOWN":
+                return self._result(
+                    current,
+                    created.created,
+                    "SUBMISSION_UNKNOWN",
+                    self._known_place_order_id(current, "SUBMIT_PLACE"),
+                    preview.preview_id,
+                    "TRANSPORT_RESPONSE_PERSISTENCE_ERROR",
+                )
+            self._fail_unplaced_submission(
+                record.intent_id, command.owner, lease.fencing_token
+            )
+            raise
+        current = self._require_intent(record.intent_id)
+        if placed.disposition == "ACKNOWLEDGED":
+            if (
+                current.state != "SUBMITTED"
+                or current.broker_order_id != placed.broker_order_id
+            ):
+                raise GatewayReconciliationRequired(
+                    "transport acknowledgement was not applied durably"
+                )
+            return self._result(
+                current,
+                created.created,
+                "SUBMITTED",
+                current.broker_order_id,
+                preview.preview_id,
+                None,
+            )
+        if current.state != "SUBMISSION_UNKNOWN":
+            raise GatewayReconciliationRequired(
+                "ambiguous place response lacks its durable pending state"
+            )
+        return self._result(
+            current,
+            created.created,
+            "SUBMISSION_UNKNOWN",
+            placed.broker_order_id,
+            preview.preview_id,
+            placed.unknown_reason,
+        )
+
+    def reprice_opening(
+        self, command: RepriceOpeningCommand
+    ) -> GatewayMutationResult:
+        """Issue one previewed, fenced limit-price amendment."""
+
+        self._require_started()
+        command = _validate_reprice_command(command)
+        record = self._require_intent(command.intent_id)
+        if (
+            record.envelope.intent_kind != "OPENING"
+            or record.state != "SUBMITTED"
+        ):
+            raise GatewayValidationError(
+                "only a submitted opening intent may be repriced"
+            )
+        account = self._checked_account()
+        self._require_no_blockers(account)
+        if (
+            record.envelope.account_id != account.account_id
+            or record.envelope.environment
+            != self.runtime_safety.environment
+        ):
+            raise RuntimeSafetyError(
+                "durable intent does not match the armed account"
+            )
+        amendment_payload = _decode_payload(command.payload_bytes)
+        amendment_hash = canonical_order_payload_hash(
+            amendment_payload
+        )
+        replay = self._completed_amendment_result(
+            record, command.idempotency_key, amendment_hash
+        )
+        if replay is not None:
+            return replay
+        try:
+            lease = self.ledger.acquire_amendment_lease(
+                record.intent_id,
+                command.owner,
+                lease_seconds=command.lease_seconds,
+                idempotency_key=command.idempotency_key,
+                amendment_payload=amendment_payload,
+            )
+        except OrderIntentTransitionError:
+            current = self._require_intent(record.intent_id)
+            replay = self._completed_amendment_result(
+                current, command.idempotency_key, amendment_hash
+            )
+            if replay is not None:
+                return replay
+            raise
+        authorization = self.ledger.prepare_amendment_payload(
+            record.intent_id, command.owner, lease.fencing_token
+        )
+        try:
+            preview = self.transport.preview_change(
+                lease.broker_order_id, authorization
+            )
+        except Exception:
+            self.ledger.release_amendment_lease(
+                record.intent_id, command.owner, lease.fencing_token
+            )
+            raise
+        if preview.disposition == "UNKNOWN":
+            self.ledger.release_amendment_lease(
+                record.intent_id, command.owner, lease.fencing_token
+            )
+            return self._result(
+                self._require_intent(record.intent_id),
+                False,
+                "SUBMITTED",
+                record.broker_order_id,
+                preview.preview_id,
+                f"PREVIEW_{preview.unknown_reason}",
+            )
+        try:
+            self._checked_account()
+            placed = self.transport.place_change(
+                lease.broker_order_id, authorization, preview
+            )
+        except ETradeBrokerTransportError:
+            current = self._require_intent(record.intent_id)
+            if current.pending_operation == "AMEND":
+                return self._result(
+                    current,
+                    False,
+                    "AMENDMENT_UNKNOWN",
+                    self._known_place_order_id(current, "AMEND_PLACE"),
+                    preview.preview_id,
+                    "TRANSPORT_RESPONSE_PERSISTENCE_ERROR",
+                )
+            self.ledger.release_amendment_lease(
+                record.intent_id,
+                command.owner,
+                lease.fencing_token,
+            )
+            raise
+        except RuntimeSafetyError:
+            current = self._require_intent(record.intent_id)
+            if current.pending_operation is None:
+                self.ledger.release_amendment_lease(
+                    record.intent_id,
+                    command.owner,
+                    lease.fencing_token,
+                )
+            raise
+        current = self._require_intent(record.intent_id)
+        if placed.disposition == "ACKNOWLEDGED":
+            if (
+                current.state != "SUBMITTED"
+                or current.pending_operation is not None
+                or current.broker_order_id != placed.broker_order_id
+            ):
+                raise GatewayReconciliationRequired(
+                    "amendment acknowledgement was not applied durably"
+                )
+            return self._result(
+                current,
+                False,
+                "SUBMITTED",
+                current.broker_order_id,
+                preview.preview_id,
+                None,
+            )
+        if current.pending_operation != "AMEND":
+            raise GatewayReconciliationRequired(
+                "ambiguous amendment lacks its durable pending state"
+            )
+        return self._result(
+            current,
+            False,
+            "AMENDMENT_UNKNOWN",
+            placed.broker_order_id,
+            preview.preview_id,
+            placed.unknown_reason,
+        )
+
+    def _checked_account(self) -> SelectedBrokerAccount:
+        initial_now = self._now()
+        self.runtime_safety.assert_current(initial_now)
+        self.transport.assert_gateway_binding(
+            self.ledger, self.runtime_safety
+        )
+        transport_account = self.transport.selected_account()
+        self.reader.assert_gateway_binding(self.runtime_safety)
+        reader_account = self.reader.selected_account()
+        _validate_account(transport_account)
+        _validate_account(reader_account)
+        _require_same_account(transport_account, reader_account)
+        final_now = self._now()
+        self.runtime_safety.assert_current(final_now)
+        self.runtime_safety.verify_account(
+            transport_account.runtime_mapping(), now=final_now
+        )
+        if self._account is not None:
+            _require_same_account(self._account, transport_account)
+        return transport_account
+
+    def _read_capacity(
+        self,
+        account: SelectedBrokerAccount,
+    ) -> AccountCapacityEvidence:
+        checked = self._checked_account()
+        _require_same_account(account, checked)
+        snapshot = self.reader.read_capacity(checked)
+        if type(snapshot) is not BrokerCapacitySnapshot:
+            raise GatewayValidationError(
+                "capacity reader returned an invalid typed response"
+            )
+        _validate_account(snapshot.account)
+        _require_same_account(checked, snapshot.account)
+        _require_environment(
+            self.runtime_safety.environment, snapshot.environment
+        )
+        _exact_decimal(
+            snapshot.broker_buying_power,
+            "broker_buying_power",
+            allow_zero=True,
+        )
+        _fresh_time(snapshot.observed_at, self._now(), "capacity observed_at")
+        _exact_sha256(
+            snapshot.portfolio_snapshot_digest,
+            "portfolio_snapshot_digest",
+        )
+        if (
+            snapshot.positions_complete is not True
+            or snapshot.open_orders_complete is not True
+            or type(snapshot.source_response_digests) is not tuple
+            or not snapshot.source_response_digests
+        ):
+            raise GatewayValidationError(
+                "capacity snapshot must prove complete positions and open orders"
+            )
+        for digest in snapshot.source_response_digests:
+            _exact_sha256(digest, "capacity source response digest")
+        self._checked_account()
+        return AccountCapacityEvidence(
+            account_id=checked.account_id,
+            environment=self.runtime_safety.environment,
+            broker_buying_power=snapshot.broker_buying_power,
+            risk_budget=self._opening_risk_budget,
+            observed_at=snapshot.observed_at,
+            portfolio_snapshot_digest=snapshot.portfolio_snapshot_digest,
+        )
+
+    def _reconcile_once(
+        self,
+        record: IntentRecord,
+        account: SelectedBrokerAccount,
+    ) -> None:
+        context = self._reconciliation_context(record)
+        if context is None:
+            return
+        try:
+            reply = self.reader.query_order(
+                account, context.broker_order_id
+            )
+        except Exception:
+            return
+        if type(reply) not in {BrokerOrderSnapshot, BrokerOrderNotFound}:
+            return
+        try:
+            _validate_order_read(
+                reply,
+                account,
+                context.broker_order_id,
+                self.runtime_safety.environment,
+                self._now(),
+            )
+        except (GatewayValidationError, RuntimeSafetyError):
+            return
+        if type(reply) is BrokerOrderNotFound:
+            return
+        if reply.outcome == "UNRESOLVED":
+            return
+        if (
+            reply.order_payload_hash
+            != context.expected_order_payload_hash
+        ):
+            return
+        evidence = BrokerEvidence(
+            account_id=account.account_id,
+            environment=self.runtime_safety.environment,
+            client_order_id=context.client_order_id,
+            broker_order_id=reply.broker_order_id,
+            operation=context.operation,
+            outcome=reply.outcome,
+            observed_at=reply.observed_at,
+            http_status=reply.http_status,
+            raw_response_digest=reply.raw_response_digest,
+        )
+        try:
+            if reply.outcome == "OPEN":
+                if record.pending_operation is not None:
+                    self.ledger.reconcile_open(record.intent_id, evidence)
+                else:
+                    self.ledger.mark_reconciled(record.intent_id, evidence)
+            else:
+                self.ledger.reconcile_terminal(
+                    record.intent_id, reply.outcome, evidence
+                )
+        except OrderIntentLedgerError:
+            return
+
+    def _reconciliation_context(
+        self, record: IntentRecord
+    ) -> _ReconciliationContext | None:
+        if record.state == "CLAIMED":
+            return None
+        if record.pending_operation is None:
+            if record.state != "SUBMITTED" or record.broker_order_id is None:
+                return None
+            return _ReconciliationContext(
+                "ORDER_QUERY",
+                record.client_order_id,
+                record.broker_order_id,
+                self.ledger.expected_order_payload_hash(record.intent_id),
+            )
+        operation = (
+            "SUBMIT_PLACE"
+            if record.pending_operation == "SUBMIT"
+            else "AMEND_PLACE"
+        )
+        receipt = self._pending_place_receipt(record, operation)
+        if receipt is None or receipt.response.broker_order_id is None:
+            # E*TRADE does not echo clientOrderId in order responses. Without
+            # a broker id there is no causal lookup key and guessing is unsafe.
+            return None
+        return _ReconciliationContext(
+            "ORDER_QUERY"
+            if record.pending_operation == "SUBMIT"
+            else "AMEND_QUERY",
+            receipt.client_order_id,
+            receipt.response.broker_order_id,
+            self.ledger.expected_order_payload_hash(record.intent_id),
+        )
+
+    def _pending_place_receipt(
+        self,
+        record: IntentRecord,
+        operation: Literal["SUBMIT_PLACE", "AMEND_PLACE"],
+    ) -> TransportResponseReceipt | None:
+        matches = [
+            receipt
+            for receipt in self.ledger.transport_response_receipts(
+                record.intent_id
+            )
+            if receipt.transport_operation == operation
+            and receipt.fencing_token == record.pending_fence
+        ]
+        return matches[-1] if matches else None
+
+    def _known_place_order_id(
+        self,
+        record: IntentRecord,
+        operation: Literal["SUBMIT_PLACE", "AMEND_PLACE"],
+    ) -> str | None:
+        receipt = self._pending_place_receipt(record, operation)
+        return receipt.response.broker_order_id if receipt else None
+
+    def _require_no_blockers(
+        self, account: SelectedBrokerAccount
+    ) -> None:
+        blockers = self.ledger.reconciliation_blockers(
+            account.account_id, self.runtime_safety.environment
+        )
+        if blockers:
+            raise GatewayReconciliationRequired(
+                f"{len(blockers)} durable broker operation(s) block mutation"
+            )
+        if self.ledger.unabsorbed_filled_reservation_count(
+            account.account_id, self.runtime_safety.environment
+        ):
+            raise GatewayReconciliationRequired(
+                "unabsorbed filled risk blocks mutation"
+            )
+
+    def _require_started(self) -> None:
+        if not self._started:
+            raise GatewayReconciliationRequired(
+                "gateway.start() must complete before mutation"
+            )
+
+    def _require_intent(self, intent_id: str) -> IntentRecord:
+        record = self.ledger.get_intent(intent_id)
+        if record is None:
+            raise GatewayValidationError("unknown intent_id")
+        return record
+
+    def _completed_amendment_result(
+        self,
+        record: IntentRecord,
+        idempotency_key: str,
+        requested_payload_hash: str,
+    ) -> GatewayMutationResult | None:
+        completed_hash = self.ledger.completed_amendment_payload_hash(
+            record.intent_id, idempotency_key
+        )
+        if completed_hash is None:
+            return None
+        if completed_hash != requested_payload_hash:
+            raise OrderIntentIntegrityError(
+                "completed amendment idempotency key cannot be rebound"
+            )
+        if (
+            record.state != "SUBMITTED"
+            or record.pending_operation is not None
+            or self.ledger.expected_order_payload_hash(record.intent_id)
+            != completed_hash
+        ):
+            raise GatewayValidationError(
+                "completed amendment has been superseded or is unresolved"
+            )
+        return self._result(
+            record,
+            False,
+            "SUBMITTED",
+            record.broker_order_id,
+            None,
+            "IDEMPOTENT_REPLAY",
+        )
+
+    def _fail_unplaced_submission(
+        self, intent_id: str, owner: str, fencing_token: int
+    ) -> None:
+        current = self._require_intent(intent_id)
+        if current.state == "CLAIMED":
+            self.ledger.mark_pre_post_failed(
+                intent_id, owner, fencing_token
+            )
+
+    def _now(self) -> datetime:
+        value = self._clock()
+        _exact_utc_time(value, "gateway clock")
+        return value
+
+    @staticmethod
+    def _existing_submission_result(
+        record: IntentRecord, created: bool
+    ) -> GatewayMutationResult | None:
+        if created or record.state == "INTENT":
+            return None
+        if record.state == "SUBMITTED":
+            return EtradeOrderGateway._result(
+                record,
+                False,
+                "SUBMITTED",
+                record.broker_order_id,
+                None,
+                "IDEMPOTENT_REPLAY",
+            )
+        if record.state == "FAILED":
+            return EtradeOrderGateway._result(
+                record,
+                False,
+                "FAILED",
+                None,
+                None,
+                "IDEMPOTENT_REPLAY",
+            )
+        raise GatewayReconciliationRequired(
+            "existing intent has unresolved durable broker state"
+        )
+
+    @staticmethod
+    def _result(
+        record: IntentRecord,
+        created: bool,
+        state: Literal[
+            "SUBMITTED",
+            "SUBMISSION_UNKNOWN",
+            "AMENDMENT_UNKNOWN",
+            "FAILED",
+        ],
+        broker_order_id: str | None,
+        preview_id: str | None,
+        reason_code: str | None,
+    ) -> GatewayMutationResult:
+        return GatewayMutationResult(
+            intent_id=record.intent_id,
+            client_order_id=record.client_order_id,
+            state=state,
+            created=created,
+            broker_order_id=broker_order_id,
+            preview_id=preview_id,
+            reason_code=reason_code,
+        )
+
+
+def _validate_submit_command(
+    command: SubmitOpeningCommand,
+) -> SubmitOpeningCommand:
+    if type(command) is not SubmitOpeningCommand:
+        raise GatewayValidationError(
+            "submit command must use its exact immutable type"
+        )
+    for name in (
+        "strategy_id",
+        "decision_id",
+        "idempotency_scope",
+        "idempotency_key",
+        "owner",
+    ):
+        _exact_text(getattr(command, name), name)
+    _exact_payload_bytes(command.payload_bytes)
+    _exact_decimal(command.max_loss_amount, "max_loss_amount")
+    _exact_decimal(command.collateral_amount, "collateral_amount")
+    _exact_utc_time(command.quote_observed_at, "quote_observed_at")
+    _exact_sha256(command.quote_digest, "quote_digest")
+    _lease_seconds(command.lease_seconds)
+    return command
+
+
+def _validate_reprice_command(
+    command: RepriceOpeningCommand,
+) -> RepriceOpeningCommand:
+    if type(command) is not RepriceOpeningCommand:
+        raise GatewayValidationError(
+            "reprice command must use its exact immutable type"
+        )
+    _exact_text(command.intent_id, "intent_id")
+    _exact_text(command.idempotency_key, "idempotency_key")
+    _exact_text(command.owner, "owner")
+    _exact_payload_bytes(command.payload_bytes)
+    _lease_seconds(command.lease_seconds)
+    return command
+
+
+def _decode_payload(payload_bytes: bytes) -> dict[str, Any]:
+    _exact_payload_bytes(payload_bytes)
+    try:
+        payload = json.loads(
+            payload_bytes.decode("utf-8"),
+            object_pairs_hook=_strict_json_object,
+            parse_constant=_reject_json_constant,
+        )
+    except (UnicodeDecodeError, json.JSONDecodeError) as exc:
+        raise GatewayValidationError(
+            "payload_bytes must contain one strict JSON object"
+        ) from exc
+    if type(payload) is not dict:
+        raise GatewayValidationError(
+            "payload_bytes must contain one strict JSON object"
+        )
+    return payload
+
+
+def _strict_json_object(pairs: list[tuple[str, Any]]) -> dict[str, Any]:
+    result: dict[str, Any] = {}
+    for key, value in pairs:
+        if type(key) is not str or key in result:
+            raise GatewayValidationError(
+                "payload JSON contains duplicate or invalid keys"
+            )
+        result[key] = value
+    return result
+
+
+def _reject_json_constant(value: str) -> None:
+    raise GatewayValidationError(
+        f"payload JSON constant {value} is forbidden"
+    )
+
+
+def _validate_account(account: SelectedBrokerAccount) -> None:
+    if type(account) is not SelectedBrokerAccount:
+        raise GatewayValidationError(
+            "broker account must use exact SelectedBrokerAccount"
+        )
+
+
+def _require_same_account(
+    expected: SelectedBrokerAccount,
+    actual: SelectedBrokerAccount,
+) -> None:
+    if actual != expected:
+        raise RuntimeSafetyError(
+            "broker account identity changed during the operation"
+        )
+
+
+def _require_environment(expected: str, actual: str) -> None:
+    if (
+        type(expected) is not str
+        or expected not in {"sandbox", "production"}
+        or type(actual) is not str
+        or actual != expected
+    ):
+        raise RuntimeSafetyError(
+            "broker environment changed during the operation"
+        )
+
+
+def _validate_order_read(
+    reply: BrokerOrderSnapshot | BrokerOrderNotFound,
+    account: SelectedBrokerAccount,
+    broker_order_id: str,
+    environment: str,
+    now: datetime,
+) -> None:
+    _validate_account(reply.account)
+    _require_same_account(account, reply.account)
+    _require_environment(environment, reply.environment)
+    _exact_broker_id(reply.broker_order_id)
+    if reply.broker_order_id != broker_order_id:
+        raise GatewayValidationError(
+            "order read returned a different broker order id"
+        )
+    _fresh_time(reply.observed_at, now, "order observed_at")
+    if type(reply.http_status) is not int or reply.http_status not in {
+        200,
+        404,
+    }:
+        raise GatewayValidationError(
+            "order read has an unsupported HTTP status"
+        )
+    _exact_sha256(reply.raw_response_digest, "order raw_response_digest")
+    if reply.complete is not True:
+        raise GatewayValidationError("order read must be complete")
+    if type(reply) is BrokerOrderSnapshot:
+        _exact_sha256(
+            reply.order_payload_hash, "order_payload_hash"
+        )
+        if reply.http_status != 200 or reply.outcome not in {
+            "OPEN",
+            "FILLED",
+            "CANCELLED",
+            "REJECTED",
+            "EXPIRED",
+            "UNRESOLVED",
+        }:
+            raise GatewayValidationError(
+                "order snapshot outcome is invalid"
+            )
+
+
+def _fresh_time(value: datetime, now: datetime, name: str) -> None:
+    _exact_utc_time(value, name)
+    if value > now or (now - value).total_seconds() > _MAX_EVIDENCE_AGE_SECONDS:
+        raise GatewayValidationError(f"{name} is stale or future-dated")
+
+
+def _exact_payload_bytes(value: Any) -> None:
+    if (
+        type(value) is not bytes
+        or not value
+        or len(value) > _MAX_COMMAND_BYTES
+    ):
+        raise GatewayValidationError(
+            "payload_bytes must be bounded non-empty exact bytes"
+        )
+
+
+def _exact_text(value: Any, name: str) -> None:
+    if (
+        type(value) is not str
+        or not value
+        or len(value) > 256
+        or any(ord(character) < 33 or ord(character) > 126 for character in value)
+    ):
+        raise GatewayValidationError(
+            f"{name} must be a printable ASCII identifier"
+        )
+
+
+def _exact_broker_id(value: Any) -> None:
+    if (
+        type(value) is not str
+        or not value.isascii()
+        or not value.isdigit()
+        or value[0] == "0"
+        or len(value) > 19
+    ):
+        raise GatewayValidationError("broker order id is invalid")
+
+
+def _exact_sha256(value: Any, name: str) -> None:
+    if (
+        type(value) is not str
+        or len(value) != 64
+        or any(character not in "0123456789abcdef" for character in value)
+    ):
+        raise GatewayValidationError(
+            f"{name} must be a lowercase SHA-256 digest"
+        )
+
+
+def _exact_decimal(
+    value: Any,
+    name: str,
+    *,
+    allow_zero: bool = False,
+) -> None:
+    if type(value) is not Decimal or not value.is_finite():
+        raise GatewayValidationError(
+            f"{name} must be an exact finite Decimal"
+        )
+    if value < 0 or (value == 0 and not allow_zero):
+        raise GatewayValidationError(f"{name} is outside the allowed range")
+
+
+def _exact_utc_time(value: Any, name: str) -> None:
+    if (
+        type(value) is not datetime
+        or value.tzinfo is not timezone.utc
+    ):
+        raise GatewayValidationError(
+            f"{name} must use the exact UTC timezone"
+        )
+
+
+def _lease_seconds(value: Any) -> None:
+    if (
+        type(value) is not int
+        or not 20 <= value <= _MAX_LEASE_SECONDS
+    ):
+        raise GatewayValidationError(
+            "lease_seconds must be an exact integer between 20 and 300"
+        )

--- a/etrade_python_client/live_trading/order_intent_ledger.py
+++ b/etrade_python_client/live_trading/order_intent_ledger.py
@@ -210,6 +210,8 @@ class IntentRecord:
     submission_fence: int
     submission_lease_owner: str | None
     submission_lease_expires_at: datetime | None
+    pending_operation: Literal["SUBMIT", "AMEND"] | None
+    pending_fence: int | None
     last_reconciled_run: str | None
     created_at: datetime
     updated_at: datetime
@@ -309,6 +311,8 @@ class TransportResponseReceipt:
     transport_operation: Literal[
         "SUBMIT_PREVIEW", "SUBMIT_PLACE", "AMEND_PREVIEW", "AMEND_PLACE"
     ]
+    client_order_id: str = field(repr=False)
+    target_broker_order_id: str | None = field(repr=False)
     response: TransportResponseEvidence
     recorded_at: datetime
 
@@ -472,6 +476,15 @@ def normalize_order_payload(order_payload: Mapping[str, Any]) -> dict[str, Any]:
     return {key: value for key, value in order_payload.items() if key not in _NORMALIZED_TRANSPORT_FIELDS}
 
 
+def canonical_order_payload_hash(order_payload: Mapping[str, Any]) -> str:
+    """Return the immutable economic hash used for broker-order comparison."""
+
+    normalized = normalize_order_payload(order_payload)
+    wire_payload = wire_order_payload(normalized)
+    canonical_payload = canonical_order_payload(json.loads(wire_payload))
+    return _payload_hash(canonical_payload)
+
+
 def wire_order_payload(order_payload: Mapping[str, Any]) -> str:
     """Return a strict broker-schema payload with primitive JSON values intact."""
     if type(order_payload) is not dict or not order_payload:
@@ -623,6 +636,80 @@ class OrderIntentLedger:
             row = conn.execute("SELECT * FROM order_intents WHERE intent_id = ?", (intent_id,)).fetchone()
         return self._intent_from_row(row) if row else None
 
+    def expected_order_payload_hash(self, intent_id: str) -> str:
+        """Return the exact durable order terms a broker query must prove."""
+
+        _validate_identity("intent_id", intent_id)
+        with self._connection() as conn:
+            intent = self._require_intent(conn, intent_id)
+            if intent["pending_operation"] == "AMEND":
+                amendment = conn.execute(
+                    "SELECT * FROM amendment_leases WHERE intent_id = ?",
+                    (intent_id,),
+                ).fetchone()
+                if (
+                    amendment is None
+                    or amendment["state"] != "IN_DOUBT"
+                    or int(amendment["fencing_token"])
+                    != int(intent["pending_fence"] or -1)
+                ):
+                    raise OrderIntentIntegrityError(
+                        "pending amendment lacks matching durable order terms"
+                    )
+                result = amendment["payload_hash"]
+            elif intent["pending_operation"] == "SUBMIT":
+                result = intent["payload_hash"]
+            else:
+                completed = conn.execute(
+                    """
+                    SELECT payload_hash, completed_at
+                    FROM amendment_history
+                    WHERE intent_id = ?
+                    ORDER BY completed_at DESC
+                    """,
+                    (intent_id,),
+                ).fetchall()
+                if not completed:
+                    result = intent["payload_hash"]
+                else:
+                    latest_at = int(completed[0]["completed_at"])
+                    latest_hashes = {
+                        row["payload_hash"]
+                        for row in completed
+                        if int(row["completed_at"]) == latest_at
+                    }
+                    if len(latest_hashes) != 1:
+                        raise OrderIntentIntegrityError(
+                            "latest durable amendment terms are ambiguous"
+                        )
+                    result = next(iter(latest_hashes))
+        _validate_sha256("expected_order_payload_hash", result)
+        return result
+
+    def completed_amendment_payload_hash(
+        self, intent_id: str, idempotency_key: str
+    ) -> str | None:
+        """Return immutable terms for a completed amendment replay."""
+
+        _validate_identity("intent_id", intent_id)
+        _validate_identity(
+            "amendment_idempotency_key", idempotency_key
+        )
+        with self._connection() as conn:
+            self._require_intent(conn, intent_id)
+            row = conn.execute(
+                """
+                SELECT payload_hash FROM amendment_history
+                WHERE intent_id = ? AND idempotency_key = ?
+                """,
+                (intent_id, idempotency_key),
+            ).fetchone()
+        if row is None:
+            return None
+        result = row["payload_hash"]
+        _validate_sha256("completed_amendment_payload_hash", result)
+        return result
+
     def transport_response_receipts(
         self, intent_id: str
     ) -> tuple[TransportResponseReceipt, ...]:
@@ -633,19 +720,27 @@ class OrderIntentLedger:
             self._require_intent(conn, intent_id)
             rows = conn.execute(
                 """
-                SELECT * FROM transport_response_receipts
-                WHERE intent_id = ?
+                SELECT response.*,
+                    attempt.client_order_id AS request_client_order_id,
+                    attempt.target_broker_order_id AS request_target_broker_order_id
+                FROM transport_response_receipts AS response
+                JOIN transport_send_attempts AS attempt
+                  ON attempt.intent_id = response.intent_id
+                 AND attempt.authorization_operation = response.authorization_operation
+                 AND attempt.fencing_token = response.fencing_token
+                 AND attempt.transport_operation = response.transport_operation
+                WHERE response.intent_id = ?
                 ORDER BY
-                    CASE authorization_operation
+                    CASE response.authorization_operation
                         WHEN 'SUBMIT' THEN 0 ELSE 1
                     END,
-                    fencing_token,
-                    recorded_at,
+                    response.fencing_token,
+                    response.recorded_at,
                     CASE
-                        WHEN transport_operation LIKE '%_PREVIEW' THEN 0
+                        WHEN response.transport_operation LIKE '%_PREVIEW' THEN 0
                         ELSE 1
                     END,
-                    transport_operation
+                    response.transport_operation
                 """,
                 (intent_id,),
             ).fetchall()
@@ -658,9 +753,36 @@ class OrderIntentLedger:
         AccountCapacityEvidence.validate(evidence, _from_us(now))
         cap = _canonical_amount(min(evidence.broker_buying_power, evidence.risk_budget))
         with self._transaction() as conn:
-            existing = conn.execute("SELECT observed_at FROM reservation_caps WHERE account_id = ? AND environment = ?", (evidence.account_id, evidence.environment)).fetchone()
-            if existing is not None and _to_us(evidence.observed_at) <= int(existing["observed_at"]):
-                raise OrderIntentIntegrityError("capacity evidence must be newer than the persisted account snapshot")
+            existing = conn.execute(
+                """
+                SELECT * FROM reservation_caps
+                WHERE account_id = ? AND environment = ?
+                """,
+                (evidence.account_id, evidence.environment),
+            ).fetchone()
+            observed_at = _to_us(evidence.observed_at)
+            if existing is not None and observed_at == int(existing["observed_at"]):
+                expected = (
+                    cap,
+                    _canonical_amount(evidence.broker_buying_power),
+                    _canonical_amount(evidence.risk_budget),
+                    evidence.portfolio_snapshot_digest,
+                )
+                actual = (
+                    existing["cap_amount"],
+                    existing["broker_buying_power"],
+                    existing["risk_budget"],
+                    existing["portfolio_snapshot_digest"],
+                )
+                if actual == expected:
+                    return Decimal(existing["cap_amount"])
+                raise OrderIntentIntegrityError(
+                    "equal-time capacity evidence conflicts with the persisted snapshot"
+                )
+            if existing is not None and observed_at < int(existing["observed_at"]):
+                raise OrderIntentIntegrityError(
+                    "capacity evidence must not predate the persisted account snapshot"
+                )
             conn.execute(
                 """
                 INSERT INTO reservation_caps (account_id, environment, cap_amount, broker_buying_power, risk_budget, observed_at, portfolio_snapshot_digest, updated_at)
@@ -670,7 +792,7 @@ class OrderIntentLedger:
                     risk_budget = excluded.risk_budget, observed_at = excluded.observed_at,
                     portfolio_snapshot_digest = excluded.portfolio_snapshot_digest, updated_at = excluded.updated_at
                 """,
-                (evidence.account_id, evidence.environment, cap, _canonical_amount(evidence.broker_buying_power), _canonical_amount(evidence.risk_budget), _to_us(evidence.observed_at), evidence.portfolio_snapshot_digest, now),
+                (evidence.account_id, evidence.environment, cap, _canonical_amount(evidence.broker_buying_power), _canonical_amount(evidence.risk_budget), observed_at, evidence.portfolio_snapshot_digest, now),
             )
         return Decimal(cap)
 
@@ -749,6 +871,25 @@ class OrderIntentLedger:
         _validate_identity("environment", environment)
         with self._connection() as conn:
             return self._active_reservation_total(conn, account_id, environment)
+
+    def unabsorbed_filled_reservation_count(
+        self, account_id: str, environment: str
+    ) -> int:
+        """Return terminal opening risk not yet proven in positions."""
+
+        _validate_identity("account_id", account_id)
+        _validate_environment(environment)
+        with self._connection() as conn:
+            row = conn.execute(
+                """
+                SELECT COUNT(*) AS total
+                FROM margin_reservations
+                WHERE account_id = ? AND environment = ?
+                  AND state = 'FILLED_PENDING_ABSORPTION'
+                """,
+                (account_id, environment),
+            ).fetchone()
+        return int(row["total"])
 
     def claim_submission(self, intent_id: str, owner: str, *, lease_seconds: float) -> SubmissionLease:
         _validate_identity("intent_id", intent_id)
@@ -2714,6 +2855,12 @@ class OrderIntentLedger:
             broker_order_id=row["broker_order_id"], submission_fence=int(row["submission_fence"]),
             submission_lease_owner=row["submission_lease_owner"],
             submission_lease_expires_at=_from_us(row["submission_lease_expires_at"]) if row["submission_lease_expires_at"] is not None else None,
+            pending_operation=row["pending_operation"],
+            pending_fence=(
+                int(row["pending_fence"])
+                if row["pending_fence"] is not None
+                else None
+            ),
             last_reconciled_run=row["last_reconciled_run"], created_at=_from_us(row["created_at"]), updated_at=_from_us(row["updated_at"]),
         )
 
@@ -2771,7 +2918,14 @@ def _transport_response_receipt(
     authorization_operation = row["authorization_operation"]
     fencing_token = int(row["fencing_token"])
     transport_operation = row["transport_operation"]
+    client_order_id = row["request_client_order_id"]
+    target_broker_order_id = row["request_target_broker_order_id"]
     _validate_identity("intent_id", intent_id)
+    _validate_identity("client_order_id", client_order_id)
+    if target_broker_order_id is not None:
+        _validate_identity(
+            "target_broker_order_id", target_broker_order_id
+        )
     _validate_fencing_token(fencing_token)
     if (
         authorization_operation not in {"SUBMIT", "AMEND"}
@@ -2787,6 +2941,8 @@ def _transport_response_receipt(
         authorization_operation=authorization_operation,
         fencing_token=fencing_token,
         transport_operation=transport_operation,
+        client_order_id=client_order_id,
+        target_broker_order_id=target_broker_order_id,
         response=response,
         recorded_at=_from_us(row["recorded_at"]),
     )

--- a/etrade_python_client/tests/test_etrade_broker_transport.py
+++ b/etrade_python_client/tests/test_etrade_broker_transport.py
@@ -344,6 +344,17 @@ class ETradeBrokerTransportTests(unittest.TestCase):
             ],
             ["SUBMIT_PREVIEW", "SUBMIT_PLACE"],
         )
+        receipts = case.ledger.transport_response_receipts(
+            case.record.intent_id
+        )
+        self.assertEqual(
+            [receipt.client_order_id for receipt in receipts],
+            [case.record.client_order_id, case.record.client_order_id],
+        )
+        self.assertEqual(
+            [receipt.target_broker_order_id for receipt in receipts],
+            [None, None],
+        )
         prepared, kwargs = case.adapter.calls[1]
         self.assertEqual(
             prepared.url,

--- a/etrade_python_client/tests/test_etrade_order_gateway.py
+++ b/etrade_python_client/tests/test_etrade_order_gateway.py
@@ -1,0 +1,952 @@
+from __future__ import annotations
+
+import inspect
+import json
+import os
+import tempfile
+import unittest
+from dataclasses import replace
+from datetime import datetime, timedelta, timezone
+from decimal import Decimal
+from pathlib import Path
+from unittest.mock import patch
+
+from rauth import OAuth1Session
+
+import live_trading.etrade_order_gateway as gateway_module
+from live_trading.etrade_broker_transport import (
+    ETradeBrokerTransport,
+    SelectedBrokerAccount,
+    _ExchangeResult,
+)
+from live_trading.etrade_order_gateway import (
+    BrokerCapacitySnapshot,
+    BrokerOrderNotFound,
+    BrokerOrderSnapshot,
+    EtradeOrderGateway,
+    GatewayReconciliationRequired,
+    GatewayValidationError,
+    RepriceOpeningCommand,
+    SubmitOpeningCommand,
+)
+from live_trading.order_intent_ledger import (
+    OrderIntentLedger,
+    OrderIntentReconciliationRequired,
+    OrderIntentReservationError,
+    canonical_order_payload_hash,
+)
+from live_trading.runtime_safety import (
+    RuntimeSafetyBoundary,
+    RuntimeSafetyError,
+)
+
+
+ACCOUNT_ID = "842468410"
+ACCOUNT_KEY = "account/key"
+INSTITUTION_TYPE = "BROKERAGE"
+OWNER = "gateway-worker"
+
+
+class Clock:
+    def __init__(self):
+        self.now = datetime.now(timezone.utc)
+
+    def __call__(self):
+        return self.now
+
+    def advance(self, seconds):
+        self.now += timedelta(seconds=seconds)
+
+
+def vertical_payload(limit_price=1.25):
+    return {
+        "securityType": "OPTN",
+        "orderAction": "SPREAD",
+        "priceType": "NET_CREDIT",
+        "limitPrice": limit_price,
+        "orderTerm": "GOOD_FOR_DAY",
+        "spreadType": "VERTICAL",
+        "legs": [
+            {
+                "symbol": "SPY",
+                "callPut": "PUT",
+                "expiryYear": 2027,
+                "expiryMonth": 1,
+                "expiryDay": 15,
+                "strikePrice": 620,
+                "orderAction": "SELL_OPEN",
+                "quantity": 1,
+            },
+            {
+                "symbol": "SPY",
+                "callPut": "PUT",
+                "expiryYear": 2027,
+                "expiryMonth": 1,
+                "expiryDay": 15,
+                "strikePrice": 615,
+                "orderAction": "BUY_OPEN",
+                "quantity": 1,
+            },
+        ],
+    }
+
+
+def payload_bytes(limit_price=1.25):
+    return json.dumps(
+        vertical_payload(limit_price),
+        sort_keys=True,
+        separators=(",", ":"),
+    ).encode("utf-8")
+
+
+def order_payload_hash(limit_price=1.25):
+    return canonical_order_payload_hash(
+        vertical_payload(limit_price)
+    )
+
+
+def preview_result(
+    *,
+    preview_id="1020563279",
+    status="OPEN",
+    messages=None,
+):
+    order = {"status": status}
+    if messages is not None:
+        order["messages"] = {"Message": messages}
+    body = {
+        "PreviewOrderResponse": {
+            "accountId": ACCOUNT_ID,
+            "orderType": "SPREADS",
+            "PreviewIds": [{"previewId": preview_id}],
+            "Order": [order],
+        }
+    }
+    return _ExchangeResult(
+        "RESPONSE",
+        http_status=200,
+        raw_response=json.dumps(
+            body, sort_keys=True, separators=(",", ":")
+        ).encode("utf-8"),
+    )
+
+
+def place_result(*, order_id="94", status="OPEN", messages=None):
+    order = {"status": status}
+    if messages is not None:
+        order["messages"] = {"Message": messages}
+    body = {
+        "PlaceOrderResponse": {
+            "accountId": ACCOUNT_ID,
+            "orderType": "SPREADS",
+            "OrderIds": [{"orderId": order_id}],
+            "Order": [order],
+        }
+    }
+    return _ExchangeResult(
+        "RESPONSE",
+        http_status=200,
+        raw_response=json.dumps(
+            body, sort_keys=True, separators=(",", ":")
+        ).encode("utf-8"),
+    )
+
+
+class ExchangeHarness:
+    def __init__(self):
+        self.outcomes = []
+        self.calls = []
+
+    def exchange(self, prepared, *, timeout_seconds):
+        self.calls.append((prepared, timeout_seconds))
+        if not self.outcomes:
+            raise AssertionError("unexpected broker mutation")
+        outcome = self.outcomes.pop(0)
+        if callable(outcome):
+            outcome = outcome()
+        if isinstance(outcome, BaseException):
+            raise outcome
+        return outcome
+
+    def add(self, *outcomes):
+        self.outcomes.extend(outcomes)
+
+    def count(self, suffix):
+        return sum(call[0].url.endswith(suffix) for call in self.calls)
+
+
+class FakeReader:
+    def __init__(self, clock, account, environment="sandbox"):
+        self.clock = clock
+        self.account = account
+        self.environment = environment
+        self.capacity_digest = "a" * 64
+        self.capacity_complete = True
+        self.selected_hook = None
+        self.query_behaviors = {}
+        self.query_calls = []
+
+    def assert_gateway_binding(self, runtime_safety):
+        if self.environment != runtime_safety.environment:
+            raise RuntimeSafetyError("reader environment mismatch")
+
+    def selected_account(self):
+        if self.selected_hook is not None:
+            hook = self.selected_hook
+            self.selected_hook = None
+            hook()
+        return self.account
+
+    def read_capacity(self, account):
+        return BrokerCapacitySnapshot(
+            account=self.account,
+            environment=self.environment,
+            broker_buying_power=Decimal("2000"),
+            observed_at=self.clock.now,
+            portfolio_snapshot_digest=self.capacity_digest,
+            positions_complete=self.capacity_complete,
+            open_orders_complete=self.capacity_complete,
+            source_response_digests=("1" * 64, "2" * 64),
+        )
+
+    def query_order(self, account, broker_order_id):
+        self.query_calls.append((account, broker_order_id))
+        behavior = self.query_behaviors.get(broker_order_id)
+        if isinstance(behavior, BaseException):
+            raise behavior
+        if callable(behavior):
+            return behavior()
+        if behavior is None:
+            return BrokerOrderNotFound(
+                account=self.account,
+                environment=self.environment,
+                broker_order_id=broker_order_id,
+                observed_at=self.clock.now,
+                http_status=404,
+                raw_response_digest="3" * 64,
+                complete=True,
+            )
+        return behavior
+
+
+class EtradeOrderGatewayTests(unittest.TestCase):
+    def setUp(self):
+        self.temporary = tempfile.TemporaryDirectory()
+        os.chmod(self.temporary.name, 0o700)
+        self.path = (
+            Path(self.temporary.name) / "runtime" / "orders.sqlite3"
+        )
+        self.clock = Clock()
+        self.account = SelectedBrokerAccount(
+            ACCOUNT_ID, ACCOUNT_KEY, INSTITUTION_TYPE
+        )
+        self.boundary = RuntimeSafetyBoundary(
+            "sandbox",
+            ACCOUNT_ID,
+            ACCOUNT_KEY,
+            INSTITUTION_TYPE,
+            self.clock.now - timedelta(seconds=1),
+            self.clock.now + timedelta(minutes=10),
+        )
+        self.ledger = OrderIntentLedger(
+            self.path, clock=self.clock, run_id="gateway-run-a"
+        )
+        self.harness = ExchangeHarness()
+        self.patcher = patch(
+            "live_trading.etrade_broker_transport._isolated_exchange",
+            side_effect=self.harness.exchange,
+        )
+        self.patcher.start()
+        self.reader = FakeReader(self.clock, self.account)
+        self.transport = self.make_transport(
+            self.ledger, self.boundary
+        )
+        self.gateway = EtradeOrderGateway(
+            runtime_safety=self.boundary,
+            ledger=self.ledger,
+            transport=self.transport,
+            reader=self.reader,
+            opening_risk_budget=Decimal("2000"),
+            clock=self.clock,
+        )
+        self.gateway.start()
+
+    def tearDown(self):
+        self.patcher.stop()
+        self.temporary.cleanup()
+
+    def make_transport(self, ledger, boundary):
+        return ETradeBrokerTransport(
+            session=OAuth1Session(
+                "consumer-key",
+                "consumer-secret",
+                access_token="access-token",
+                access_token_secret="access-secret",
+            ),
+            ledger=ledger,
+            runtime_safety=boundary,
+            selected_account=self.account,
+            clock=self.clock,
+        )
+
+    def command(
+        self,
+        *,
+        key="order-1",
+        decision="decision-1",
+        lease_seconds=30,
+    ):
+        return SubmitOpeningCommand(
+            strategy_id="put-credit-spread",
+            decision_id=decision,
+            idempotency_scope="decision",
+            idempotency_key=key,
+            payload_bytes=payload_bytes(),
+            max_loss_amount=Decimal("400"),
+            collateral_amount=Decimal("500"),
+            quote_observed_at=self.clock.now,
+            quote_digest="f" * 64,
+            owner=OWNER,
+            lease_seconds=lease_seconds,
+        )
+
+    def restart(self, *, reader=None):
+        ledger = OrderIntentLedger(
+            self.path, clock=self.clock, run_id="gateway-run-b"
+        )
+        reader = reader or FakeReader(self.clock, self.account)
+        transport = self.make_transport(ledger, self.boundary)
+        gateway = EtradeOrderGateway(
+            runtime_safety=self.boundary,
+            ledger=ledger,
+            transport=transport,
+            reader=reader,
+            opening_risk_budget=Decimal("2000"),
+            clock=self.clock,
+        )
+        return gateway, ledger, reader
+
+    def submit_success(self):
+        self.harness.add(preview_result(), place_result())
+        return self.gateway.submit_opening(self.command())
+
+    def test_real_transport_submission_is_idempotent_and_places_once(self):
+        first = self.submit_success()
+        replay = self.gateway.submit_opening(self.command())
+
+        self.assertEqual(first.state, "SUBMITTED")
+        self.assertEqual(replay.state, "SUBMITTED")
+        self.assertFalse(replay.created)
+        self.assertEqual(first.intent_id, replay.intent_id)
+        self.assertEqual(self.harness.count("/orders/preview"), 1)
+        self.assertEqual(self.harness.count("/orders/place"), 1)
+        self.assertEqual(
+            [
+                receipt.transport_operation
+                for receipt in self.ledger.transport_response_receipts(
+                    first.intent_id
+                )
+            ],
+            ["SUBMIT_PREVIEW", "SUBMIT_PLACE"],
+        )
+
+    def test_no_id_timeout_is_durable_and_cannot_be_auto_reconciled(self):
+        self.harness.add(preview_result(), _ExchangeResult("TIMEOUT"))
+
+        result = self.gateway.submit_opening(self.command())
+
+        self.assertEqual(result.state, "SUBMISSION_UNKNOWN")
+        self.assertEqual(result.reason_code, "TIMEOUT")
+        with self.assertRaises(GatewayReconciliationRequired):
+            self.gateway.submit_opening(self.command())
+        restarted, _, reader = self.restart()
+        with self.assertRaises(GatewayReconciliationRequired):
+            restarted.start()
+        self.assertEqual(reader.query_calls, [])
+        self.assertEqual(self.harness.count("/orders/place"), 1)
+
+    def test_known_executed_response_reconciles_filled_but_absorption_blocks(self):
+        self.harness.add(
+            preview_result(), place_result(status="EXECUTED")
+        )
+        unknown = self.gateway.submit_opening(self.command())
+        self.assertEqual(unknown.state, "SUBMISSION_UNKNOWN")
+        self.assertEqual(unknown.broker_order_id, "94")
+        reader = FakeReader(self.clock, self.account)
+        reader.query_behaviors["94"] = BrokerOrderSnapshot(
+            account=self.account,
+            environment=reader.environment,
+            broker_order_id="94",
+            outcome="FILLED",
+            observed_at=self.clock.now,
+            http_status=200,
+            raw_response_digest="4" * 64,
+            order_payload_hash=order_payload_hash(),
+            complete=True,
+        )
+        restarted, ledger, _ = self.restart(reader=reader)
+
+        with self.assertRaises(GatewayReconciliationRequired):
+            restarted.start()
+
+        self.assertEqual(ledger.get_intent(unknown.intent_id).state, "FILLED")
+        self.assertEqual(
+            ledger.unabsorbed_filled_reservation_count(
+                ACCOUNT_ID, "sandbox"
+            ),
+            1,
+        )
+
+    def test_known_hold_reconciles_open_and_allows_next_opening(self):
+        self.harness.add(
+            preview_result(),
+            place_result(
+                messages={
+                    "description": "manual review",
+                    "code": 4002,
+                    "type": "INFO_HOLD",
+                }
+            ),
+        )
+        unknown = self.gateway.submit_opening(self.command())
+        reader = FakeReader(self.clock, self.account)
+        reader.query_behaviors["94"] = BrokerOrderSnapshot(
+            account=self.account,
+            environment=reader.environment,
+            broker_order_id="94",
+            outcome="OPEN",
+            observed_at=self.clock.now,
+            http_status=200,
+            raw_response_digest="4" * 64,
+            order_payload_hash=order_payload_hash(),
+            complete=True,
+        )
+        restarted, ledger, reader = self.restart(reader=reader)
+        restarted.start()
+        self.assertEqual(ledger.get_intent(unknown.intent_id).state, "SUBMITTED")
+
+        self.clock.advance(1)
+        reader.capacity_digest = "5" * 64
+        self.harness.add(
+            preview_result(preview_id="1020563280"),
+            place_result(order_id="95"),
+        )
+        result = restarted.submit_opening(
+            self.command(key="order-2", decision="decision-2")
+        )
+        self.assertEqual(result.state, "SUBMITTED")
+
+    def test_process_crash_after_place_claim_is_never_retried(self):
+        self.harness.add(
+            preview_result(), SystemExit("simulated crash")
+        )
+
+        with self.assertRaises(SystemExit):
+            self.gateway.submit_opening(self.command())
+
+        blockers = self.ledger.reconciliation_blockers(
+            ACCOUNT_ID, "sandbox"
+        )
+        self.assertEqual(len(blockers), 1)
+        self.assertEqual(blockers[0].state, "SUBMISSION_UNKNOWN")
+        self.assertEqual(self.harness.count("/orders/place"), 1)
+
+    def test_preview_warning_fails_before_place_and_releases_reservation(self):
+        self.harness.add(
+            preview_result(
+                messages={
+                    "description": "possible duplicate",
+                    "code": 1042,
+                    "type": "WARNING",
+                }
+            )
+        )
+
+        result = self.gateway.submit_opening(self.command())
+
+        self.assertEqual(result.state, "FAILED")
+        self.assertEqual(result.reason_code, "PREVIEW_REVIEW_REQUIRED")
+        self.assertEqual(self.harness.count("/orders/place"), 0)
+        self.assertEqual(
+            self.ledger.get_margin_reservation(result.intent_id).state,
+            "RELEASED",
+        )
+
+    def test_lease_expiry_after_preview_resets_without_place(self):
+        def expire_after_preview():
+            self.reader.selected_hook = lambda: self.clock.advance(31)
+            return preview_result()
+
+        self.harness.add(expire_after_preview)
+
+        with self.assertRaises(OrderIntentReconciliationRequired):
+            self.gateway.submit_opening(self.command())
+
+        self.assertEqual(self.harness.count("/orders/place"), 0)
+        self.assertEqual(
+            self.ledger.reconciliation_blockers(
+                ACCOUNT_ID, "sandbox"
+            ),
+            (),
+        )
+
+    def test_runtime_expiry_after_preview_fails_before_place(self):
+        boundary = RuntimeSafetyBoundary(
+            "production",
+            ACCOUNT_ID,
+            ACCOUNT_KEY,
+            INSTITUTION_TYPE,
+            self.clock.now - timedelta(seconds=1),
+            self.clock.now + timedelta(seconds=1),
+        )
+        ledger = OrderIntentLedger(
+            Path(self.temporary.name) / "expiring" / "orders.sqlite3",
+            clock=self.clock,
+            run_id="expiring-run",
+        )
+        reader = FakeReader(self.clock, self.account, "production")
+        gateway = EtradeOrderGateway(
+            runtime_safety=boundary,
+            ledger=ledger,
+            transport=self.make_transport(ledger, boundary),
+            reader=reader,
+            opening_risk_budget=Decimal("2000"),
+            clock=self.clock,
+        )
+        gateway.start()
+
+        def expire_after_preview():
+            reader.selected_hook = lambda: self.clock.advance(2)
+            return preview_result()
+
+        self.harness.add(expire_after_preview)
+        with self.assertRaises(RuntimeSafetyError):
+            gateway.submit_opening(self.command())
+        self.assertEqual(self.harness.count("/orders/place"), 0)
+        self.assertEqual(
+            ledger.active_reserved_margin(ACCOUNT_ID, "production"),
+            Decimal("0"),
+        )
+
+    def test_runtime_expiry_after_place_claim_blocks_before_socket_io(self):
+        boundary = RuntimeSafetyBoundary(
+            "production",
+            ACCOUNT_ID,
+            ACCOUNT_KEY,
+            INSTITUTION_TYPE,
+            self.clock.now - timedelta(seconds=1),
+            self.clock.now + timedelta(seconds=1),
+        )
+        ledger = OrderIntentLedger(
+            Path(self.temporary.name) / "post-claim" / "orders.sqlite3",
+            clock=self.clock,
+            run_id="post-claim-run",
+        )
+        reader = FakeReader(self.clock, self.account, "production")
+        gateway = EtradeOrderGateway(
+            runtime_safety=boundary,
+            ledger=ledger,
+            transport=self.make_transport(ledger, boundary),
+            reader=reader,
+            opening_risk_budget=Decimal("2000"),
+            clock=self.clock,
+        )
+        gateway.start()
+        original = ledger.claim_transport_send
+
+        def claim(request, authorization):
+            original(request, authorization)
+            if request.transport_operation == "SUBMIT_PLACE":
+                self.clock.advance(2)
+
+        self.harness.add(preview_result())
+        with patch.object(
+            ledger, "claim_transport_send", side_effect=claim
+        ):
+            with self.assertRaises(RuntimeSafetyError):
+                gateway.submit_opening(self.command())
+
+        blockers = ledger.reconciliation_blockers(
+            ACCOUNT_ID, "production"
+        )
+        self.assertEqual(len(blockers), 1)
+        self.assertEqual(blockers[0].state, "SUBMISSION_UNKNOWN")
+        self.assertEqual(self.harness.count("/orders/place"), 0)
+
+    def test_response_persistence_failure_returns_durable_unknown(self):
+        self.harness.add(preview_result(), place_result())
+        original = self.ledger.record_transport_response
+
+        def persist(request, response):
+            if request.transport_operation == "SUBMIT_PLACE":
+                raise RuntimeError("simulated durable write failure")
+            return original(request, response)
+
+        with patch.object(
+            self.ledger,
+            "record_transport_response",
+            side_effect=persist,
+        ):
+            result = self.gateway.submit_opening(self.command())
+
+        self.assertEqual(result.state, "SUBMISSION_UNKNOWN")
+        self.assertEqual(
+            result.reason_code,
+            "TRANSPORT_RESPONSE_PERSISTENCE_ERROR",
+        )
+        self.assertEqual(
+            self.ledger.get_intent(result.intent_id).pending_operation,
+            "SUBMIT",
+        )
+
+    def test_amendment_response_persistence_failure_is_durable_unknown(self):
+        submitted = self.submit_success()
+        self.harness.add(
+            preview_result(preview_id="1020563280"),
+            place_result(order_id="95"),
+        )
+        original = self.ledger.record_transport_response
+
+        def persist(request, response):
+            if request.transport_operation == "AMEND_PLACE":
+                raise RuntimeError("simulated durable write failure")
+            return original(request, response)
+
+        with patch.object(
+            self.ledger,
+            "record_transport_response",
+            side_effect=persist,
+        ):
+            result = self.gateway.reprice_opening(
+                RepriceOpeningCommand(
+                    intent_id=submitted.intent_id,
+                    idempotency_key="reprice-persistence-failure",
+                    payload_bytes=payload_bytes(1.50),
+                    owner=OWNER,
+                )
+            )
+
+        self.assertEqual(result.state, "AMENDMENT_UNKNOWN")
+        self.assertEqual(
+            result.reason_code,
+            "TRANSPORT_RESPONSE_PERSISTENCE_ERROR",
+        )
+        self.assertEqual(
+            self.ledger.get_intent(result.intent_id).pending_operation,
+            "AMEND",
+        )
+
+    def test_successful_reprice_uses_real_change_transport(self):
+        submitted = self.submit_success()
+        self.harness.add(
+            preview_result(preview_id="1020563280"),
+            place_result(order_id="95"),
+        )
+        command = RepriceOpeningCommand(
+            intent_id=submitted.intent_id,
+            idempotency_key="reprice-1",
+            payload_bytes=payload_bytes(1.50),
+            owner=OWNER,
+        )
+        result = self.gateway.reprice_opening(command)
+        replay = self.gateway.reprice_opening(command)
+
+        self.assertEqual(result.state, "SUBMITTED")
+        self.assertEqual(result.broker_order_id, "95")
+        self.assertEqual(replay.reason_code, "IDEMPOTENT_REPLAY")
+        self.assertFalse(replay.created)
+        self.assertEqual(self.harness.count("/change/preview"), 1)
+        self.assertEqual(self.harness.count("/change/place"), 1)
+        current = self.ledger.get_intent(submitted.intent_id)
+        self.assertIsNone(current.pending_operation)
+        reader = FakeReader(self.clock, self.account)
+        reader.query_behaviors["95"] = BrokerOrderSnapshot(
+            account=self.account,
+            environment=reader.environment,
+            broker_order_id="95",
+            outcome="OPEN",
+            observed_at=self.clock.now,
+            http_status=200,
+            raw_response_digest="9" * 64,
+            order_payload_hash=order_payload_hash(1.50),
+            complete=True,
+        )
+        restarted, ledger, _ = self.restart(reader=reader)
+
+        restarted.start()
+
+        self.assertEqual(
+            ledger.expected_order_payload_hash(submitted.intent_id),
+            order_payload_hash(1.50),
+        )
+
+    def test_no_id_amendment_timeout_remains_hard_blocker(self):
+        submitted = self.submit_success()
+        self.harness.add(
+            preview_result(preview_id="1020563280"),
+            _ExchangeResult("TIMEOUT"),
+        )
+        result = self.gateway.reprice_opening(
+            RepriceOpeningCommand(
+                intent_id=submitted.intent_id,
+                idempotency_key="reprice-timeout",
+                payload_bytes=payload_bytes(1.50),
+                owner=OWNER,
+            )
+        )
+        self.assertEqual(result.state, "AMENDMENT_UNKNOWN")
+
+        restarted, _, reader = self.restart()
+        with self.assertRaises(GatewayReconciliationRequired):
+            restarted.start()
+        self.assertEqual(reader.query_calls, [])
+
+    def test_process_crash_after_amendment_place_claim_is_not_retried(self):
+        submitted = self.submit_success()
+        self.harness.add(
+            preview_result(preview_id="1020563280"),
+            SystemExit("simulated amendment crash"),
+        )
+
+        with self.assertRaises(SystemExit):
+            self.gateway.reprice_opening(
+                RepriceOpeningCommand(
+                    intent_id=submitted.intent_id,
+                    idempotency_key="reprice-crash",
+                    payload_bytes=payload_bytes(1.50),
+                    owner=OWNER,
+                )
+            )
+
+        self.assertEqual(
+            self.ledger.get_intent(submitted.intent_id).pending_operation,
+            "AMEND",
+        )
+        restarted, _, reader = self.restart()
+        with self.assertRaises(GatewayReconciliationRequired):
+            restarted.start()
+        self.assertEqual(reader.query_calls, [])
+        self.assertEqual(self.harness.count("/change/place"), 1)
+
+    def test_known_amendment_hold_reconciles_replacement_open(self):
+        submitted = self.submit_success()
+        self.harness.add(
+            preview_result(preview_id="1020563280"),
+            place_result(
+                order_id="95",
+                messages={
+                    "description": "manual review",
+                    "code": 4002,
+                    "type": "INFO_HOLD",
+                },
+            ),
+        )
+        result = self.gateway.reprice_opening(
+            RepriceOpeningCommand(
+                intent_id=submitted.intent_id,
+                idempotency_key="reprice-hold",
+                payload_bytes=payload_bytes(1.50),
+                owner=OWNER,
+            )
+        )
+        self.assertEqual(result.state, "AMENDMENT_UNKNOWN")
+        reader = FakeReader(self.clock, self.account)
+        reader.query_behaviors["95"] = BrokerOrderSnapshot(
+            account=self.account,
+            environment=reader.environment,
+            broker_order_id="95",
+            outcome="OPEN",
+            observed_at=self.clock.now,
+            http_status=200,
+            raw_response_digest="6" * 64,
+            order_payload_hash=order_payload_hash(1.50),
+            complete=True,
+        )
+        restarted, ledger, _ = self.restart(reader=reader)
+
+        restarted.start()
+
+        current = ledger.get_intent(submitted.intent_id)
+        self.assertEqual(current.broker_order_id, "95")
+        self.assertIsNone(current.pending_operation)
+
+    def test_open_order_with_old_terms_does_not_clear_pending_amendment(self):
+        submitted = self.submit_success()
+        self.harness.add(
+            preview_result(preview_id="1020563280"),
+            place_result(
+                order_id="95",
+                messages={
+                    "description": "manual review",
+                    "code": 4002,
+                    "type": "INFO_HOLD",
+                },
+            ),
+        )
+        result = self.gateway.reprice_opening(
+            RepriceOpeningCommand(
+                intent_id=submitted.intent_id,
+                idempotency_key="reprice-old-terms",
+                payload_bytes=payload_bytes(1.50),
+                owner=OWNER,
+            )
+        )
+        reader = FakeReader(self.clock, self.account)
+        reader.query_behaviors["95"] = BrokerOrderSnapshot(
+            account=self.account,
+            environment=reader.environment,
+            broker_order_id="95",
+            outcome="OPEN",
+            observed_at=self.clock.now,
+            http_status=200,
+            raw_response_digest="8" * 64,
+            order_payload_hash=order_payload_hash(1.25),
+            complete=True,
+        )
+        restarted, ledger, _ = self.restart(reader=reader)
+
+        with self.assertRaises(GatewayReconciliationRequired):
+            restarted.start()
+
+        self.assertEqual(
+            ledger.get_intent(result.intent_id).pending_operation,
+            "AMEND",
+        )
+
+    def test_submitted_order_is_revalidated_on_restart(self):
+        submitted = self.submit_success()
+        reader = FakeReader(self.clock, self.account)
+        reader.query_behaviors["94"] = BrokerOrderSnapshot(
+            account=self.account,
+            environment=reader.environment,
+            broker_order_id="94",
+            outcome="OPEN",
+            observed_at=self.clock.now,
+            http_status=200,
+            raw_response_digest="7" * 64,
+            order_payload_hash=order_payload_hash(),
+            complete=True,
+        )
+        restarted, ledger, _ = self.restart(reader=reader)
+
+        restarted.start()
+
+        self.assertEqual(reader.query_calls[0][1], "94")
+        self.assertEqual(
+            ledger.get_intent(submitted.intent_id).last_reconciled_run,
+            "gateway-run-b",
+        )
+
+    def test_not_found_known_order_keeps_gateway_read_only(self):
+        self.submit_success()
+        restarted, _, reader = self.restart()
+
+        with self.assertRaises(GatewayReconciliationRequired):
+            restarted.start()
+
+        self.assertEqual(reader.query_calls[0][1], "94")
+
+    def test_incomplete_capacity_blocks_before_any_preview(self):
+        self.reader.capacity_complete = False
+
+        with self.assertRaises(GatewayValidationError):
+            self.gateway.submit_opening(self.command())
+
+        self.assertEqual(self.harness.calls, [])
+
+    def test_gateway_owned_risk_ceiling_cannot_be_raised_by_a_command(self):
+        limited = EtradeOrderGateway(
+            runtime_safety=self.boundary,
+            ledger=self.ledger,
+            transport=self.transport,
+            reader=self.reader,
+            opening_risk_budget=Decimal("600"),
+            clock=self.clock,
+        )
+        limited.start()
+        self.harness.add(preview_result(), place_result())
+        limited.submit_opening(self.command())
+
+        with self.assertRaises(OrderIntentReservationError):
+            limited.submit_opening(
+                self.command(key="order-2", decision="decision-2")
+            )
+
+        self.assertNotIn(
+            "risk_budget",
+            SubmitOpeningCommand.__dataclass_fields__,
+        )
+        self.assertEqual(self.harness.count("/orders/place"), 1)
+
+    def test_strict_command_json_rejects_duplicates_and_nonfinite_values(self):
+        for raw in (
+            b'{"securityType":"OPTN","securityType":"OPTN"}',
+            b'{"limitPrice":NaN}',
+        ):
+            with self.subTest(raw=raw):
+                with self.assertRaises(GatewayValidationError):
+                    self.gateway.submit_opening(
+                        replace(self.command(), payload_bytes=raw)
+                    )
+        self.assertEqual(self.harness.calls, [])
+
+    def test_account_or_boundary_mismatch_is_rejected_before_mutation(self):
+        other_reader = FakeReader(
+            self.clock,
+            SelectedBrokerAccount(
+                "999999999", "other-key", INSTITUTION_TYPE
+            ),
+        )
+        with self.assertRaises(RuntimeSafetyError):
+            EtradeOrderGateway(
+                runtime_safety=self.boundary,
+                ledger=self.ledger,
+                transport=self.transport,
+                reader=other_reader,
+                opening_risk_budget=Decimal("2000"),
+                clock=self.clock,
+            ).start()
+        other_ledger = OrderIntentLedger(
+            Path(self.temporary.name) / "other" / "orders.sqlite3",
+            clock=self.clock,
+            run_id="other-run",
+        )
+        with self.assertRaises(GatewayValidationError):
+            EtradeOrderGateway(
+                runtime_safety=self.boundary,
+                ledger=other_ledger,
+                transport=self.transport,
+                reader=self.reader,
+                opening_risk_budget=Decimal("2000"),
+                clock=self.clock,
+            )
+        with self.assertRaises(GatewayValidationError):
+            EtradeOrderGateway(
+                runtime_safety=self.boundary,
+                ledger=self.ledger,
+                transport=self.transport,
+                reader=FakeReader(
+                    self.clock, self.account, "production"
+                ),
+                opening_risk_budget=Decimal("2000"),
+                clock=self.clock,
+            )
+        self.assertEqual(self.harness.calls, [])
+
+    def test_gateway_owns_no_duplicate_post_state_transitions(self):
+        source = inspect.getsource(gateway_module)
+        self.assertNotIn(".begin_submission(", source)
+        self.assertNotIn(".begin_amendment(", source)
+        self.assertNotIn(".record_post_acknowledgement(", source)
+        self.assertNotIn(".record_amendment_acknowledgement(", source)
+
+    def test_gateway_result_repr_redacts_broker_identifiers(self):
+        result = self.submit_success()
+        rendered = repr(result)
+        self.assertNotIn("client_order_id=", rendered)
+        self.assertNotIn("broker_order_id=", rendered)
+        self.assertNotIn("preview_id=", rendered)
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/etrade_python_client/tests/test_order_intent_ledger.py
+++ b/etrade_python_client/tests/test_order_intent_ledger.py
@@ -619,6 +619,22 @@ class OrderIntentLedgerTests(unittest.TestCase):
         with self.assertRaises(OrderIntentReservationError):
             self.ledger.reserve_margin(blocked.intent_id, risk(blocked, self.clock))
 
+    def test_identical_equal_time_capacity_is_idempotent_but_conflict_fails(self):
+        snapshot = capacity(self.clock)
+
+        self.assertEqual(
+            self.ledger.set_reservation_cap(snapshot),
+            Decimal("1000"),
+        )
+        self.assertEqual(
+            self.ledger.set_reservation_cap(snapshot),
+            Decimal("1000"),
+        )
+        with self.assertRaises(OrderIntentIntegrityError):
+            self.ledger.set_reservation_cap(
+                capacity(self.clock, digest="d" * 64)
+            )
+
     def test_reservation_requires_the_capacity_snapshot_used_for_its_portfolio_risk(self):
         record = self.ledger.create_intent(make_intent()).intent
         self.ledger.set_reservation_cap(capacity(self.clock, digest="d" * 64))


### PR DESCRIPTION
## Summary
- compose the exact hardened transport, durable intent ledger, runtime boundary, and environment-bound read contract
- add opening submission and price-only amendment orchestration with a gateway-owned risk ceiling
- reconcile only durably known broker IDs whose normalized economic terms match the original or amendment authorization
- retain unknown/no-ID results and terminal exposure as hard blockers; make completed amendment replay idempotent without another PUT
- update architecture and reliability documentation

## Safety boundary
This slice is intentionally not wired into the live agent. Live composition remains blocked until an origin-bound durable E*TRADE reader, position absorption, cancellation/closing protocols, and a static legacy-mutation ban are delivered.

## Verification
- 88 focused gateway/transport/ledger tests passed in a clean stacked worktree
- 253 repository tests passed in the working workspace
- independent adversarial reviews found no remaining P0/P1 mutation-state defect in this isolated slice

A clean full-suite checkout still exposes the pre-existing dependency packaging gap for yfinance; that remains assigned to the packaging/lock slice.