### PR TITLE
R7d: add durable E*TRADE broker reader

### DIFF
--- a/etrade_python_client/RELIABILITY.md
+++ b/etrade_python_client/RELIABILITY.md
@@ -71,8 +71,9 @@ For every reliability incident:
 - Production startup requires an exact account ID, account key, and institution
   type plus an owner-only, signed, short-lived arm document bound to the same
   identity. The arm and identity must be revalidated after account refresh and
-  immediately before every order API call. R7 must preserve that invariant
-  while replacing the compatibility guard with one durable mutation gateway.
+  immediately before every order API call. The isolated R7 stack preserves
+  that invariant; future live composition must replace the compatibility guard
+  with that durable gateway as the sole mutation owner.
 - Every broker mutation must have one durable, uniquely fenced send claim
   before I/O and one parsed response receipt before acknowledgement. An
   ambiguous send is reconciliation-only and is never retried. A broker query
@@ -497,7 +498,8 @@ finding.
     metadata for order payloads, account/order response bodies, and
     account-bearing URLs.
 - `live_trading/order_intent_ledger.py`,
-  `live_trading/etrade_broker_transport.py`, and
+  `live_trading/etrade_broker_transport.py`,
+  `live_trading/etrade_broker_reader.py`, and
   `live_trading/etrade_order_gateway.py`
   - Persist immutable intent, reservation, authorization, exact send, preview,
     and parsed-response evidence.
@@ -507,8 +509,18 @@ finding.
     broker ID plus exact canonical order-term hash before reconciliation.
   - Revalidate the exact runtime/account/environment around each mutation and
     enforce a gateway-owned account risk ceiling.
-  - Remain intentionally disconnected from the live agent until the read side
-    and migration gates below are complete.
+  - Pin every broker GET to the configured origin and exact account, bound its
+    execution and retained bytes, disable redirects/retries/ambient session
+    state, and persist the raw response before any normalized result can leave
+    the reader.
+  - Independently replay the installed strict parser over each retained
+    response, then accept capacity only from a content-addressed schema-11
+    manifest containing two complete economically identical account scans.
+    Reconciliation uses only a direct query for the already durable broker
+    order ID.
+  - Remain intentionally disconnected from the live agent until the remaining
+    position, closing, cancellation, composition, and operational migration
+    gates below are complete.
 - `live_trading/etrade_check_option.py` and
   `live_trading/etrade_option_chains.py`
   - Remove hardcoded OAuth credentials from the current source and require
@@ -517,15 +529,14 @@ finding.
 ### Remaining risk
 
 This is containment in the current source, not production readiness. The
-compatibility order client still owns current live calls. The isolated R7a–R7c
-stack now provides a schema 10 intent ledger, hardened mutation transport, and
-opening/reprice coordinator, but no live code instantiates it.
+compatibility order client still owns current live calls. The isolated R7a–R7d
+stack now provides a schema-11 intent ledger, hardened mutation transport,
+origin-bound durable reader, and opening/reprice coordinator, but no live code
+instantiates it.
 
-The next gate is a concrete private E*TRADE reader with complete pagination,
-stable two-pass capacity snapshots, origin-bound durable raw/parser receipts,
-and atomic reconciliation evidence. Position absorption, closing capacity,
-durable per-intent cancellation, a single production composition root, and a
-static ban on every direct legacy mutation path also remain required.
+Position-bound fill absorption, closing capacity, durable per-intent
+cancellation, a single production composition root, and a static ban on every
+direct legacy mutation path remain required.
 
 The exposed OAuth keys still require external revocation and rotation. A later
 coordinated history purge must remove them from all refs and arrange cleanup of
@@ -547,15 +558,23 @@ deployed dashboard has not been reloaded or visually inspected with R6.
   files, guarded response/request logging, order calls without a boundary,
   placement-time arm expiry, dashboard credential rejection, and loopback/CORS
   behavior.
-- The current R7 ledger/transport/coordinator focused suite includes 88
-  deterministic tests for immutable identity, exact authorization/XML,
+- The current R7 ledger/reader/transport/coordinator focused suite includes
+  112 deterministic tests for immutable identity, exact authorization/XML,
   transport deadlines, send fencing, parsed receipts, crash/timeout recovery,
   capacity arithmetic, gateway-owned risk ceilings, environment/account
-  binding, exact order-term reconciliation, amendment replay, terminal-risk
-  retention, and additive schema 8→9→10 migration. Independent adversarial
-  reviews found no remaining reproducible P0/P1 mutation-state defect in the
-  isolated stack; they explicitly retain a no-go on live wiring until the
-  durable reader and remaining protocols are delivered.
+  binding, strict raw-response replay, pagination/marker completeness,
+  two-scan stability, exact order-term reconciliation, amendment replay,
+  terminal-risk retention, and additive schema 8→9→10→11 migration.
+  Independent adversarial review found and closed fail-open handling for
+  replacement-linked and partially filled terminal orders; both now remain
+  unresolved. The review explicitly retains a no-go on live wiring until the
+  remaining position, closing, cancellation, and composition protocols are
+  delivered.
+- The maintained `tests/` suite passes 277 tests in the clean Python 3.10
+  environment. An unscoped repository-root pytest invocation still
+  mis-collects two legacy `scratch/test_delta_*` research scripts and triggers
+  import-time market-data behavior; the reproducible-build/CI gate must
+  constrain collection and remove those import side effects.
 - Deployment verification is deliberately recorded as incomplete. This
   incident remains open until the remaining-risk conditions above are
   satisfied.

--- a/etrade_python_client/docs/order_intent_ledger.md
+++ b/etrade_python_client/docs/order_intent_ledger.md
@@ -1,16 +1,18 @@
 # Durable Order Intent Ledger
 
-**Delivery status:** R7a ledger + R7b transport + R7c coordinator, isolated
+**Delivery status:** R7a ledger + R7b transport + R7c coordinator + R7d
+durable reader, isolated
 
 **Production status:** not connected to live E*TRADE mutation paths
 
 `live_trading/order_intent_ledger.py` is the durable, broker-agnostic state
 machine for order identity, capacity reservation, fencing, and ambiguous broker
-outcomes. It performs no network I/O. `etrade_broker_transport.py` now owns the
-reviewed no-retry mutation exchange, and `etrade_order_gateway.py` coordinates
-opening submissions, price-only amendments, and restart reconciliation. The
-live agent still instantiates none of them, so this stack does not yet protect
-the current legacy order paths.
+outcomes. It performs no network I/O. `etrade_broker_transport.py` owns the
+reviewed no-retry mutation exchange, `etrade_broker_reader.py` owns the exact
+origin-bound GET surface, and `etrade_order_gateway.py` coordinates opening
+submissions, price-only amendments, and restart reconciliation. The live agent
+still instantiates none of them, so this stack does not yet protect the current
+legacy order paths.
 
 ## Supported scope
 
@@ -70,9 +72,10 @@ remains blocked rather than guessed or retried.
   evidence. The caller's asserted maximum loss cannot be below the exposure
   derived from strike width, price, contract multiplier, and quantity.
 - An opening terminal state retains its reservation as
-  `FILLED_PENDING_ABSORPTION`. R7a never releases it: neither a newer timestamp
-  nor a different account digest proves that a specific partial or terminal
-  fill is reflected in positions. R7b must add order-bound position evidence.
+  `FILLED_PENDING_ABSORPTION`. The schema-11 R7a–R7d stack never releases it:
+  neither a newer timestamp nor a different account digest proves that a
+  specific partial or terminal fill is reflected in positions. A later
+  position-absorption slice must add order-bound position evidence.
 - Evidence dataclasses and their security-critical string, timestamp, integer,
   byte, and `Decimal` fields must use exact built-in types. Subclass overrides
   cannot replace validation or comparison behavior.
@@ -85,19 +88,37 @@ remains blocked rather than guessed or retried.
   Strategy commands cannot raise it. Reconciliation requires the reader's
   normalized order payload to match the durable original, pending amendment, or
   latest completed amendment hash.
+- Capacity can be set only from a content-addressed schema-11 manifest. A
+  complete manifest brackets two independent scans with exact account-list
+  reads; fully traverses balance, every portfolio page, and all reviewed active
+  order status lanes; and requires both economic scans to match. Moving balance
+  effective timestamps are freshness-checked separately from economic
+  stability.
+- Every usable broker GET is pinned to the configured E*TRADE origin and exact
+  account, has no redirects/retries/ambient session state, runs in a bounded
+  disposable process, and is persisted before its result can leave the reader.
+  The ledger deterministically reruns the installed parser over the raw bytes
+  before accepting the normalized receipt.
+- Known-order reconciliation performs only the direct lookup for the already
+  durable broker order ID. A 404, partial fill, replacement ambiguity, payload
+  mismatch, or undocumented shape remains unresolved and cannot clear a
+  blocker.
 - Order events, broker-order history, amendment history, outbound
-  authorizations, transport attempts, preview receipts, and response receipts
-  are append-only.
+  authorizations, transport attempts, preview receipts, mutation responses,
+  broker-read responses, read manifests, and capacity decisions are
+  append-only.
 - The ledger database must live in an owner-only `0700` directory and remain an
   owner-only regular `0600` file. SQLite sidecars receive the same validation.
 
 ## Schema policy
 
-Schema 10 adds append-only transport attempts, broker-preview receipts, and
-parsed transport-response receipts. Additive schema 8→9→10 migration is
-restart-safe and tested. Unknown versions fail closed. Before any production
-migration, the operator runbook must add an atomic backup, integrity check,
-rollback exercise, and an explicit version-by-version migration.
+Schema 11 adds raw broker-read receipts, ordered semantic manifests, durable
+capacity decisions, and provenance foreign keys on caps, reservations, and
+events. Additive schema 8→9→10→11 migration is one explicit SQLite transaction
+and verifies required columns, foreign keys, append-only triggers, journal
+mode, foreign-key integrity, and `quick_check` before version promotion.
+Unknown or malformed schemas fail closed. A production operator must still
+take an atomic private backup and complete a rollback drill before migration.
 
 ## Remaining production release gates
 
@@ -105,29 +126,25 @@ The isolated R7 stack must not be used as evidence that live execution is
 production-ready. The following remain required before any order-capable
 process is enabled:
 
-1. A concrete private reader must pin the exact E*TRADE origin, runtime
-   boundary, environment, and account; completely paginate account/order data;
-   persist origin-bound raw/parser receipts; and atomically bind durable read
-   evidence to reconciliation and capacity decisions.
-2. Position-level fill evidence must safely absorb terminal opening
+1. Position-level fill evidence must safely absorb terminal opening
    reservations, including partial fills, replacements, assignment/exercise,
    and zero-fill proof for cancelled/rejected/expired orders.
-3. Closing-position capacity and one-shot per-intent cancellation need durable,
+2. Closing-position capacity and one-shot per-intent cancellation need durable,
    crash-tested protocols. Bulk cancellation remains disabled.
-4. The live composition root must construct the exact ledger, reader,
+3. The live composition root must construct the exact ledger, reader,
    transport, and coordinator, and static enforcement must reject direct legacy
    order mutations outside that root.
-5. Sandbox restart/crash fixtures must cover pagination drift, stale evidence,
+4. Sandbox restart/crash fixtures must cover pagination drift, stale evidence,
    every nonterminal/terminal broker status, replacement chains, cancellation,
    closing, and process death at each durable/I/O boundary.
-6. Operational migration needs a private database backup, integrity check,
+5. Operational migration needs a private database backup, integrity check,
    rollback drill, credential rotation/history purge, deployment restart, and
    observation of the exact served/live artifacts.
 
-The current focused ledger/transport/coordinator suite contains 88 deterministic
-tests. Independent adversarial reviews found no remaining reproducible
-mutation-core path to double-submit, exceed the gateway-owned reservation
-ceiling, release opening exposure early, reuse an identifier, substitute a
-different authorized economic payload, or clear an amendment merely because
-the old broker order is still open. This is source verification only; the
-durable reader and live migration gates above remain open.
+The focused ledger/reader/transport/coordinator suites exercise raw-parser
+binding, pagination and marker drift, two-scan stability, schema rollback,
+exact payload reconciliation, mutation fencing, and crash/timeout behavior.
+They contain 112 deterministic tests; the maintained repository `tests/` suite
+contains 277 passing tests in the clean Python 3.10 environment. This is source
+verification only; position, cancellation/closing, live composition, and
+operational migration gates above remain open.

--- a/etrade_python_client/docs/production_readiness_upgrade_plan.md
+++ b/etrade_python_client/docs/production_readiness_upgrade_plan.md
@@ -61,15 +61,17 @@ current source:
   quarantined.
 
 These changes do **not** satisfy Phase 0 or make the repository production
-ready. The existing order paths are guarded but not yet centralized, so R7 must
-preserve the arm/account check in a sole mutation owner and add durable
-idempotency, capacity reservations, and reconciliation. The current local dashboard settings
-are intentionally rejected until stronger credentials are provisioned. The
-repository is public, and OAuth keys retained in public Git history must be
-treated as compromised: external revoke/rotate is required, followed by a
-coordinated history purge and downstream cleanup. No live service restart,
-deployment, E*TRADE mutation, or exact served-dashboard verification has been
-performed for R6.
+ready. The existing order paths are guarded but not yet centralized. R7a–R7d
+preserve the arm/account check and add isolated durable intent identity,
+capacity reservations, mutation fencing, direct known-order reconciliation,
+and raw read provenance, but no live caller is composed through that stack.
+The current local dashboard settings are intentionally rejected until stronger
+credentials are provisioned. GitHub reports the repository as public on
+2026-07-26, and OAuth keys retained in its public history must be treated as
+compromised: external revoke/rotate is required, followed by a coordinated
+history purge and downstream cleanup. No live service restart, deployment,
+E*TRADE mutation, or exact served-dashboard verification has been performed
+for R6.
 
 ## What is worth preserving
 
@@ -290,13 +292,16 @@ explicit environment selection; exact production account identity; a
 versioned, signed arm document with a maximum 15-minute lifetime; refresh-time
 and order-call revalidation; strong dashboard credential validation; and
 owner-only local files. It does not yet provide the complete typed
-configuration model or an OS secret-store integration. Its compatibility
-order guard does not replace the R7 requirement for a durable single placement
-gateway with stable intent identity and reconciliation.
+configuration model or an OS secret-store integration. The isolated R7
+gateway, transport, reader, and ledger now provide stable intent identity and
+durable reconciliation evidence, but live composition and static enforcement
+must still replace the compatibility order paths.
 
 ### Boundary 2: E*TRADE gateway
 
-Only this module may make broker HTTP calls. It owns:
+One private gateway owns the broker boundary. Its read adapter and mutation
+transport are the only modules below that gateway permitted to make broker
+HTTP calls. Together they own:
 
 - OAuth lifecycle and environment binding.
 - Connect/read/total deadlines.
@@ -304,11 +309,15 @@ Only this module may make broker HTTP calls. It owns:
   `Partial`, `Unauthorized`, `RateLimited`, `TransientFailure`, and
   `PermanentFailure` outcomes.
 - Complete pagination and request-volume budgets.
-- Bounded retries for safe reads.
+- One recorded exchange per read attempt; callers may begin a new attempt only
+  from durable state, never through hidden transport retries.
 - No blind retry of mutating POSTs.
 - Redacted structured logging and correlation IDs.
-- `place_once(intent_id)`: query/reconcile the stable client ID before any retry
-  after an unknown response.
+- `place_once(intent_id)`: an unknown response with a durable broker ID is
+  reconciled by direct ID lookup before any further mutation. Because E*TRADE
+  does not echo the client order ID, an unknown response without a durable
+  broker ID remains blocked for supervised resolution and is never guessed or
+  retried.
 
 ### Boundary 3: canonical snapshots
 
@@ -378,6 +387,12 @@ PROPOSED
 intent, idempotency key, preview, broker IDs, price budget, every transition,
 actor, timestamps, retries, and reconciliation generation. Repricing has one
 owner and absolute slippage/debit/credit/time limits.
+
+Implementation status: schema 11 currently supports isolated opening and
+price-only reprice flows with `INTENT`, `CLAIMED`, `FAILED`,
+`SUBMISSION_UNKNOWN`, `SUBMITTED`, and terminal states. Terminal-fill
+absorption, new closing intents, cancellation, and live composition remain
+fail-closed release gates.
 
 ### Boundary 6: deterministic backtesting
 
@@ -500,6 +515,12 @@ Exit gate:
 
 ### Phase 2 — broker and snapshot foundations (weeks 2–3)
 
+Status: partially delivered. R7b–R7d provide the isolated bounded mutation
+transport, strict origin-bound reader, durable raw/parser receipts, explicit
+pagination, and two-scan capacity manifests. Shared OAuth recovery, general
+snapshot read models, health/readiness, graceful shutdown, metrics, and live
+composition remain open.
+
 Deliver:
 
 1. Extract the typed E*TRADE gateway.
@@ -519,6 +540,12 @@ Exit gate:
 - `SIGTERM` drains or durably records in-flight work within 30 seconds.
 
 ### Phase 3 — durable live control plane (weeks 3–5)
+
+Status: partially delivered. R7a–R7d provide the schema-11 ledger, stable
+opening intent identity, outbox-style send claims, reconciliation, capacity
+reservations, and a single isolated reprice owner. Fill absorption,
+closing/cancellation, the broader pure risk policy, process decomposition,
+dashboard command routing, and hardened live deployment remain open.
 
 Deliver:
 
@@ -641,19 +668,20 @@ boundaries are extracted. Remove old paths only after golden tests and
 shadow-parity prove equivalent intended behavior.
 
 The current stacked delivery names the source-level startup containment slice
-R6. R7a now implements the isolated durable order-intent foundation: strict
-vertical-spread validation, stable intent/client identity, capacity
+R6. R7a–R7d now implement an isolated schema-11 execution core: strict
+vertical-spread validation, stable intent/client identity, durable capacity
 reservations, monotonic submission/amendment fences, exact immutable outbound
-authorization, and reconciliation-only ambiguous outcomes. Its schema 9 ledger
-performs no network I/O and no live caller instantiates it. New closing orders
-and terminal reservation absorption deliberately fail closed until R7b adds
-position-level evidence.
+authorization, a no-retry mutation transport, an opening/reprice coordinator,
+and an origin-bound durable E*TRADE reader. The reader records bounded raw
+responses, the ledger independently replays their strict parser, and capacity
+or reconciliation can use only a semantically complete content-addressed
+manifest. No live caller instantiates this stack.
 
-R7b is therefore still the next production safety boundary: centralize every
-placement, amendment, and cancellation under one private E*TRADE gateway;
-preserve the arm/account check at the mutation boundary; derive broker evidence
-inside that gateway; reconcile all startup blockers; and statically prohibit
-direct legacy mutation calls. See `docs/order_intent_ledger.md`.
+The next R7 safety boundary is position-bound terminal-fill absorption,
+followed by closing-position capacity and one-shot per-intent cancellation.
+Only after those protocols pass restart/crash tests may the live composition
+root own the gateway and static enforcement prohibit every direct legacy
+mutation call. See `docs/order_intent_ledger.md`.
 
 ## Test and verification matrix
 
@@ -704,11 +732,12 @@ R6 has not restarted or inspected the deployed dashboard, called E*TRADE, or
 exercised a live/sandbox mutation. Current-source credential removal also does
 not establish secret hygiene while the repository remains public and the old
 keys remain in Git history. External revoke/rotate, coordinated history purge,
-strong local credential reprovisioning, R7b durable gateway enforcement, and
-deployment verification remain required. R7a's isolated ledger passed 32
-focused tests and independent causal/security review, but it has no production
-call site and is not live-execution evidence. The remaining actions belong to
-the staged acceptance gates above.
+strong local credential reprovisioning, the remaining R7
+position/closing/cancellation protocols, durable-gateway composition, and
+deployment verification remain required. The isolated R7a–R7d stack has
+focused deterministic coverage and independent causal/security review, but it
+has no production call site and is not live-execution evidence. The remaining
+actions belong to the staged acceptance gates above.
 
 The working tree was already heavily modified and contains important untracked
 runtime sources. This review intentionally adds only this plan and does not

--- a/etrade_python_client/docs/project_overview.md
+++ b/etrade_python_client/docs/project_overview.md
@@ -152,7 +152,7 @@ flowchart LR
     LEDGER["R7a Order Intent Ledger<br/>(Implemented, Isolated)"]
     TRANSPORT["R7b Mutation Transport<br/>(Implemented, Isolated)"]
     GATE["R7c Order Gateway<br/>(Implemented, Isolated)"]
-    READER["Durable E*TRADE Reader<br/>(Required Before Live Wiring)"]
+    READER["R7d Durable E*TRADE Reader<br/>(Implemented, Isolated)"]
     BROKER["E*TRADE"]
 
     CLI --> SAFE
@@ -163,10 +163,12 @@ flowchart LR
     ACCOUNT --> DIRECT
     DIRECT -->|"current, guarded but non-durable"| BROKER
     DIRECT -.->|"future migration"| GATE
-    LEDGER --> GATE
-    LEDGER --> TRANSPORT
-    READER -.->|"not implemented yet"| GATE
+    GATE -->|"intent, reservation, reconciliation"| LEDGER
+    GATE -->|"capacity and known-order reads"| READER
     GATE --> TRANSPORT
+    READER -->|"append-only raw receipts + manifests"| LEDGER
+    TRANSPORT -->|"send claims + mutation receipts"| LEDGER
+    READER -.->|"bounded origin-pinned GETs; not connected yet"| BROKER
     TRANSPORT -.->|"not connected yet"| BROKER
 ```
 
@@ -177,10 +179,13 @@ mutation transport that claims every send before broker I/O and persists parsed
 responses. R7c composes those components into an opening/reprice coordinator
 with a gateway-owned risk ceiling, exact environment/account binding,
 restart reconciliation, and exact economic-term comparison. No live code
-instantiates this stack. A concrete origin-bound reader with durable raw and
-parsed receipts, position absorption, cancellation/closing protocols, and
-removal of legacy mutation paths remain mandatory before live wiring. The
-deployed service has not been restarted or inspected with R6 or R7.
+instantiates this stack. R7d adds the concrete origin-bound reader: every
+usable GET is durably recorded as bounded raw bytes, independently reparsed by
+the ledger, and grouped into a semantically complete manifest before it can
+authorize capacity or reconciliation. Position absorption,
+cancellation/closing protocols, the single live composition root, and removal
+of legacy mutation paths remain mandatory before live wiring. The deployed
+service has not been restarted or inspected with R6 or R7.
 
 ---
 
@@ -223,10 +228,11 @@ shadow/research-only and cannot affect E*TRADE order eligibility.
 ### 3. Live Runtime Safety
 
 *   **Runtime Safety Boundary** ([`runtime_safety.py`](file:///Users/btian/EtradePythonClient/etrade_python_client/live_trading/runtime_safety.py)): Resolves an explicit `sandbox` or `production` environment before OAuth construction. Production requires an exact account identity plus a versioned, signed arm file with a bounded lifetime; unsafe, missing, mismatched, future, or expired proof fails closed. The operator CLI writes the arm atomically as an owner-only file without accepting the signing secret as a command-line argument.
-*   **Account Identity Revalidation** ([`accounts_bo.py`](file:///Users/btian/EtradePythonClient/etrade_python_client/accounts/accounts_bo.py), [`order_bo.py`](file:///Users/btian/EtradePythonClient/etrade_python_client/order/order_bo.py)): Selects production accounts by exact account ID, account key, and institution type instead of a mutable list index. The live process revalidates the armed identity after startup and account refresh, and the compatibility order client repeats it immediately before every order API call. R7 must preserve the check inside the durable single mutation gateway.
+*   **Account Identity Revalidation** ([`accounts_bo.py`](file:///Users/btian/EtradePythonClient/etrade_python_client/accounts/accounts_bo.py), [`order_bo.py`](file:///Users/btian/EtradePythonClient/etrade_python_client/order/order_bo.py)): Selects production accounts by exact account ID, account key, and institution type instead of a mutable list index. The live process revalidates the armed identity after startup and account refresh, and the compatibility order client repeats it immediately before every order API call. The isolated R7 reader, gateway, and transport preserve the same boundary; future live composition must make that gateway the sole mutation owner.
 *   **Durable Order Intent Ledger** ([`order_intent_ledger.py`](file:///Users/btian/EtradePythonClient/etrade_python_client/live_trading/order_intent_ledger.py), [`order_intent_ledger.md`](file:///Users/btian/EtradePythonClient/etrade_python_client/docs/order_intent_ledger.md)): R7a provides strict vertical-spread validation, account capacity reservations, stable identifiers, monotonic submission/amendment fences, immutable outbound authorizations, exact send/response receipts, and reconciliation-only handling after an ambiguous mutation.
 *   **Hardened Mutation Transport** ([`etrade_broker_transport.py`](file:///Users/btian/EtradePythonClient/etrade_python_client/live_trading/etrade_broker_transport.py)): R7b is the only reviewed adapter permitted to derive E*TRADE mutation XML from a durable authorization. It disables ambient proxies, cookies, hooks, redirects, and retries; revalidates the armed account; claims the exact send before I/O; bounds the exchange in an isolated process; and records the parsed result before returning.
-*   **Order Gateway** ([`etrade_order_gateway.py`](file:///Users/btian/EtradePythonClient/etrade_python_client/live_trading/etrade_order_gateway.py)): R7c coordinates opening submissions and price-only amendments through the exact transport. Startup stays read-only until every known broker order is reconciled, unknown responses without a broker ID remain permanent blockers, returned order terms must hash to the durable authorization, and an immutable gateway policy—not a strategy command—sets the account risk ceiling. This component remains intentionally unreachable from the live agent until the durable broker reader and remaining execution protocols are delivered.
+*   **Order Gateway** ([`etrade_order_gateway.py`](file:///Users/btian/EtradePythonClient/etrade_python_client/live_trading/etrade_order_gateway.py)): R7c coordinates opening submissions and price-only amendments through the exact transport. Startup stays read-only until every known broker order is reconciled, unknown responses without a broker ID remain permanent blockers, returned order terms must hash to the durable authorization, and an immutable gateway policy—not a strategy command—sets the account risk ceiling. This component remains intentionally unreachable from the live agent until position absorption, closing/cancellation, live composition/static enforcement, and operational validation are delivered.
+*   **Durable E*TRADE Reader** ([`etrade_broker_reader.py`](file:///Users/btian/EtradePythonClient/etrade_python_client/live_trading/etrade_broker_reader.py)): R7d performs only exact origin-pinned, no-retry GETs in bounded disposable processes. It rebinds the configured account before and after a read, traverses explicit portfolio pages and reviewed active-order marker lanes, requires two economically identical capacity scans, and persists raw response bytes plus parser and request provenance before returning a content-addressed manifest. Known-order reconciliation uses only a direct lookup of the durable broker order ID; missing, incomplete, ambiguous, or mismatched evidence remains blocked.
 *   **Dashboard Containment** ([`etrade_cover_call_new.py`](file:///Users/btian/EtradePythonClient/etrade_python_client/live_trading/etrade_cover_call_new.py)): Serves the order-capable dashboard on loopback only, does not start ngrok automatically, and does not grant wildcard CORS. Startup rejects default or weak dashboard credentials, while local settings and touched logs use owner-only file handling.
 *   **Credential Source Cleanup** ([`etrade_check_option.py`](file:///Users/btian/EtradePythonClient/etrade_python_client/live_trading/etrade_check_option.py), [`etrade_option_chains.py`](file:///Users/btian/EtradePythonClient/etrade_python_client/live_trading/etrade_option_chains.py)): Removes hardcoded OAuth credentials from the current source and requires local configuration or environment variables. Because the repository is currently public and those values remain in Git history, the affected keys must be treated as compromised until they are revoked and rotated externally; a coordinated history purge remains separate follow-up work.
 

--- a/etrade_python_client/live_trading/etrade_broker_reader.py
+++ b/etrade_python_client/live_trading/etrade_broker_reader.py
@@ -1,0 +1,2193 @@
+"""Origin-bound, durable, read-only E*TRADE broker evidence.
+
+Every usable result is assembled from immutable raw-response receipts in the
+order ledger.  The reader exposes no generic HTTP method and never retries,
+follows broker-provided links, or authorizes a mutation.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import threading
+from dataclasses import dataclass
+from datetime import datetime, timedelta, timezone
+from decimal import Decimal, InvalidOperation
+from pathlib import Path
+from typing import Any, Callable, Literal
+from urllib.parse import quote, urlencode, urlsplit
+
+from rauth import OAuth1Session
+from rauth.utils import CaseInsensitiveDict, OAuth1Auth
+from requests import Request
+
+from live_trading.etrade_broker_transport import (
+    SelectedBrokerAccount,
+    _ExchangeResult,
+    _isolated_exchange,
+)
+from live_trading.order_intent_ledger import (
+    BrokerReadEvidenceRef,
+    BrokerReadManifestEvidence,
+    BrokerReadManifestMember,
+    BrokerReadReceiptRef,
+    BrokerReadResponseEvidence,
+    OrderIntentLedger,
+    canonical_order_payload_hash,
+)
+from live_trading.runtime_safety import (
+    RuntimeSafetyBoundary,
+    RuntimeSafetyError,
+)
+
+
+_ETRADE_ORIGINS = {
+    "sandbox": "https://apisb.etrade.com",
+    "production": "https://api.etrade.com",
+}
+_TOTAL_EXCHANGE_TIMEOUT_SECONDS = 15.0
+_MAX_RAW_RESPONSE_BYTES = 2 * 1024 * 1024
+_MAX_BALANCE_AGE_SECONDS = 300
+_MAX_JSON_NODES = 50_000
+_MAX_JSON_DEPTH = 48
+_MAX_PORTFOLIO_PAGES = 100
+_MAX_POSITIONS = 5_000
+_MAX_ORDER_PAGES = 100
+_MAX_ORDERS = 10_000
+_MAX_BROKER_INT64 = 9_223_372_036_854_775_807
+_ACTIVE_ORDER_STATUSES = (
+    "OPEN",
+    "CANCEL_REQUESTED",
+    "INDIVIDUAL_FILLS",
+)
+_PARSER_SCHEMA = "etrade-broker-reader.v1"
+_PARSER_CODE_SHA256 = hashlib.sha256(Path(__file__).read_bytes()).hexdigest()
+_PARSER_CONFIG_SHA256 = hashlib.sha256(
+    json.dumps(
+        {
+            "active_statuses": _ACTIVE_ORDER_STATUSES,
+            "max_json_depth": _MAX_JSON_DEPTH,
+            "max_json_nodes": _MAX_JSON_NODES,
+            "max_order_pages": _MAX_ORDER_PAGES,
+            "max_orders": _MAX_ORDERS,
+            "max_portfolio_pages": _MAX_PORTFOLIO_PAGES,
+            "max_positions": _MAX_POSITIONS,
+            "max_raw_response_bytes": _MAX_RAW_RESPONSE_BYTES,
+        },
+        sort_keys=True,
+        separators=(",", ":"),
+    ).encode("ascii")
+).hexdigest()
+
+
+class ETradeBrokerReaderError(RuntimeError):
+    """Base class for fail-closed broker read failures."""
+
+
+class ETradeBrokerReaderUnavailable(ETradeBrokerReaderError):
+    """The broker did not yield complete usable evidence."""
+
+
+class ETradeBrokerReaderIntegrityError(ETradeBrokerReaderError):
+    """A response or durable receipt violated the closed contract."""
+
+
+@dataclass(frozen=True)
+class _AccountBinding:
+    account_id: str
+    account_id_key: str
+    institution_type: str
+    account_status: Literal["ACTIVE"]
+    account_mode: Literal["MARGIN"]
+    account_type: str
+
+
+@dataclass(frozen=True)
+class _ReadResult:
+    parsed: Any
+    receipt: BrokerReadReceiptRef
+    http_status: int
+    raw_response_digest: str
+    completed_at: datetime
+    completeness: Literal["COMPLETE", "HAS_NEXT", "INELIGIBLE"]
+
+
+@dataclass(frozen=True)
+class _CapacityScan:
+    result: dict[str, Any]
+    state_sha256: str
+    members: tuple[BrokerReadManifestMember, ...]
+    completed_at: datetime
+
+
+class ETradeBrokerReader:
+    """Perform exact GETs and return only durable evidence references."""
+
+    def __init__(
+        self,
+        *,
+        session: OAuth1Session,
+        ledger: OrderIntentLedger,
+        runtime_safety: RuntimeSafetyBoundary,
+        selected_account: SelectedBrokerAccount,
+        clock: Callable[[], datetime] | None = None,
+    ) -> None:
+        if type(session) is not OAuth1Session:
+            raise ETradeBrokerReaderError(
+                "broker reader requires an exact rauth OAuth1Session"
+            )
+        if type(ledger) is not OrderIntentLedger:
+            raise ETradeBrokerReaderError(
+                "broker reader requires the exact durable ledger"
+            )
+        if type(runtime_safety) is not RuntimeSafetyBoundary:
+            raise ETradeBrokerReaderError(
+                "broker reader requires an exact runtime safety boundary"
+            )
+        if type(selected_account) is not SelectedBrokerAccount:
+            raise ETradeBrokerReaderError(
+                "broker reader requires an exact selected account"
+            )
+        if (
+            runtime_safety.environment not in _ETRADE_ORIGINS
+            or runtime_safety.expected_account_id is None
+            or runtime_safety.expected_account_id_key is None
+            or runtime_safety.expected_institution_type is None
+        ):
+            raise ETradeBrokerReaderError(
+                "broker reads require an explicitly armed account"
+            )
+        self._clock = clock or (lambda: datetime.now(timezone.utc))
+        now = self._now()
+        runtime_safety.assert_current(now)
+        runtime_safety.verify_account(
+            selected_account.runtime_mapping(), now=now
+        )
+        credentials = (
+            session.consumer_key,
+            session.consumer_secret,
+            session.access_token,
+            session.access_token_secret,
+        )
+        if any(type(value) is not str or not value for value in credentials):
+            raise ETradeBrokerReaderError(
+                "OAuth session lacks exact consumer/access credentials"
+            )
+        self._oauth = OAuth1Session(
+            session.consumer_key,
+            session.consumer_secret,
+            access_token=session.access_token,
+            access_token_secret=session.access_token_secret,
+        )
+        self._oauth.trust_env = False
+        self._oauth.params = {}
+        self._oauth.proxies = {}
+        self._oauth.hooks = {"response": []}
+        self._oauth.cookies.clear()
+        self._oauth.verify = True
+        self._oauth.cert = None
+        self._ledger = ledger
+        self._runtime_safety = runtime_safety
+        self._selected_account = selected_account
+        self._account_id = selected_account.account_id
+        self._account_id_key = selected_account.account_id_key
+        self._institution_type = selected_account.institution_type
+        self._environment = runtime_safety.environment
+        self._origin = _ETRADE_ORIGINS[self._environment]
+        self._read_lock = threading.Lock()
+
+    def assert_gateway_binding(
+        self,
+        ledger: OrderIntentLedger,
+        runtime_safety: RuntimeSafetyBoundary,
+    ) -> None:
+        """Prove the reader shares the exact ledger and runtime boundary."""
+
+        if ledger is not self._ledger or runtime_safety is not self._runtime_safety:
+            raise ETradeBrokerReaderError(
+                "gateway and reader must share exact durable/runtime boundaries"
+            )
+        self._assert_runtime()
+
+    def selected_account(self) -> SelectedBrokerAccount:
+        return SelectedBrokerAccount(
+            self._account_id,
+            self._account_id_key,
+            self._institution_type,
+        )
+
+    def read_capacity(
+        self, account: SelectedBrokerAccount
+    ) -> BrokerReadEvidenceRef:
+        """Return a complete capacity manifest after two identical scans."""
+
+        self._require_account(account)
+        with self._read_lock:
+            self._assert_runtime()
+            binding_start, binding_start_read = self._read_account_binding()
+            scan_a = self._read_capacity_scan(binding_start, "scan_a")
+            scan_b = self._read_capacity_scan(binding_start, "scan_b")
+            binding_end, binding_end_read = self._read_account_binding()
+            if binding_start != binding_end:
+                raise ETradeBrokerReaderIntegrityError(
+                    "account binding changed during capacity read"
+                )
+            if scan_a.state_sha256 != scan_b.state_sha256:
+                raise ETradeBrokerReaderUnavailable(
+                    "capacity state changed between complete scans"
+                )
+            if int(
+                scan_b.result["broker_buying_power_as_of"]
+            ) < int(scan_a.result["broker_buying_power_as_of"]):
+                raise ETradeBrokerReaderIntegrityError(
+                    "balance effective time moved backward between scans"
+                )
+            result = dict(scan_b.result)
+            result["state_sha256"] = scan_b.state_sha256
+            members = (
+                BrokerReadManifestMember(
+                    "binding.start",
+                    binding_start_read.receipt.receipt_sha256,
+                ),
+                *scan_a.members,
+                *scan_b.members,
+                BrokerReadManifestMember(
+                    "binding.end",
+                    binding_end_read.receipt.receipt_sha256,
+                ),
+            )
+            evidence = self._ledger.record_broker_read_manifest(
+                BrokerReadManifestEvidence(
+                    evidence_kind="CAPACITY",
+                    account_id=self._account_id,
+                    account_id_key=self._account_id_key,
+                    institution_type=self._institution_type,
+                    environment=self._environment,
+                    origin=self._origin,
+                    target_broker_order_id=None,
+                    observed_at=binding_end_read.completed_at,
+                    completeness="COMPLETE",
+                    canonical_result_json=_canonical_json(result),
+                ),
+                tuple(members),
+            )
+            self._assert_runtime()
+            return evidence
+
+    def query_order(
+        self,
+        account: SelectedBrokerAccount,
+        broker_order_id: str,
+    ) -> BrokerReadEvidenceRef:
+        """Query exactly one already-known broker ID with no list fallback."""
+
+        self._require_account(account)
+        target = _broker_int64_text(
+            broker_order_id, "broker order id"
+        )
+        with self._read_lock:
+            self._assert_runtime()
+            binding_start, binding_start_read = self._read_account_binding()
+            order_read = self._read_order_detail(target)
+            binding_end, binding_end_read = self._read_account_binding()
+            if binding_start != binding_end:
+                raise ETradeBrokerReaderIntegrityError(
+                    "account binding changed during order query"
+                )
+            parsed = order_read.parsed
+            result = {
+                "schema": "etrade-order-query.v1",
+                "broker_order_id": target,
+                "raw_status": parsed["raw_status"],
+                "outcome": parsed["outcome"],
+                "order_payload_hashes": parsed["order_payload_hashes"],
+                "http_status": order_read.http_status,
+                "raw_response_digest": order_read.raw_response_digest,
+                "not_found": parsed["not_found"],
+                "replacement_links": parsed["replacement_links"],
+            }
+            evidence = self._ledger.record_broker_read_manifest(
+                BrokerReadManifestEvidence(
+                    evidence_kind="ORDER_QUERY",
+                    account_id=self._account_id,
+                    account_id_key=self._account_id_key,
+                    institution_type=self._institution_type,
+                    environment=self._environment,
+                    origin=self._origin,
+                    target_broker_order_id=target,
+                    observed_at=binding_end_read.completed_at,
+                    completeness="COMPLETE",
+                    canonical_result_json=_canonical_json(result),
+                ),
+                (
+                    BrokerReadManifestMember(
+                        "binding.start",
+                        binding_start_read.receipt.receipt_sha256,
+                    ),
+                    BrokerReadManifestMember(
+                        "order.detail",
+                        order_read.receipt.receipt_sha256,
+                    ),
+                    BrokerReadManifestMember(
+                        "binding.end",
+                        binding_end_read.receipt.receipt_sha256,
+                    ),
+                ),
+            )
+            self._assert_runtime()
+            return evidence
+
+    def _read_account_binding(
+        self,
+    ) -> tuple[_AccountBinding, _ReadResult]:
+        read = self._get(
+            read_kind="ACCOUNT_LIST",
+            route="/v1/accounts/list.json",
+            query=(),
+            target_broker_order_id=None,
+            allowed_statuses={200},
+            parser=self._parse_account_list,
+        )
+        parsed = read.parsed
+        binding = _AccountBinding(
+            account_id=parsed["account_id"],
+            account_id_key=parsed["account_id_key"],
+            institution_type=parsed["institution_type"],
+            account_status=parsed["account_status"],
+            account_mode=parsed["account_mode"],
+            account_type=parsed["account_type"],
+        )
+        return binding, read
+
+    def _parse_account_list(
+        self, status: int, raw: bytes
+    ) -> tuple[dict[str, Any], Literal["COMPLETE"]]:
+        if status != 200:
+            raise ETradeBrokerReaderUnavailable(
+                "account list did not return HTTP 200"
+            )
+        document = _strict_json(raw)
+        root = _exact_object(
+            document, {"AccountListResponse"}, "account list root"
+        )["AccountListResponse"]
+        response = _exact_object(
+            root, {"Accounts"}, "AccountListResponse"
+        )
+        accounts_container = _exact_object(
+            response["Accounts"], {"Account"}, "Accounts"
+        )
+        accounts = accounts_container["Account"]
+        if type(accounts) is not list or not accounts:
+            raise ETradeBrokerReaderIntegrityError(
+                "account list must contain a non-empty Account array"
+            )
+        matches: list[dict[str, Any]] = []
+        for value in accounts:
+            account = _object(value, "Account")
+            required = {
+                "accountId",
+                "accountIdKey",
+                "institutionType",
+                "accountStatus",
+                "accountMode",
+                "accountType",
+            }
+            if not required.issubset(account):
+                raise ETradeBrokerReaderIntegrityError(
+                    "account list entry is missing identity/status fields"
+                )
+            normalized = {
+                "account_id": _broker_int64_text(
+                    account["accountId"], "account id"
+                ),
+                "account_id_key": _ascii_text(
+                    account["accountIdKey"], "account key"
+                ),
+                "institution_type": _ascii_text(
+                    account["institutionType"], "institution type"
+                ),
+                "account_status": _ascii_text(
+                    account["accountStatus"], "account status"
+                ),
+                "account_mode": _ascii_text(
+                    account["accountMode"], "account mode"
+                ),
+                "account_type": _ascii_text(
+                    account["accountType"], "account type"
+                ),
+            }
+            if (
+                normalized["account_id"] == self._account_id
+                and normalized["account_id_key"] == self._account_id_key
+                and normalized["institution_type"]
+                == self._institution_type
+            ):
+                matches.append(normalized)
+        if len(matches) != 1:
+            raise ETradeBrokerReaderIntegrityError(
+                "account list did not yield exactly one configured account"
+            )
+        match = matches[0]
+        if (
+            match["account_status"] != "ACTIVE"
+            or match["account_mode"] != "MARGIN"
+            or match["institution_type"] != "BROKERAGE"
+        ):
+            raise ETradeBrokerReaderUnavailable(
+                "configured account is not an ACTIVE MARGIN brokerage account"
+            )
+        return match, "COMPLETE"
+
+    def _read_capacity_scan(
+        self, binding: _AccountBinding, label: str
+    ) -> _CapacityScan:
+        balance = self._read_balance()
+        positions, portfolio_members, portfolio_completed = (
+            self._read_portfolio()
+        )
+        orders, order_members, orders_completed = self._read_active_orders()
+        result = {
+            "schema": "etrade-capacity.v1",
+            "account_status": binding.account_status,
+            "account_mode": binding.account_mode,
+            "account_type": binding.account_type,
+            "broker_buying_power": balance.parsed[
+                "margin_buying_power"
+            ],
+            "broker_buying_power_as_of": balance.parsed["as_of_date"],
+            "positions": positions,
+            "open_orders": orders,
+        }
+        economic_state = dict(result)
+        economic_state.pop("broker_buying_power_as_of")
+        state_sha256 = _domain_json_hash(
+            b"etrade-capacity-state.v1\0", economic_state
+        )
+        members = (
+            BrokerReadManifestMember(
+                f"{label}.balance", balance.receipt.receipt_sha256
+            ),
+            *(
+                BrokerReadManifestMember(
+                    f"{label}.{member.role}", member.receipt_sha256
+                )
+                for member in portfolio_members
+            ),
+            *(
+                BrokerReadManifestMember(
+                    f"{label}.{member.role}", member.receipt_sha256
+                )
+                for member in order_members
+            ),
+        )
+        return _CapacityScan(
+            result=result,
+            state_sha256=state_sha256,
+            members=tuple(members),
+            completed_at=max(
+                balance.completed_at,
+                portfolio_completed,
+                orders_completed,
+            ),
+        )
+
+    def _read_balance(self) -> _ReadResult:
+        encoded_account = quote(self._account_id_key, safe="")
+        return self._get(
+            read_kind="BALANCE",
+            route=f"/v1/accounts/{encoded_account}/balance.json",
+            query=(
+                ("instType", self._institution_type),
+                ("realTimeNAV", "true"),
+            ),
+            target_broker_order_id=None,
+            allowed_statuses={200},
+            parser=self._parse_balance,
+        )
+
+    def _parse_balance(
+        self, status: int, raw: bytes
+    ) -> tuple[dict[str, Any], Literal["COMPLETE"]]:
+        if status != 200:
+            raise ETradeBrokerReaderUnavailable(
+                "balance did not return HTTP 200"
+            )
+        document = _strict_json(raw)
+        response = _exact_object(
+            document, {"BalanceResponse"}, "balance root"
+        )["BalanceResponse"]
+        response = _object(response, "BalanceResponse")
+        account_id = _broker_int64_text(
+            response.get("accountId"), "balance account id"
+        )
+        if account_id != self._account_id:
+            raise ETradeBrokerReaderIntegrityError(
+                "balance account id does not match configured account"
+            )
+        institution = response.get("institutionType")
+        if institution is not None and _ascii_text(
+            institution, "balance institution type"
+        ) != self._institution_type:
+            raise ETradeBrokerReaderIntegrityError(
+                "balance institution type does not match configured account"
+            )
+        computed = _object(response.get("Computed"), "BalanceResponse.Computed")
+        buying_power = _decimal_text(
+            computed.get("marginBuyingPower"),
+            "margin buying power",
+            nonnegative=True,
+        )
+        as_of = response.get("asOfDate")
+        if as_of is None:
+            raise ETradeBrokerReaderIntegrityError(
+                "real-time balance omitted its effective timestamp"
+            )
+        as_of_text = _epoch_milliseconds_text(
+            as_of, "balance asOfDate"
+        )
+        as_of_time = datetime.fromtimestamp(
+            int(as_of_text) / 1_000, timezone.utc
+        )
+        now = self._now()
+        if (
+            as_of_time > now + timedelta(seconds=5)
+            or now - as_of_time
+            > timedelta(seconds=_MAX_BALANCE_AGE_SECONDS)
+        ):
+            raise ETradeBrokerReaderUnavailable(
+                "real-time balance effective timestamp is stale or future"
+            )
+        return {
+            "account_id": account_id,
+            "institution_type": (
+                self._institution_type if institution is not None else None
+            ),
+            "margin_buying_power": buying_power,
+            "as_of_date": as_of_text,
+        }, "COMPLETE"
+
+    def _read_portfolio(
+        self,
+    ) -> tuple[
+        list[dict[str, Any]],
+        tuple[BrokerReadManifestMember, ...],
+        datetime,
+    ]:
+        encoded_account = quote(self._account_id_key, safe="")
+        positions: list[dict[str, Any]] = []
+        members: list[BrokerReadManifestMember] = []
+        seen_position_ids: set[str] = set()
+        expected_total_pages: int | None = None
+        expected_metadata_field: str | None = None
+        page_number = 1
+        completed_at: datetime | None = None
+        while True:
+            if page_number > _MAX_PORTFOLIO_PAGES:
+                raise ETradeBrokerReaderIntegrityError(
+                    "portfolio pagination exceeded its fixed page bound"
+                )
+            read = self._get(
+                read_kind="PORTFOLIO_PAGE",
+                route=f"/v1/accounts/{encoded_account}/portfolio.json",
+                query=(
+                    ("count", "50"),
+                    ("lotsRequired", "false"),
+                    ("marketSession", "REGULAR"),
+                    ("pageNumber", str(page_number)),
+                    ("sortBy", "SYMBOL"),
+                    ("sortOrder", "ASC"),
+                    ("totalsRequired", "false"),
+                    ("view", "COMPLETE"),
+                ),
+                target_broker_order_id=None,
+                allowed_statuses={200, 204},
+                parser=lambda status, raw, page=page_number: (
+                    self._parse_portfolio_page(status, raw, page)
+                ),
+            )
+            parsed = read.parsed
+            members.append(
+                BrokerReadManifestMember(
+                    f"portfolio.{page_number:04d}",
+                    read.receipt.receipt_sha256,
+                )
+            )
+            completed_at = read.completed_at
+            total_pages = parsed["total_pages"]
+            metadata_field = parsed["metadata_field"]
+            if page_number == 1:
+                expected_total_pages = total_pages
+                expected_metadata_field = metadata_field
+            elif (
+                total_pages != expected_total_pages
+                or metadata_field != expected_metadata_field
+            ):
+                raise ETradeBrokerReaderIntegrityError(
+                    "portfolio pagination metadata changed between pages"
+                )
+            for position in parsed["positions"]:
+                position_id = position["position_id"]
+                if position_id in seen_position_ids:
+                    raise ETradeBrokerReaderIntegrityError(
+                        "portfolio contains a duplicate position id"
+                    )
+                seen_position_ids.add(position_id)
+                positions.append(position)
+                if len(positions) > _MAX_POSITIONS:
+                    raise ETradeBrokerReaderIntegrityError(
+                        "portfolio exceeded its fixed position bound"
+                    )
+            if read.completeness == "COMPLETE":
+                break
+            next_page = parsed["next_page"]
+            if next_page != page_number + 1:
+                raise ETradeBrokerReaderIntegrityError(
+                    "portfolio next-page sequence is not contiguous"
+                )
+            page_number = next_page
+        if completed_at is None:
+            raise ETradeBrokerReaderIntegrityError(
+                "portfolio scan produced no durable page"
+            )
+        positions.sort(key=lambda item: item["position_id"])
+        return positions, tuple(members), completed_at
+
+    def _parse_portfolio_page(
+        self, status: int, raw: bytes, page_number: int
+    ) -> tuple[
+        dict[str, Any], Literal["COMPLETE", "HAS_NEXT"]
+    ]:
+        if status == 204:
+            if page_number != 1 or raw:
+                raise ETradeBrokerReaderIntegrityError(
+                    "only an empty first-page 204 can represent no positions"
+                )
+            return {
+                "page_number": 1,
+                "total_pages": 0,
+                "metadata_field": "HTTP_204",
+                "next_page": None,
+                "positions": [],
+            }, "COMPLETE"
+        if status != 200:
+            raise ETradeBrokerReaderUnavailable(
+                "portfolio page did not return HTTP 200/204"
+            )
+        document = _strict_json(raw)
+        response = _exact_object(
+            document, {"PortfolioResponse"}, "portfolio root"
+        )["PortfolioResponse"]
+        response = _object(response, "PortfolioResponse")
+        portfolios = response.get("AccountPortfolio")
+        if type(portfolios) is not list or len(portfolios) != 1:
+            raise ETradeBrokerReaderIntegrityError(
+                "portfolio page must contain exactly one AccountPortfolio"
+            )
+        account_portfolio = _object(
+            portfolios[0], "AccountPortfolio"
+        )
+        account_id = _broker_int64_text(
+            account_portfolio.get("accountId"),
+            "portfolio account id",
+        )
+        if account_id != self._account_id:
+            raise ETradeBrokerReaderIntegrityError(
+                "portfolio page account id does not match"
+            )
+        total_fields = [
+            field
+            for field in ("totalNoOfPages", "totalPages")
+            if field in account_portfolio
+        ]
+        if len(total_fields) != 1:
+            raise ETradeBrokerReaderIntegrityError(
+                "portfolio page must use one reviewed total-pages field"
+            )
+        metadata_field = total_fields[0]
+        total_pages = _positive_int(
+            account_portfolio[metadata_field],
+            "portfolio total pages",
+        )
+        if total_pages > _MAX_PORTFOLIO_PAGES or page_number > total_pages:
+            raise ETradeBrokerReaderIntegrityError(
+                "portfolio total-pages metadata is out of bounds"
+            )
+        raw_positions = account_portfolio.get("Position", [])
+        if type(raw_positions) is not list:
+            raise ETradeBrokerReaderIntegrityError(
+                "AccountPortfolio.Position must be an array"
+            )
+        positions = [
+            self._normalize_position(position)
+            for position in raw_positions
+        ]
+        raw_next_page = account_portfolio.get("nextPageNo")
+        if page_number < total_pages:
+            next_page = _positive_int(
+                raw_next_page, "portfolio next page"
+            )
+            if next_page != page_number + 1:
+                raise ETradeBrokerReaderIntegrityError(
+                    "portfolio next page skipped or repeated a page"
+                )
+            completeness: Literal["COMPLETE", "HAS_NEXT"] = "HAS_NEXT"
+        else:
+            if raw_next_page not in {None, ""}:
+                raise ETradeBrokerReaderIntegrityError(
+                    "terminal portfolio page advertised another page"
+                )
+            next_page = None
+            completeness = "COMPLETE"
+        positions.sort(key=lambda item: item["position_id"])
+        return {
+            "page_number": page_number,
+            "total_pages": total_pages,
+            "metadata_field": metadata_field,
+            "next_page": next_page,
+            "positions": positions,
+        }, completeness
+
+    def _normalize_position(self, value: Any) -> dict[str, Any]:
+        position = _object(value, "Position")
+        position_id = _broker_int64_text(
+            position.get("positionId"), "position id"
+        )
+        account_id = _broker_int64_text(
+            position.get("accountId"), "position account id"
+        )
+        if account_id != self._account_id:
+            raise ETradeBrokerReaderIntegrityError(
+                "position account id does not match configured account"
+            )
+        product = _normalize_product(
+            position.get("Product"), "position product"
+        )
+        quantity = _decimal_text(
+            position.get("quantity"),
+            "position quantity",
+            nonnegative=False,
+        )
+        position_type = _optional_ascii_text(
+            position.get("positionType"), "position type"
+        )
+        position_indicator = _optional_ascii_text(
+            position.get("positionIndicator"), "position indicator"
+        )
+        osi_key = _optional_ascii_text(
+            position.get("osiKey"), "position osi key"
+        )
+        return {
+            "position_id": position_id,
+            "account_id": account_id,
+            "product": product,
+            "quantity": quantity,
+            "position_type": position_type,
+            "position_indicator": position_indicator,
+            "osi_key": osi_key,
+        }
+
+    def _read_active_orders(
+        self,
+    ) -> tuple[
+        list[dict[str, Any]],
+        tuple[BrokerReadManifestMember, ...],
+        datetime,
+    ]:
+        encoded_account = quote(self._account_id_key, safe="")
+        all_orders: list[dict[str, Any]] = []
+        members: list[BrokerReadManifestMember] = []
+        seen_order_ids: set[str] = set()
+        completed_at: datetime | None = None
+        for lane in _ACTIVE_ORDER_STATUSES:
+            marker: str | None = None
+            seen_markers: set[str] = set()
+            page = 0
+            while True:
+                if page >= _MAX_ORDER_PAGES:
+                    raise ETradeBrokerReaderIntegrityError(
+                        "order pagination exceeded its fixed page bound"
+                    )
+                query = [("count", "100"), ("status", lane)]
+                if marker is not None:
+                    query.append(("marker", marker))
+                read = self._get(
+                    read_kind="OPEN_ORDERS_PAGE",
+                    route=f"/v1/accounts/{encoded_account}/orders.json",
+                    query=tuple(query),
+                    target_broker_order_id=None,
+                    allowed_statuses={200, 204},
+                    parser=lambda status, raw, status_lane=lane, first=(
+                        marker is None
+                    ): self._parse_orders_page(
+                        status, raw, status_lane, first
+                    ),
+                )
+                parsed = read.parsed
+                members.append(
+                    BrokerReadManifestMember(
+                        f"orders.{lane}.{page:04d}",
+                        read.receipt.receipt_sha256,
+                    )
+                )
+                completed_at = read.completed_at
+                for order in parsed["orders"]:
+                    order_id = order["order_id"]
+                    if order_id in seen_order_ids:
+                        raise ETradeBrokerReaderIntegrityError(
+                            "active-order scans contain a duplicate order id"
+                        )
+                    seen_order_ids.add(order_id)
+                    all_orders.append(order)
+                    if len(all_orders) > _MAX_ORDERS:
+                        raise ETradeBrokerReaderIntegrityError(
+                            "active orders exceeded the fixed row bound"
+                        )
+                next_marker = parsed["marker"]
+                if read.completeness == "COMPLETE":
+                    break
+                if (
+                    next_marker is None
+                    or next_marker in seen_markers
+                    or next_marker == marker
+                ):
+                    raise ETradeBrokerReaderIntegrityError(
+                        "order marker pagination repeated or cycled"
+                    )
+                seen_markers.add(next_marker)
+                marker = next_marker
+                page += 1
+        if completed_at is None:
+            raise ETradeBrokerReaderIntegrityError(
+                "active-order scan produced no durable page"
+            )
+        all_orders.sort(key=lambda item: item["order_id"])
+        return all_orders, tuple(members), completed_at
+
+    def _parse_orders_page(
+        self,
+        status: int,
+        raw: bytes,
+        lane: str,
+        first_page: bool,
+    ) -> tuple[
+        dict[str, Any], Literal["COMPLETE", "HAS_NEXT"]
+    ]:
+        if status == 204:
+            if not first_page or raw:
+                raise ETradeBrokerReaderIntegrityError(
+                    "only an empty first-page 204 can mean no active orders"
+                )
+            return {"status_lane": lane, "orders": [], "marker": None}, "COMPLETE"
+        if status != 200:
+            raise ETradeBrokerReaderUnavailable(
+                "orders page did not return HTTP 200/204"
+            )
+        document = _strict_json(raw)
+        response = _exact_object(
+            document, {"OrdersResponse"}, "orders root"
+        )["OrdersResponse"]
+        response = _object(response, "OrdersResponse")
+        if any(key.casefold() == "messages" for key in response):
+            raise ETradeBrokerReaderIntegrityError(
+                "orders page contains broker messages instead of "
+                "unambiguous order evidence"
+            )
+        if "Order" not in response:
+            raise ETradeBrokerReaderIntegrityError(
+                "HTTP 200 orders page omitted the Order array"
+            )
+        raw_orders = response["Order"]
+        if type(raw_orders) is not list:
+            raise ETradeBrokerReaderIntegrityError(
+                "OrdersResponse.Order must be an array"
+            )
+        orders = [
+            self._normalize_live_order(order, lane)
+            for order in raw_orders
+        ]
+        order_ids = [order["order_id"] for order in orders]
+        if len(order_ids) != len(set(order_ids)):
+            raise ETradeBrokerReaderIntegrityError(
+                "orders page contains duplicate order ids"
+            )
+        raw_marker = response.get("marker")
+        if raw_marker in {None, ""}:
+            marker = None
+            completeness: Literal["COMPLETE", "HAS_NEXT"] = "COMPLETE"
+        else:
+            marker = _ascii_text(raw_marker, "orders marker", maximum=512)
+            completeness = "HAS_NEXT"
+        orders.sort(key=lambda item: item["order_id"])
+        return {
+            "status_lane": lane,
+            "orders": orders,
+            "marker": marker,
+        }, completeness
+
+    def _normalize_live_order(
+        self, value: Any, lane: str
+    ) -> dict[str, Any]:
+        order = _object(value, "Order")
+        order_id = _broker_int64_text(
+            order.get("orderId"), "order id"
+        )
+        order_type = _ascii_text(
+            order.get("orderType"), "order type"
+        )
+        raw_details = order.get("OrderDetail")
+        if type(raw_details) is not list or not raw_details:
+            raise ETradeBrokerReaderIntegrityError(
+                "active order must contain OrderDetail entries"
+            )
+        details = [
+            self._normalize_generic_order_detail(detail)
+            for detail in raw_details
+        ]
+        if {detail["status"] for detail in details} != {lane}:
+            raise ETradeBrokerReaderIntegrityError(
+                "active order status does not match its requested lane"
+            )
+        return {
+            "order_id": order_id,
+            "order_type": order_type,
+            "replaces_order_id": _optional_broker_id(
+                order.get("replacesOrderId"), "replaces order id"
+            ),
+            "replaced_by_order_id": _optional_broker_id(
+                order.get("replacedByOrderId"), "replaced-by order id"
+            ),
+            "details": details,
+        }
+
+    def _normalize_generic_order_detail(
+        self, value: Any
+    ) -> dict[str, Any]:
+        detail = _object(value, "OrderDetail")
+        raw_account_id = detail.get("accountId")
+        account_id = (
+            self._account_id
+            if raw_account_id is None
+            else _broker_int64_text(
+                raw_account_id, "order detail account id"
+            )
+        )
+        if raw_account_id is not None and account_id != self._account_id:
+            raise ETradeBrokerReaderIntegrityError(
+                "order detail account id does not match configured account"
+            )
+        status = _ascii_text(
+            detail.get("status"), "order detail status"
+        )
+        raw_instruments = detail.get("Instrument")
+        if type(raw_instruments) is not list or not raw_instruments:
+            raise ETradeBrokerReaderIntegrityError(
+                "order detail must contain an Instrument array"
+            )
+        instruments = [
+            _normalize_generic_instrument(instrument)
+            for instrument in raw_instruments
+        ]
+        instruments.sort(key=_canonical_json)
+        return {
+            "account_id": account_id,
+            "status": status,
+            "price_type": _optional_ascii_text(
+                detail.get("priceType"), "price type"
+            ),
+            "limit_price": _optional_decimal_text(
+                detail.get("limitPrice"), "limit price"
+            ),
+            "order_term": _optional_ascii_text(
+                detail.get("orderTerm"), "order term"
+            ),
+            "market_session": _optional_ascii_text(
+                detail.get("marketSession"), "market session"
+            ),
+            "all_or_none": _optional_bool(
+                detail.get("allOrNone"), "all or none"
+            ),
+            "replaces_order_id": _optional_broker_id(
+                detail.get("replacesOrderId"), "detail replaces order id"
+            ),
+            "replaced_by_order_id": _optional_broker_id(
+                detail.get("replacedByOrderId"),
+                "detail replaced-by order id",
+            ),
+            "instruments": instruments,
+        }
+
+    def _read_order_detail(self, target: str) -> _ReadResult:
+        encoded_account = quote(self._account_id_key, safe="")
+        encoded_order = quote(target, safe="")
+        return self._get(
+            read_kind="ORDER_DETAIL",
+            route=(
+                f"/v1/accounts/{encoded_account}/orders/"
+                f"{encoded_order}.json"
+            ),
+            query=(),
+            target_broker_order_id=target,
+            allowed_statuses={200, 404},
+            parser=lambda status, raw: self._parse_order_detail(
+                status, raw, target
+            ),
+        )
+
+    def _parse_order_detail(
+        self, status: int, raw: bytes, target: str
+    ) -> tuple[dict[str, Any], Literal["COMPLETE"]]:
+        if status == 404:
+            if raw:
+                error = _strict_json(raw)
+                if type(error) is not dict:
+                    raise ETradeBrokerReaderIntegrityError(
+                        "order 404 body must be an object or empty"
+                    )
+            return {
+                "not_found": True,
+                "raw_status": "NOT_FOUND",
+                "outcome": "UNRESOLVED",
+                "order_payload_hashes": [],
+                "replacement_links": {},
+                "normalized_order": None,
+            }, "COMPLETE"
+        if status != 200:
+            raise ETradeBrokerReaderUnavailable(
+                "order detail did not return HTTP 200/404"
+            )
+        document = _strict_json(raw)
+        response = _exact_object(
+            document, {"OrdersResponse"}, "order detail root"
+        )["OrdersResponse"]
+        response = _object(response, "OrdersResponse")
+        raw_orders = response.get("Order")
+        if type(raw_orders) is not list or len(raw_orders) != 1:
+            raise ETradeBrokerReaderIntegrityError(
+                "known-order response must contain exactly one Order"
+            )
+        order = _object(raw_orders[0], "known Order")
+        order_id = _broker_int64_text(
+            order.get("orderId"), "known order id"
+        )
+        if order_id != target:
+            raise ETradeBrokerReaderIntegrityError(
+                "known-order response returned a different order id"
+            )
+        if _ascii_text(order.get("orderType"), "known order type") != "SPREADS":
+            raise ETradeBrokerReaderIntegrityError(
+                "known R7 order must be a SPREADS order"
+            )
+        details = order.get("OrderDetail")
+        if type(details) is not list or len(details) != 1:
+            raise ETradeBrokerReaderIntegrityError(
+                "known R7 order must contain exactly one OrderDetail"
+            )
+        normalized, outcome, hashes, replacement_links = (
+            self._normalize_known_vertical(order, details[0])
+        )
+        return {
+            "not_found": False,
+            "raw_status": normalized["status"],
+            "outcome": outcome,
+            "order_payload_hashes": hashes,
+            "replacement_links": replacement_links,
+            "normalized_order": normalized,
+        }, "COMPLETE"
+
+    def _normalize_known_vertical(
+        self, order: dict[str, Any], raw_detail: Any
+    ) -> tuple[
+        dict[str, Any],
+        Literal[
+            "OPEN",
+            "FILLED",
+            "CANCELLED",
+            "REJECTED",
+            "EXPIRED",
+            "UNRESOLVED",
+        ],
+        list[str],
+        dict[str, str | None],
+    ]:
+        detail = _object(raw_detail, "known OrderDetail")
+        raw_account_id = detail.get("accountId")
+        account_id = (
+            self._account_id
+            if raw_account_id is None
+            else _broker_int64_text(
+                raw_account_id, "known order account id"
+            )
+        )
+        if raw_account_id is not None and account_id != self._account_id:
+            raise ETradeBrokerReaderIntegrityError(
+                "known order account id does not match"
+            )
+        order_number = detail.get("orderNumber")
+        if (
+            order_number is not None
+            and _broker_int64_text(
+                order_number, "known order number"
+            )
+            != _broker_int64_text(order["orderId"], "known order id")
+        ):
+            raise ETradeBrokerReaderIntegrityError(
+                "known order number conflicts with outer order id"
+            )
+        status = _ascii_text(detail.get("status"), "known order status")
+        price_type = _ascii_text(
+            detail.get("priceType"), "known order price type"
+        )
+        if price_type not in {"NET_CREDIT", "NET_DEBIT"}:
+            raise ETradeBrokerReaderIntegrityError(
+                "known vertical has an unsupported price type"
+            )
+        limit_price = _decimal_text(
+            detail.get("limitPrice"),
+            "known order limit price",
+            nonnegative=price_type == "NET_CREDIT",
+            positive=price_type == "NET_DEBIT",
+        )
+        if _ascii_text(
+            detail.get("orderTerm"), "known order term"
+        ) != "GOOD_FOR_DAY":
+            raise ETradeBrokerReaderIntegrityError(
+                "known vertical order term changed"
+            )
+        if _ascii_text(
+            detail.get("marketSession"), "known market session"
+        ) != "REGULAR":
+            raise ETradeBrokerReaderIntegrityError(
+                "known vertical market session changed"
+            )
+        if _bool(detail.get("allOrNone"), "known all-or-none") is not False:
+            raise ETradeBrokerReaderIntegrityError(
+                "known vertical all-or-none semantics changed"
+            )
+        stop_price = detail.get("stopPrice")
+        if (
+            stop_price is not None
+            and _decimal_text(
+                stop_price, "known stop price", nonnegative=True
+            )
+            != "0"
+        ):
+            raise ETradeBrokerReaderIntegrityError(
+                "known vertical stop price must remain zero"
+            )
+        raw_instruments = detail.get("Instrument")
+        if type(raw_instruments) is not list or len(raw_instruments) != 2:
+            raise ETradeBrokerReaderIntegrityError(
+                "known vertical must contain exactly two option legs"
+            )
+        legs = [
+            _normalize_known_leg(instrument)
+            for instrument in raw_instruments
+        ]
+        reference = (
+            legs[0]["symbol"],
+            legs[0]["callPut"],
+            legs[0]["expiryYear"],
+            legs[0]["expiryMonth"],
+            legs[0]["expiryDay"],
+            legs[0]["quantity"],
+        )
+        if any(
+            (
+                leg["symbol"],
+                leg["callPut"],
+                leg["expiryYear"],
+                leg["expiryMonth"],
+                leg["expiryDay"],
+                leg["quantity"],
+            )
+            != reference
+            for leg in legs
+        ):
+            raise ETradeBrokerReaderIntegrityError(
+                "known vertical leg identity/quantity is inconsistent"
+            )
+        if (
+            {leg["orderAction"] for leg in legs}
+            != {"BUY_OPEN", "SELL_OPEN"}
+            or len({leg["strikePrice"] for leg in legs}) != 2
+        ):
+            raise ETradeBrokerReaderIntegrityError(
+                "known vertical is not one buy-open and one sell-open"
+            )
+        payload_base = {
+            "securityType": "OPTN",
+            "orderAction": "SPREAD",
+            "priceType": price_type,
+            "limitPrice": Decimal(limit_price),
+            "orderTerm": "GOOD_FOR_DAY",
+            "spreadType": "VERTICAL",
+        }
+        payload_hashes = sorted(
+            {
+                canonical_order_payload_hash(
+                    {
+                        **payload_base,
+                        "legs": [
+                            {
+                                "symbol": leg["symbol"],
+                                "callPut": leg["callPut"],
+                                "expiryYear": int(leg["expiryYear"]),
+                                "expiryMonth": int(leg["expiryMonth"]),
+                                "expiryDay": int(leg["expiryDay"]),
+                                "strikePrice": Decimal(
+                                    leg["strikePrice"]
+                                ),
+                                "orderAction": leg["orderAction"],
+                                "quantity": int(leg["quantity"]),
+                            }
+                            for leg in permutation
+                        ],
+                    }
+                )
+                for permutation in (legs, list(reversed(legs)))
+            }
+        )
+        fills_complete = all(
+            Decimal(leg["filledQuantity"])
+            == Decimal(leg["quantity"])
+            for leg in legs
+        )
+        any_fill = any(
+            Decimal(leg["filledQuantity"]) > 0 for leg in legs
+        )
+        replacement_links = {
+            "replaces_order_id": _first_optional_broker_id(
+                order.get("replacesOrderId"),
+                detail.get("replacesOrderId"),
+                "replaces order id",
+            ),
+            "replaced_by_order_id": _first_optional_broker_id(
+                order.get("replacedByOrderId"),
+                detail.get("replacedByOrderId"),
+                "replaced-by order id",
+            ),
+        }
+        has_replacement_link = any(
+            value is not None for value in replacement_links.values()
+        )
+        if has_replacement_link:
+            outcome = "UNRESOLVED"
+        elif status == "OPEN" and not any_fill:
+            outcome = "OPEN"
+        elif status == "EXECUTED" and fills_complete:
+            outcome = "FILLED"
+        elif (
+            status in {"CANCELLED", "REJECTED", "EXPIRED"}
+            and not any_fill
+        ):
+            outcome = status
+        else:
+            outcome = "UNRESOLVED"
+        return {
+            "account_id": account_id,
+            "status": status,
+            "price_type": price_type,
+            "limit_price": limit_price,
+            "order_term": "GOOD_FOR_DAY",
+            "market_session": "REGULAR",
+            "all_or_none": False,
+            "stop_price": (
+                "0"
+                if stop_price is None
+                else _decimal_text(
+                    stop_price, "known stop price", nonnegative=True
+                )
+            ),
+            "legs": legs,
+        }, outcome, payload_hashes, replacement_links
+
+    def _get(
+        self,
+        *,
+        read_kind: Literal[
+            "ACCOUNT_LIST",
+            "BALANCE",
+            "PORTFOLIO_PAGE",
+            "OPEN_ORDERS_PAGE",
+            "ORDER_DETAIL",
+        ],
+        route: str,
+        query: tuple[tuple[str, str], ...],
+        target_broker_order_id: str | None,
+        allowed_statuses: set[int],
+        parser: Callable[
+            [int, bytes],
+            tuple[
+                Any,
+                Literal["COMPLETE", "HAS_NEXT", "INELIGIBLE"],
+            ],
+        ],
+    ) -> _ReadResult:
+        self._assert_runtime()
+        canonical_query = tuple(sorted(query))
+        if (
+            len({name for name, _value in canonical_query})
+            != len(canonical_query)
+            or any(
+                type(name) is not str
+                or type(value) is not str
+                or not name
+                for name, value in canonical_query
+            )
+        ):
+            raise ETradeBrokerReaderIntegrityError(
+                "broker read query is not a unique string mapping"
+            )
+        prepared, expected_url = _prepare_oauth_get(
+            self._oauth,
+            self._origin,
+            route,
+            canonical_query,
+        )
+        _validate_prepared_get(
+            prepared,
+            expected_url,
+            self._origin,
+            route,
+            canonical_query,
+        )
+        authorization = prepared.headers["Authorization"]
+        if type(authorization) is not str or not authorization.isascii():
+            raise ETradeBrokerReaderIntegrityError(
+                "prepared OAuth authorization is not bounded ASCII"
+            )
+        authorization_sha256 = hashlib.sha256(
+            authorization.encode("ascii")
+        ).hexdigest()
+        started_at = self._now()
+        self._assert_runtime()
+        try:
+            exchange = _isolated_exchange(
+                prepared,
+                timeout_seconds=_TOTAL_EXCHANGE_TIMEOUT_SECONDS,
+                max_response_bytes=_MAX_RAW_RESPONSE_BYTES,
+            )
+        except Exception as exc:
+            raise ETradeBrokerReaderUnavailable(
+                "isolated broker GET failed"
+            ) from exc
+        completed_at = self._now()
+        self._assert_runtime()
+        if type(exchange) is not _ExchangeResult or exchange.kind != "RESPONSE":
+            raise ETradeBrokerReaderUnavailable(
+                "isolated broker GET did not return a complete response"
+            )
+        status = exchange.http_status
+        raw = exchange.raw_response
+        if (
+            type(status) is not int
+            or type(raw) is not bytes
+            or len(raw) > _MAX_RAW_RESPONSE_BYTES
+        ):
+            raise ETradeBrokerReaderIntegrityError(
+                "isolated broker GET returned an invalid result"
+            )
+        parsed: Any = None
+        completeness: Literal[
+            "COMPLETE", "HAS_NEXT", "INELIGIBLE"
+        ] = "INELIGIBLE"
+        parse_error: Exception | None = None
+        if status not in allowed_statuses:
+            parse_error = ETradeBrokerReaderUnavailable(
+                "broker GET returned an ineligible HTTP status"
+            )
+        else:
+            try:
+                parsed, completeness = parser(status, raw)
+                _canonical_json(parsed)
+            except Exception as exc:
+                parse_error = exc
+                parsed = None
+                completeness = "INELIGIBLE"
+        try:
+            receipt = self._ledger.record_broker_read_response(
+                BrokerReadResponseEvidence(
+                    read_kind=read_kind,
+                    account_id=self._account_id,
+                    account_id_key=self._account_id_key,
+                    institution_type=self._institution_type,
+                    environment=self._environment,
+                    origin=self._origin,
+                    route=route,
+                    query_json=_canonical_json(
+                        [list(pair) for pair in canonical_query]
+                    ),
+                    authorization_sha256=authorization_sha256,
+                    target_broker_order_id=target_broker_order_id,
+                    request_started_at=started_at,
+                    response_completed_at=completed_at,
+                    http_status=status,
+                    raw_response_bytes=raw,
+                    parser_schema=_PARSER_SCHEMA,
+                    parser_code_sha256=_PARSER_CODE_SHA256,
+                    parser_config_sha256=_PARSER_CONFIG_SHA256,
+                    canonical_parsed_json=_canonical_json(parsed),
+                    completeness=completeness,
+                )
+            )
+        except Exception as exc:
+            raise ETradeBrokerReaderIntegrityError(
+                "broker GET response could not be persisted durably"
+            ) from exc
+        if parse_error is not None:
+            if isinstance(parse_error, ETradeBrokerReaderError):
+                raise parse_error
+            raise ETradeBrokerReaderIntegrityError(
+                "broker GET response violated its parser contract"
+            ) from parse_error
+        self._assert_runtime()
+        return _ReadResult(
+            parsed=parsed,
+            receipt=receipt,
+            http_status=status,
+            raw_response_digest=hashlib.sha256(raw).hexdigest(),
+            completed_at=completed_at,
+            completeness=completeness,
+        )
+
+    def _require_account(self, account: SelectedBrokerAccount) -> None:
+        if type(account) is not SelectedBrokerAccount:
+            raise ETradeBrokerReaderError(
+                "reader account must use the exact selected account type"
+            )
+        if account != self._selected_account:
+            raise ETradeBrokerReaderError(
+                "reader account does not match its immutable binding"
+            )
+        self._assert_runtime()
+
+    def _assert_runtime(self) -> None:
+        now = self._now()
+        try:
+            self._runtime_safety.assert_current(now)
+            self._runtime_safety.verify_account(
+                self._selected_account.runtime_mapping(), now=now
+            )
+        except RuntimeSafetyError as exc:
+            raise ETradeBrokerReaderError(
+                "broker reader runtime safety boundary is not current"
+            ) from exc
+
+    def _now(self) -> datetime:
+        value = self._clock()
+        if type(value) is not datetime or value.tzinfo is not timezone.utc:
+            raise ETradeBrokerReaderError(
+                "broker reader clock must use the exact UTC timezone"
+            )
+        return value
+
+
+def _reparse_broker_read_response(
+    evidence: BrokerReadResponseEvidence,
+) -> tuple[str, Literal["COMPLETE", "HAS_NEXT", "INELIGIBLE"]]:
+    """Reproduce persisted parser output from raw bytes inside the ledger."""
+
+    if type(evidence) is not BrokerReadResponseEvidence:
+        raise ETradeBrokerReaderIntegrityError(
+            "durable parser requires exact broker-read evidence"
+        )
+    try:
+        query_pairs = json.loads(evidence.query_json)
+        if (
+            type(query_pairs) is not list
+            or any(
+                type(pair) is not list
+                or len(pair) != 2
+                or any(type(item) is not str for item in pair)
+                for pair in query_pairs
+            )
+        ):
+            raise ETradeBrokerReaderIntegrityError(
+                "durable parser query is invalid"
+            )
+        query = {pair[0]: pair[1] for pair in query_pairs}
+        parser = object.__new__(ETradeBrokerReader)
+        parser._account_id = evidence.account_id
+        parser._account_id_key = evidence.account_id_key
+        parser._institution_type = evidence.institution_type
+        parser._clock = lambda: evidence.response_completed_at
+        if evidence.read_kind == "ACCOUNT_LIST":
+            parsed, completeness = parser._parse_account_list(
+                evidence.http_status, evidence.raw_response_bytes
+            )
+        elif evidence.read_kind == "BALANCE":
+            parsed, completeness = parser._parse_balance(
+                evidence.http_status, evidence.raw_response_bytes
+            )
+        elif evidence.read_kind == "PORTFOLIO_PAGE":
+            page_number = _positive_int(
+                query.get("pageNumber"),
+                "durable portfolio page number",
+            )
+            parsed, completeness = parser._parse_portfolio_page(
+                evidence.http_status,
+                evidence.raw_response_bytes,
+                page_number,
+            )
+        elif evidence.read_kind == "OPEN_ORDERS_PAGE":
+            lane = _ascii_text(
+                query.get("status"), "durable order status lane"
+            )
+            if lane not in _ACTIVE_ORDER_STATUSES:
+                raise ETradeBrokerReaderIntegrityError(
+                    "durable order status lane is unsupported"
+                )
+            parsed, completeness = parser._parse_orders_page(
+                evidence.http_status,
+                evidence.raw_response_bytes,
+                lane,
+                "marker" not in query,
+            )
+        elif evidence.read_kind == "ORDER_DETAIL":
+            target = _broker_int64_text(
+                evidence.target_broker_order_id,
+                "durable target broker order id",
+            )
+            parsed, completeness = parser._parse_order_detail(
+                evidence.http_status,
+                evidence.raw_response_bytes,
+                target,
+            )
+        else:
+            raise ETradeBrokerReaderIntegrityError(
+                "durable broker-read kind is unsupported"
+            )
+        return _canonical_json(parsed), completeness
+    except Exception:
+        return _canonical_json(None), "INELIGIBLE"
+
+
+def _prepare_oauth_get(
+    oauth: OAuth1Session,
+    origin: str,
+    route: str,
+    query: tuple[tuple[str, str], ...],
+):
+    if (
+        type(oauth) is not OAuth1Session
+        or oauth.trust_env is not False
+        or oauth.params
+        or oauth.proxies
+        or oauth.hooks != {"response": []}
+        or oauth.cookies
+        or oauth.verify is not True
+        or oauth.cert is not None
+        or origin not in _ETRADE_ORIGINS.values()
+        or type(route) is not str
+        or not route.startswith("/v1/accounts/")
+        or "?" in route
+        or "#" in route
+    ):
+        raise ETradeBrokerReaderError(
+            "private OAuth reader configuration is unsafe"
+        )
+    params = {name: value for name, value in query}
+    base_url = origin + route
+    encoded_query = urlencode(params)
+    expected_url = (
+        base_url if not encoded_query else f"{base_url}?{encoded_query}"
+    )
+    headers = CaseInsensitiveDict(
+        {
+            "Accept": "application/json",
+            "Accept-Encoding": "identity",
+            "consumerKey": oauth.consumer_key,
+        }
+    )
+    signing_kwargs = {"headers": headers, "params": params}
+    oauth_params = oauth._get_oauth_params(signing_kwargs)
+    oauth_params["oauth_signature"] = oauth.signature.sign(
+        oauth.consumer_secret,
+        oauth.access_token_secret,
+        "GET",
+        base_url,
+        oauth_params,
+        signing_kwargs,
+    )
+    prepared = Request(
+        method="GET",
+        url=base_url,
+        headers=dict(headers),
+        params=params,
+        auth=OAuth1Auth(oauth_params, ""),
+    ).prepare()
+    return prepared, expected_url
+
+
+def _validate_prepared_get(
+    prepared: Any,
+    expected_url: str,
+    expected_origin: str,
+    expected_route: str,
+    expected_query: tuple[tuple[str, str], ...],
+) -> None:
+    parsed = urlsplit(getattr(prepared, "url", ""))
+    headers = getattr(prepared, "headers", None)
+    if not hasattr(headers, "items"):
+        raise ETradeBrokerReaderError(
+            "prepared broker GET headers are invalid"
+        )
+    normalized = {
+        name.lower(): value for name, value in headers.items()
+    }
+    expected_headers = {
+        "accept",
+        "accept-encoding",
+        "consumerkey",
+        "authorization",
+    }
+    if (
+        getattr(prepared, "method", None) != "GET"
+        or prepared.url != expected_url
+        or f"{parsed.scheme}://{parsed.netloc}" != expected_origin
+        or parsed.path != expected_route
+        or parsed.fragment
+        or getattr(prepared, "body", None) is not None
+        or set(normalized) != expected_headers
+        or normalized["accept"] != "application/json"
+        or normalized["accept-encoding"] != "identity"
+        or not normalized["consumerkey"]
+        or not normalized["authorization"].startswith("OAuth ")
+        or "cookie" in normalized
+    ):
+        raise ETradeBrokerReaderError(
+            "prepared OAuth GET changed its pinned request"
+        )
+    params = {name: value for name, value in expected_query}
+    if parsed.query != urlencode(params):
+        raise ETradeBrokerReaderError(
+            "prepared OAuth GET query is not canonical"
+        )
+
+
+def _strict_json(raw: bytes) -> dict[str, Any]:
+    if (
+        type(raw) is not bytes
+        or not raw
+        or len(raw) > _MAX_RAW_RESPONSE_BYTES
+        or raw.startswith(b"\xef\xbb\xbf")
+    ):
+        raise ETradeBrokerReaderIntegrityError(
+            "broker JSON bytes are empty, oversized, or BOM-prefixed"
+        )
+    try:
+        text = raw.decode("utf-8", errors="strict")
+    except UnicodeDecodeError as exc:
+        raise ETradeBrokerReaderIntegrityError(
+            "broker JSON is not strict UTF-8"
+        ) from exc
+
+    def strict_object(
+        pairs: list[tuple[str, Any]],
+    ) -> dict[str, Any]:
+        result: dict[str, Any] = {}
+        for key, value in pairs:
+            if type(key) is not str or key in result:
+                raise ETradeBrokerReaderIntegrityError(
+                    "broker JSON contains a duplicate key"
+                )
+            result[key] = value
+        return result
+
+    def parse_number(token: str) -> str:
+        if type(token) is not str or len(token) > 128:
+            raise ETradeBrokerReaderIntegrityError(
+                "broker JSON number is out of bounds"
+            )
+        try:
+            number = Decimal(token)
+        except InvalidOperation as exc:
+            raise ETradeBrokerReaderIntegrityError(
+                "broker JSON number is invalid"
+            ) from exc
+        if (
+            not number.is_finite()
+            or number.adjusted() > 100
+            or number.adjusted() < -100
+        ):
+            raise ETradeBrokerReaderIntegrityError(
+                "broker JSON number magnitude is out of bounds"
+            )
+        return token
+
+    def reject_constant(_token: str) -> Any:
+        raise ETradeBrokerReaderIntegrityError(
+            "broker JSON contains a non-finite number"
+        )
+
+    try:
+        document = json.loads(
+            text,
+            object_pairs_hook=strict_object,
+            parse_int=parse_number,
+            parse_float=parse_number,
+            parse_constant=reject_constant,
+        )
+    except ETradeBrokerReaderError:
+        raise
+    except Exception as exc:
+        raise ETradeBrokerReaderIntegrityError(
+            "broker response is not valid JSON"
+        ) from exc
+    _validate_json_tree(document)
+    if type(document) is not dict:
+        raise ETradeBrokerReaderIntegrityError(
+            "broker JSON root must be an object"
+        )
+    return document
+
+
+def _validate_json_tree(value: Any) -> None:
+    stack: list[tuple[Any, int]] = [(value, 0)]
+    nodes = 0
+    while stack:
+        item, depth = stack.pop()
+        nodes += 1
+        if nodes > _MAX_JSON_NODES or depth > _MAX_JSON_DEPTH:
+            raise ETradeBrokerReaderIntegrityError(
+                "broker JSON exceeds fixed complexity bounds"
+            )
+        item_type = type(item)
+        if item is None or item_type in {str, bool}:
+            if item_type is str and len(item) > _MAX_RAW_RESPONSE_BYTES:
+                raise ETradeBrokerReaderIntegrityError(
+                    "broker JSON string exceeds its fixed bound"
+                )
+            continue
+        if item_type is list:
+            stack.extend((child, depth + 1) for child in item)
+            continue
+        if item_type is dict:
+            if any(type(key) is not str for key in item):
+                raise ETradeBrokerReaderIntegrityError(
+                    "broker JSON keys must be strings"
+                )
+            stack.extend((child, depth + 1) for child in item.values())
+            continue
+        raise ETradeBrokerReaderIntegrityError(
+            "broker JSON contains an unsupported scalar"
+        )
+
+
+def _canonical_json(value: Any) -> str:
+    _validate_canonical_tree(value)
+    return json.dumps(
+        value,
+        sort_keys=True,
+        separators=(",", ":"),
+        ensure_ascii=True,
+    )
+
+
+def _validate_canonical_tree(value: Any) -> None:
+    stack: list[tuple[Any, int]] = [(value, 0)]
+    nodes = 0
+    while stack:
+        item, depth = stack.pop()
+        nodes += 1
+        if nodes > _MAX_JSON_NODES or depth > _MAX_JSON_DEPTH:
+            raise ETradeBrokerReaderIntegrityError(
+                "normalized broker evidence exceeds complexity bounds"
+            )
+        item_type = type(item)
+        if item is None or item_type in {str, bool, int}:
+            continue
+        if item_type is list:
+            stack.extend((child, depth + 1) for child in item)
+            continue
+        if item_type is dict:
+            if any(type(key) is not str for key in item):
+                raise ETradeBrokerReaderIntegrityError(
+                    "normalized broker evidence keys must be strings"
+                )
+            stack.extend((child, depth + 1) for child in item.values())
+            continue
+        raise ETradeBrokerReaderIntegrityError(
+            "normalized broker evidence contains an unsupported scalar"
+        )
+
+
+def _domain_json_hash(domain: bytes, value: Any) -> str:
+    if type(domain) is not bytes or not domain.endswith(b"\0"):
+        raise ETradeBrokerReaderIntegrityError(
+            "reader hash domain is invalid"
+        )
+    return hashlib.sha256(
+        domain + _canonical_json(value).encode("utf-8")
+    ).hexdigest()
+
+
+def _exact_object(
+    value: Any, keys: set[str], label: str
+) -> dict[str, Any]:
+    result = _object(value, label)
+    if set(result) != keys:
+        raise ETradeBrokerReaderIntegrityError(
+            f"{label} has an unexpected shape"
+        )
+    return result
+
+
+def _object(value: Any, label: str) -> dict[str, Any]:
+    if type(value) is not dict:
+        raise ETradeBrokerReaderIntegrityError(
+            f"{label} must be an object"
+        )
+    return value
+
+
+def _ascii_text(
+    value: Any, label: str, *, maximum: int = 256
+) -> str:
+    if (
+        type(value) is not str
+        or not value
+        or len(value) > maximum
+        or any(ord(char) < 33 or ord(char) > 126 for char in value)
+    ):
+        raise ETradeBrokerReaderIntegrityError(
+            f"{label} must be bounded printable ASCII"
+        )
+    return value
+
+
+def _optional_ascii_text(value: Any, label: str) -> str | None:
+    if value is None:
+        return None
+    return _ascii_text(value, label)
+
+
+def _integer_text(
+    value: Any,
+    label: str,
+    *,
+    nonnegative: bool = False,
+    positive: bool = False,
+) -> str:
+    if type(value) is int:
+        text = str(value)
+    elif type(value) is str:
+        text = value
+    else:
+        raise ETradeBrokerReaderIntegrityError(
+            f"{label} must be an exact integer"
+        )
+    if (
+        not text
+        or len(text) > 20
+        or text.startswith("+")
+        or (text.startswith("-") and not text[1:].isdigit())
+        or (not text.startswith("-") and not text.isdigit())
+        or (len(text.lstrip("-")) > 1 and text.lstrip("-").startswith("0"))
+    ):
+        raise ETradeBrokerReaderIntegrityError(
+            f"{label} must be a canonical integer"
+        )
+    number = int(text)
+    if positive and number <= 0:
+        raise ETradeBrokerReaderIntegrityError(
+            f"{label} must be positive"
+        )
+    if nonnegative and number < 0:
+        raise ETradeBrokerReaderIntegrityError(
+            f"{label} must be non-negative"
+        )
+    return str(number)
+
+
+def _positive_int(value: Any, label: str) -> int:
+    return int(_integer_text(value, label, positive=True))
+
+
+def _integral_decimal_text(
+    value: Any,
+    label: str,
+    *,
+    nonnegative: bool = False,
+    positive: bool = False,
+) -> str:
+    text = _decimal_text(
+        value,
+        label,
+        nonnegative=nonnegative,
+        positive=positive,
+    )
+    number = Decimal(text)
+    if number != number.to_integral_value():
+        raise ETradeBrokerReaderIntegrityError(
+            f"{label} must be an integral quantity"
+        )
+    return str(int(number))
+
+
+def _epoch_milliseconds_text(value: Any, label: str) -> str:
+    text = _integer_text(value, label, positive=True)
+    if len(text) != 13:
+        raise ETradeBrokerReaderIntegrityError(
+            f"{label} must be Unix epoch milliseconds"
+        )
+    return text
+
+
+def _broker_int64_text(value: Any, label: str) -> str:
+    text = _integer_text(value, label, positive=True)
+    if int(text) > _MAX_BROKER_INT64:
+        raise ETradeBrokerReaderIntegrityError(
+            f"{label} exceeds signed broker int64"
+        )
+    return text
+
+
+def _optional_broker_id(value: Any, label: str) -> str | None:
+    if value is None:
+        return None
+    return _broker_int64_text(value, label)
+
+
+def _first_optional_broker_id(
+    first: Any, second: Any, label: str
+) -> str | None:
+    values = [
+        _optional_broker_id(value, label)
+        for value in (first, second)
+        if value is not None
+    ]
+    if not values:
+        return None
+    if len(set(values)) != 1:
+        raise ETradeBrokerReaderIntegrityError(
+            f"{label} conflicts across order/detail"
+        )
+    return values[0]
+
+
+def _decimal_text(
+    value: Any,
+    label: str,
+    *,
+    nonnegative: bool = False,
+    positive: bool = False,
+) -> str:
+    if type(value) not in {str, int, Decimal}:
+        raise ETradeBrokerReaderIntegrityError(
+            f"{label} must be a decimal-compatible primitive"
+        )
+    try:
+        number = Decimal(str(value))
+    except (InvalidOperation, ValueError) as exc:
+        raise ETradeBrokerReaderIntegrityError(
+            f"{label} is not a valid decimal"
+        ) from exc
+    if (
+        not number.is_finite()
+        or number.adjusted() > 100
+        or number.adjusted() < -100
+        or positive
+        and number <= 0
+        or nonnegative
+        and number < 0
+    ):
+        raise ETradeBrokerReaderIntegrityError(
+            f"{label} is outside its finite bounds"
+        )
+    normalized = format(number, "f")
+    if "." in normalized:
+        normalized = normalized.rstrip("0").rstrip(".")
+    return "0" if normalized in {"", "-0"} else normalized
+
+
+def _optional_decimal_text(value: Any, label: str) -> str | None:
+    if value is None:
+        return None
+    return _decimal_text(value, label)
+
+
+def _bool(value: Any, label: str) -> bool:
+    if type(value) is bool:
+        return value
+    if value == "true":
+        return True
+    if value == "false":
+        return False
+    raise ETradeBrokerReaderIntegrityError(
+        f"{label} must be an exact boolean"
+    )
+
+
+def _optional_bool(value: Any, label: str) -> bool | None:
+    if value is None:
+        return None
+    return _bool(value, label)
+
+
+def _normalize_product(value: Any, label: str) -> dict[str, Any]:
+    product = _object(value, label)
+    symbol = _ascii_text(product.get("symbol"), f"{label} symbol")
+    security_type = _ascii_text(
+        product.get("securityType"), f"{label} security type"
+    )
+    product_id = product.get("ProductId", product.get("productId"))
+    if product_id is not None:
+        product_id_object = _object(product_id, f"{label} product id")
+        normalized_product_id = {
+            "symbol": _optional_ascii_text(
+                product_id_object.get(
+                    "symbol", product_id_object.get("Symbol")
+                ),
+                f"{label} product-id symbol",
+            ),
+            "type_code": _optional_ascii_text(
+                product_id_object.get(
+                    "typeCode", product_id_object.get("TypeCode")
+                ),
+                f"{label} product-id type",
+            ),
+        }
+    else:
+        normalized_product_id = None
+    return {
+        "symbol": symbol,
+        "security_type": security_type,
+        "call_put": _optional_ascii_text(
+            product.get("callPut"), f"{label} call/put"
+        ),
+        "expiry_year": (
+            _integer_text(
+                product["expiryYear"],
+                f"{label} expiry year",
+                positive=True,
+            )
+            if "expiryYear" in product
+            else None
+        ),
+        "expiry_month": (
+            _integer_text(
+                product["expiryMonth"],
+                f"{label} expiry month",
+                positive=True,
+            )
+            if "expiryMonth" in product
+            else None
+        ),
+        "expiry_day": (
+            _integer_text(
+                product["expiryDay"],
+                f"{label} expiry day",
+                positive=True,
+            )
+            if "expiryDay" in product
+            else None
+        ),
+        "strike_price": _optional_decimal_text(
+            product.get("strikePrice"), f"{label} strike price"
+        ),
+        "product_id": normalized_product_id,
+    }
+
+
+def _normalize_generic_instrument(value: Any) -> dict[str, Any]:
+    instrument = _object(value, "Instrument")
+    ordered = instrument.get(
+        "orderedQuantity", instrument.get("quantity")
+    )
+    if ordered is None:
+        raise ETradeBrokerReaderIntegrityError(
+            "active-order instrument lacks ordered quantity"
+        )
+    ordered_text = _decimal_text(
+        ordered, "instrument ordered quantity", nonnegative=True
+    )
+    filled_text = _decimal_text(
+        instrument.get("filledQuantity", "0"),
+        "instrument filled quantity",
+        nonnegative=True,
+    )
+    cancel_text = _decimal_text(
+        instrument.get("cancelQuantity", "0"),
+        "instrument cancel quantity",
+        nonnegative=True,
+    )
+    return {
+        "product": _normalize_product(
+            instrument.get("Product"), "instrument product"
+        ),
+        "order_action": _ascii_text(
+            instrument.get("orderAction"), "instrument order action"
+        ),
+        "quantity_type": _optional_ascii_text(
+            instrument.get("quantityType"), "instrument quantity type"
+        ),
+        "ordered_quantity": ordered_text,
+        "filled_quantity": filled_text,
+        "cancel_quantity": cancel_text,
+    }
+
+
+def _normalize_known_leg(value: Any) -> dict[str, Any]:
+    instrument = _object(value, "known Instrument")
+    product = _normalize_product(
+        instrument.get("Product"), "known option product"
+    )
+    if (
+        product["security_type"] != "OPTN"
+        or product["call_put"] not in {"CALL", "PUT"}
+        or any(
+            product[field] is None
+            for field in (
+                "expiry_year",
+                "expiry_month",
+                "expiry_day",
+                "strike_price",
+            )
+        )
+    ):
+        raise ETradeBrokerReaderIntegrityError(
+            "known vertical leg product is incomplete"
+        )
+    if _ascii_text(
+        instrument.get("quantityType"), "known quantity type"
+    ) != "QUANTITY":
+        raise ETradeBrokerReaderIntegrityError(
+            "known vertical quantity type changed"
+        )
+    quantity = _integral_decimal_text(
+        instrument.get(
+            "orderedQuantity", instrument.get("quantity")
+        ),
+        "known ordered quantity",
+        positive=True,
+    )
+    filled = _integral_decimal_text(
+        instrument.get("filledQuantity", "0"),
+        "known filled quantity",
+        nonnegative=True,
+    )
+    if int(filled) > int(quantity):
+        raise ETradeBrokerReaderIntegrityError(
+            "known filled quantity exceeds ordered quantity"
+        )
+    action = _ascii_text(
+        instrument.get("orderAction"), "known order action"
+    )
+    if action not in {"BUY_OPEN", "SELL_OPEN"}:
+        raise ETradeBrokerReaderIntegrityError(
+            "known vertical leg is not opening exposure"
+        )
+    return {
+        "symbol": product["symbol"],
+        "securityType": product["security_type"],
+        "callPut": product["call_put"],
+        "expiryYear": product["expiry_year"],
+        "expiryMonth": product["expiry_month"],
+        "expiryDay": product["expiry_day"],
+        "strikePrice": product["strike_price"],
+        "orderAction": action,
+        "quantityType": "QUANTITY",
+        "quantity": quantity,
+        "filledQuantity": filled,
+    }

--- a/etrade_python_client/live_trading/etrade_broker_transport.py
+++ b/etrade_python_client/live_trading/etrade_broker_transport.py
@@ -43,14 +43,15 @@ from live_trading.runtime_safety import RuntimeSafetyBoundary
 
 
 _MAX_AUTHORIZATION_BYTES = 32 * 1024
-_MAX_RESPONSE_BYTES = 64 * 1024
+_MAX_MUTATION_RESPONSE_BYTES = 64 * 1024
+_MAX_RESPONSE_BYTES = 2 * 1024 * 1024
 _MAX_RESPONSE_NODES = 512
 _REQUEST_TIMEOUT = (3.05, 10.0)
 _RESPONSE_WALL_TIMEOUT_SECONDS = 12.0
 _TOTAL_EXCHANGE_TIMEOUT_SECONDS = 15.0
 _EXCHANGE_RESULT_HEADER_BYTES = 39
 _EXCHANGE_RESULT_BUFFER_BYTES = (
-    _EXCHANGE_RESULT_HEADER_BYTES + _MAX_RESPONSE_BYTES + 1
+    _EXCHANGE_RESULT_HEADER_BYTES + _MAX_MUTATION_RESPONSE_BYTES + 1
 )
 _EXCHANGE_KIND_CODES = {
     "RESPONSE": 1,
@@ -80,7 +81,7 @@ class ETradeBrokerTransportError(RuntimeError):
 class _PreparedExchange:
     """Pickle-safe exact request handed to the isolated HTTP worker."""
 
-    method: Literal["POST", "PUT"]
+    method: Literal["GET", "POST", "PUT"]
     url: str
     headers: tuple[tuple[str, str], ...] = field(repr=False)
     body: bytes = field(repr=False)
@@ -727,7 +728,7 @@ def _copy_bound_request(request: BoundBrokerRequest) -> BoundBrokerRequest:
 
 
 def _require_pinned_adapter(adapter: HTTPAdapter) -> None:
-    """Reject any adapter configuration that could replay a mutation."""
+    """Reject retries and redirects for every isolated broker exchange."""
 
     if type(adapter) is not HTTPAdapter:
         raise ETradeBrokerTransportError(
@@ -771,15 +772,13 @@ def _validate_prepared_exchange(exchange: _PreparedExchange) -> None:
     parsed = urlsplit(exchange.url)
     if (
         type(exchange.method) is not str
-        or exchange.method not in {"POST", "PUT"}
+        or exchange.method not in {"GET", "POST", "PUT"}
         or type(exchange.url) is not str
         or parsed.scheme != "https"
-        or not parsed.netloc
-        or parsed.query
+        or f"{parsed.scheme}://{parsed.netloc}" not in _ETRADE_ORIGINS.values()
         or parsed.fragment
         or type(exchange.headers) is not tuple
         or type(exchange.body) is not bytes
-        or not exchange.body
     ):
         raise ETradeBrokerTransportError("isolated exchange request is invalid")
     normalized: dict[str, str] = {}
@@ -800,20 +799,30 @@ def _validate_prepared_exchange(exchange: _PreparedExchange) -> None:
                 "isolated exchange headers contain duplicates"
             )
         normalized[name] = pair[1]
-    expected_headers = {
-        "content-type",
+    common_headers = {
         "accept",
         "accept-encoding",
         "consumerkey",
-        "content-length",
         "authorization",
     }
+    if exchange.method == "GET":
+        valid_shape = (
+            not exchange.body
+            and set(normalized) == common_headers
+        )
+    else:
+        valid_shape = (
+            bool(exchange.body)
+            and not parsed.query
+            and set(normalized)
+            == common_headers | {"content-type", "content-length"}
+            and normalized["content-type"] == "application/xml"
+            and normalized["content-length"] == str(len(exchange.body))
+        )
     if (
-        set(normalized) != expected_headers
-        or normalized["content-type"] != "application/xml"
+        not valid_shape
         or normalized["accept"] != "application/json"
         or normalized["accept-encoding"] != "identity"
-        or normalized["content-length"] != str(len(exchange.body))
         or not normalized["consumerkey"]
         or not normalized["authorization"].startswith("OAuth ")
     ):
@@ -863,7 +872,7 @@ def _serialized_prepared_request(prepared: Any) -> _PreparedExchange:
         method=prepared.method,
         url=prepared.url,
         headers=tuple((name, value) for name, value in headers.items()),
-        body=prepared.body,
+        body=b"" if prepared.body is None else prepared.body,
     )
 
 
@@ -874,7 +883,7 @@ def _reconstruct_prepared_request(exchange: _PreparedExchange) -> PreparedReques
         method=exchange.method,
         url=exchange.url,
         headers=dict(exchange.headers),
-        data=exchange.body,
+        data=None if exchange.method == "GET" else exchange.body,
     )
     reconstructed = _serialized_prepared_request(prepared)
     if reconstructed != exchange:
@@ -886,7 +895,10 @@ def _reconstruct_prepared_request(exchange: _PreparedExchange) -> PreparedReques
 
 def _write_exchange_result(output: Any, result: _ExchangeResult) -> None:
     _validate_exchange_result(result)
-    if len(output) != _EXCHANGE_RESULT_BUFFER_BYTES:
+    if len(output) not in {
+        _EXCHANGE_RESULT_HEADER_BYTES + _MAX_MUTATION_RESPONSE_BYTES + 1,
+        _EXCHANGE_RESULT_HEADER_BYTES + _MAX_RESPONSE_BYTES + 1,
+    }:
         raise ETradeBrokerTransportError(
             "isolated exchange result buffer is invalid"
         )
@@ -908,8 +920,18 @@ def _write_exchange_result(output: Any, result: _ExchangeResult) -> None:
     output[:_EXCHANGE_RESULT_HEADER_BYTES] = header
 
 
-def _read_exchange_result(output: Any) -> _ExchangeResult:
-    if len(output) != _EXCHANGE_RESULT_BUFFER_BYTES:
+def _read_exchange_result(
+    output: Any,
+    *,
+    max_response_bytes: int = _MAX_MUTATION_RESPONSE_BYTES,
+) -> _ExchangeResult:
+    if (
+        type(max_response_bytes) is not int
+        or max_response_bytes
+        not in {_MAX_MUTATION_RESPONSE_BYTES, _MAX_RESPONSE_BYTES}
+        or len(output)
+        != _EXCHANGE_RESULT_HEADER_BYTES + max_response_bytes + 1
+    ):
         raise ETradeBrokerTransportError(
             "isolated exchange result buffer is invalid"
         )
@@ -918,7 +940,7 @@ def _read_exchange_result(output: Any) -> _ExchangeResult:
         "!BHI32s", header
     )
     kind = _EXCHANGE_CODE_KINDS.get(code)
-    if kind is None or raw_length > _MAX_RESPONSE_BYTES + 1:
+    if kind is None or raw_length > max_response_bytes + 1:
         raise ETradeBrokerTransportError(
             "isolated exchange result frame is invalid"
         )
@@ -939,8 +961,12 @@ def _read_exchange_result(output: Any) -> _ExchangeResult:
     return result
 
 
-def _exchange_worker(output: Any, exchange: _PreparedExchange) -> None:
-    """Perform exactly one mutation in a disposable process."""
+def _exchange_worker(
+    output: Any,
+    exchange: _PreparedExchange,
+    max_response_bytes: int,
+) -> None:
+    """Perform exactly one bounded broker exchange in a disposable process."""
 
     adapter: HTTPAdapter | None = None
     try:
@@ -955,7 +981,9 @@ def _exchange_worker(output: Any, exchange: _PreparedExchange) -> None:
             proxies={},
         )
         try:
-            status, raw = _read_bounded_response(response)
+            status, raw = _read_bounded_response(
+                response, max_response_bytes=max_response_bytes
+            )
         except (Timeout, TimeoutError):
             result = _ExchangeResult("TIMEOUT")
         except Exception:
@@ -991,21 +1019,30 @@ def _stop_exchange_process(process: Any) -> None:
 
 
 def _isolated_exchange(
-    prepared: Any, *, timeout_seconds: float
+    prepared: Any,
+    *,
+    timeout_seconds: float,
+    max_response_bytes: int = _MAX_MUTATION_RESPONSE_BYTES,
 ) -> _ExchangeResult:
     """Enforce one hard deadline over connect, headers, and response body."""
 
     if (
         type(timeout_seconds) is not float
         or not 0 < timeout_seconds <= _TOTAL_EXCHANGE_TIMEOUT_SECONDS
+        or type(max_response_bytes) is not int
+        or max_response_bytes
+        not in {_MAX_MUTATION_RESPONSE_BYTES, _MAX_RESPONSE_BYTES}
     ):
         raise ETradeBrokerTransportError("total exchange deadline is invalid")
     exchange = _serialized_prepared_request(prepared)
     context = multiprocessing.get_context("spawn")
-    output = context.RawArray("B", _EXCHANGE_RESULT_BUFFER_BYTES)
+    output = context.RawArray(
+        "B",
+        _EXCHANGE_RESULT_HEADER_BYTES + max_response_bytes + 1,
+    )
     process = context.Process(
         target=_exchange_worker,
-        args=(output, exchange),
+        args=(output, exchange, max_response_bytes),
         daemon=True,
     )
     deadline = time.monotonic() + timeout_seconds
@@ -1018,7 +1055,9 @@ def _isolated_exchange(
         if process.is_alive():
             return _ExchangeResult("TIMEOUT")
         try:
-            result = _read_exchange_result(output)
+            result = _read_exchange_result(
+                output, max_response_bytes=max_response_bytes
+            )
         except Exception:
             return _ExchangeResult("TRANSPORT_ERROR")
         return result
@@ -1478,7 +1517,7 @@ def _parse_reply_bytes(
             observed_at=observed_at,
         )
     raw_digest = hashlib.sha256(raw).hexdigest()
-    if len(raw) > _MAX_RESPONSE_BYTES:
+    if len(raw) > _MAX_MUTATION_RESPONSE_BYTES:
         return _unknown_reply(
             request,
             "RESPONSE_TOO_LARGE",
@@ -1584,7 +1623,19 @@ def _parse_reply_bytes(
     )
 
 
-def _read_bounded_response(response: Any) -> tuple[int, bytes]:
+def _read_bounded_response(
+    response: Any,
+    *,
+    max_response_bytes: int = _MAX_MUTATION_RESPONSE_BYTES,
+) -> tuple[int, bytes]:
+    if (
+        type(max_response_bytes) is not int
+        or max_response_bytes
+        not in {_MAX_MUTATION_RESPONSE_BYTES, _MAX_RESPONSE_BYTES}
+    ):
+        raise ETradeBrokerTransportError(
+            "broker response byte bound is invalid"
+        )
     status = getattr(response, "status_code", None)
     raw_stream = getattr(response, "raw", None)
     reader = getattr(raw_stream, "read1", None)
@@ -1621,7 +1672,7 @@ def _read_bounded_response(response: Any) -> tuple[int, bytes]:
                 type(content_length) is not str
                 or not content_length.isascii()
                 or not content_length.isdigit()
-                or int(content_length) > _MAX_RESPONSE_BYTES
+                or int(content_length) > max_response_bytes
             ):
                 raise ETradeBrokerTransportError(
                     "broker response length is invalid"
@@ -1629,12 +1680,12 @@ def _read_bounded_response(response: Any) -> tuple[int, bytes]:
         deadline = time.monotonic() + _RESPONSE_WALL_TIMEOUT_SECONDS
         chunks: list[bytes] = []
         total = 0
-        while total <= _MAX_RESPONSE_BYTES:
+        while total <= max_response_bytes:
             if time.monotonic() >= deadline:
                 raise TimeoutError("broker response wall deadline expired")
             amount = min(
                 read_chunk_size,
-                _MAX_RESPONSE_BYTES + 1 - total,
+                max_response_bytes + 1 - total,
             )
             try:
                 chunk = reader(amount, decode_content=False)

--- a/etrade_python_client/live_trading/etrade_order_gateway.py
+++ b/etrade_python_client/live_trading/etrade_order_gateway.py
@@ -12,7 +12,7 @@ import json
 from dataclasses import dataclass, field
 from datetime import datetime, timezone
 from decimal import Decimal
-from typing import Any, Literal, Protocol, runtime_checkable
+from typing import Any, Literal
 
 from live_trading.etrade_broker_transport import (
     BrokerReply,
@@ -20,11 +20,19 @@ from live_trading.etrade_broker_transport import (
     ETradeBrokerTransportError,
     SelectedBrokerAccount,
 )
+from live_trading.etrade_broker_reader import (
+    ETradeBrokerReader,
+    ETradeBrokerReaderError,
+    ETradeBrokerReaderIntegrityError,
+    ETradeBrokerReaderUnavailable,
+)
 from live_trading.order_intent_ledger import (
-    AccountCapacityEvidence,
+    BrokerReadEvidenceRef,
     BrokerEvidence,
+    CapacityDecisionReceipt,
     IntentRecord,
     OrderIntent,
+    OrderIntentBrokerTermsMismatch,
     OrderIntentIntegrityError,
     OrderIntentLedger,
     OrderIntentLedgerError,
@@ -38,7 +46,6 @@ from live_trading.runtime_safety import RuntimeSafetyBoundary, RuntimeSafetyErro
 
 
 _MAX_COMMAND_BYTES = 32 * 1024
-_MAX_EVIDENCE_AGE_SECONDS = 300
 _MAX_LEASE_SECONDS = 300
 
 
@@ -52,76 +59,6 @@ class GatewayValidationError(EtradeOrderGatewayError):
 
 class GatewayReconciliationRequired(EtradeOrderGatewayError):
     """New mutations are blocked by unresolved durable broker work."""
-
-
-@dataclass(frozen=True)
-class BrokerCapacitySnapshot:
-    """Complete account risk snapshot produced by a read-only adapter."""
-
-    account: SelectedBrokerAccount
-    environment: Literal["sandbox", "production"]
-    broker_buying_power: Decimal
-    observed_at: datetime
-    portfolio_snapshot_digest: str
-    positions_complete: bool
-    open_orders_complete: bool
-    source_response_digests: tuple[str, ...]
-
-
-@dataclass(frozen=True)
-class BrokerOrderSnapshot:
-    """Exact normalized status for one known broker order id."""
-
-    account: SelectedBrokerAccount
-    environment: Literal["sandbox", "production"]
-    broker_order_id: str = field(repr=False)
-    outcome: Literal[
-        "OPEN",
-        "FILLED",
-        "CANCELLED",
-        "REJECTED",
-        "EXPIRED",
-        "UNRESOLVED",
-    ]
-    observed_at: datetime
-    http_status: int
-    raw_response_digest: str
-    order_payload_hash: str
-    complete: bool
-
-
-@dataclass(frozen=True)
-class BrokerOrderNotFound:
-    """Complete negative lookup for one known broker order id."""
-
-    account: SelectedBrokerAccount
-    environment: Literal["sandbox", "production"]
-    broker_order_id: str = field(repr=False)
-    observed_at: datetime
-    http_status: int
-    raw_response_digest: str
-    complete: bool
-
-
-@runtime_checkable
-class EtradeBrokerReader(Protocol):
-    """Read-only evidence required by the order coordinator."""
-
-    def assert_gateway_binding(
-        self, runtime_safety: RuntimeSafetyBoundary
-    ) -> None: ...
-
-    def selected_account(self) -> SelectedBrokerAccount: ...
-
-    def read_capacity(
-        self, account: SelectedBrokerAccount
-    ) -> BrokerCapacitySnapshot: ...
-
-    def query_order(
-        self,
-        account: SelectedBrokerAccount,
-        broker_order_id: str,
-    ) -> BrokerOrderSnapshot | BrokerOrderNotFound: ...
 
 
 @dataclass(frozen=True)
@@ -166,11 +103,21 @@ class _ReconciliationContext:
     operation: Literal["ORDER_QUERY", "AMEND_QUERY"]
     client_order_id: str = field(repr=False)
     broker_order_id: str = field(repr=False)
-    expected_order_payload_hash: str
 
 
 class EtradeOrderGateway:
     """Compose runtime arming, durable state, typed reads, and one transport."""
+
+    __slots__ = (
+        "_runtime_safety",
+        "_ledger",
+        "_transport",
+        "_reader",
+        "_opening_risk_budget",
+        "_clock",
+        "_started",
+        "_account",
+    )
 
     def __init__(
         self,
@@ -178,7 +125,7 @@ class EtradeOrderGateway:
         runtime_safety: RuntimeSafetyBoundary,
         ledger: OrderIntentLedger,
         transport: ETradeBrokerTransport,
-        reader: EtradeBrokerReader,
+        reader: ETradeBrokerReader,
         opening_risk_budget: Decimal,
         clock=None,
     ) -> None:
@@ -194,14 +141,18 @@ class EtradeOrderGateway:
             raise GatewayValidationError(
                 "gateway requires the exact hardened ETradeBrokerTransport"
             )
-        if not isinstance(reader, EtradeBrokerReader):
+        if type(reader) is not ETradeBrokerReader:
             raise GatewayValidationError(
-                "reader does not implement the read-only broker protocol"
+                "gateway requires the exact hardened ETradeBrokerReader"
             )
         try:
             transport.assert_gateway_binding(ledger, runtime_safety)
-            reader.assert_gateway_binding(runtime_safety)
-        except (ETradeBrokerTransportError, RuntimeSafetyError) as exc:
+            reader.assert_gateway_binding(ledger, runtime_safety)
+        except (
+            ETradeBrokerTransportError,
+            ETradeBrokerReaderError,
+            RuntimeSafetyError,
+        ) as exc:
             raise GatewayValidationError(
                 "gateway adapters and runtime safety boundary do not match"
             ) from exc
@@ -210,14 +161,41 @@ class EtradeOrderGateway:
             "opening_risk_budget",
             allow_zero=True,
         )
-        self.runtime_safety = runtime_safety
-        self.ledger = ledger
-        self.transport = transport
-        self.reader = reader
+        self._runtime_safety = runtime_safety
+        self._ledger = ledger
+        self._transport = transport
+        self._reader = reader
         self._opening_risk_budget = opening_risk_budget
         self._clock = clock or (lambda: datetime.now(timezone.utc))
         self._started = False
         self._account: SelectedBrokerAccount | None = None
+
+    def __setattr__(self, name: str, value: Any) -> None:
+        if (
+            name
+            not in {"_started", "_account"}
+            and hasattr(self, name)
+        ):
+            raise AttributeError(
+                "gateway safety dependencies are immutable"
+            )
+        object.__setattr__(self, name, value)
+
+    @property
+    def runtime_safety(self) -> RuntimeSafetyBoundary:
+        return self._runtime_safety
+
+    @property
+    def ledger(self) -> OrderIntentLedger:
+        return self._ledger
+
+    @property
+    def transport(self) -> ETradeBrokerTransport:
+        return self._transport
+
+    @property
+    def reader(self) -> ETradeBrokerReader:
+        return self._reader
 
     def start(self) -> None:
         """Reconcile every resolvable prior order before enabling mutation."""
@@ -273,7 +251,6 @@ class EtradeOrderGateway:
             return existing
         if self.ledger.get_margin_reservation(record.intent_id) is None:
             capacity = self._read_capacity(account)
-            self.ledger.set_reservation_cap(capacity)
             self.ledger.reserve_margin(
                 record.intent_id,
                 RiskEvidence(
@@ -286,6 +263,7 @@ class EtradeOrderGateway:
                     portfolio_snapshot_digest=(
                         capacity.portfolio_snapshot_digest
                     ),
+                    capacity_decision_sha256=capacity.decision_sha256,
                 ),
             )
         lease = self.ledger.claim_submission(
@@ -508,13 +486,24 @@ class EtradeOrderGateway:
         )
 
     def _checked_account(self) -> SelectedBrokerAccount:
+        if (
+            type(self._runtime_safety) is not RuntimeSafetyBoundary
+            or type(self._ledger) is not OrderIntentLedger
+            or type(self._transport) is not ETradeBrokerTransport
+            or type(self._reader) is not ETradeBrokerReader
+        ):
+            raise GatewayValidationError(
+                "gateway safety dependency identity changed after construction"
+            )
         initial_now = self._now()
         self.runtime_safety.assert_current(initial_now)
         self.transport.assert_gateway_binding(
             self.ledger, self.runtime_safety
         )
         transport_account = self.transport.selected_account()
-        self.reader.assert_gateway_binding(self.runtime_safety)
+        self.reader.assert_gateway_binding(
+            self.ledger, self.runtime_safety
+        )
         reader_account = self.reader.selected_account()
         _validate_account(transport_account)
         _validate_account(reader_account)
@@ -531,49 +520,54 @@ class EtradeOrderGateway:
     def _read_capacity(
         self,
         account: SelectedBrokerAccount,
-    ) -> AccountCapacityEvidence:
+    ) -> CapacityDecisionReceipt:
         checked = self._checked_account()
         _require_same_account(account, checked)
-        snapshot = self.reader.read_capacity(checked)
-        if type(snapshot) is not BrokerCapacitySnapshot:
+        try:
+            evidence = self.reader.read_capacity(checked)
+        except ETradeBrokerReaderUnavailable as exc:
+            raise GatewayReconciliationRequired(
+                "broker capacity did not yield a stable complete snapshot"
+            ) from exc
+        except ETradeBrokerReaderIntegrityError as exc:
             raise GatewayValidationError(
-                "capacity reader returned an invalid typed response"
-            )
-        _validate_account(snapshot.account)
-        _require_same_account(checked, snapshot.account)
-        _require_environment(
-            self.runtime_safety.environment, snapshot.environment
-        )
-        _exact_decimal(
-            snapshot.broker_buying_power,
-            "broker_buying_power",
-            allow_zero=True,
-        )
-        _fresh_time(snapshot.observed_at, self._now(), "capacity observed_at")
-        _exact_sha256(
-            snapshot.portfolio_snapshot_digest,
-            "portfolio_snapshot_digest",
-        )
+                "broker capacity evidence violated the durable read contract"
+            ) from exc
+        except ETradeBrokerReaderError as exc:
+            raise GatewayReconciliationRequired(
+                "broker capacity could not be read safely"
+            ) from exc
         if (
-            snapshot.positions_complete is not True
-            or snapshot.open_orders_complete is not True
-            or type(snapshot.source_response_digests) is not tuple
-            or not snapshot.source_response_digests
+            type(evidence) is not BrokerReadEvidenceRef
+            or evidence.evidence_kind != "CAPACITY"
         ):
             raise GatewayValidationError(
-                "capacity snapshot must prove complete positions and open orders"
+                "capacity reader returned an invalid durable evidence reference"
             )
-        for digest in snapshot.source_response_digests:
-            _exact_sha256(digest, "capacity source response digest")
+        try:
+            verified = self.ledger.broker_read_evidence(
+                evidence.evidence_sha256
+            )
+        except OrderIntentLedgerError as exc:
+            raise GatewayValidationError(
+                "capacity evidence reference failed durable verification"
+            ) from exc
+        if verified != evidence:
+            raise GatewayValidationError(
+                "capacity evidence reference failed durable verification"
+            )
         self._checked_account()
-        return AccountCapacityEvidence(
-            account_id=checked.account_id,
-            environment=self.runtime_safety.environment,
-            broker_buying_power=snapshot.broker_buying_power,
-            risk_budget=self._opening_risk_budget,
-            observed_at=snapshot.observed_at,
-            portfolio_snapshot_digest=snapshot.portfolio_snapshot_digest,
-        )
+        try:
+            decision = self.ledger.set_reservation_cap_from_read(
+                evidence,
+                risk_budget=self._opening_risk_budget,
+            )
+        except OrderIntentLedgerError as exc:
+            raise GatewayValidationError(
+                "durable capacity evidence could not authorize a cap"
+            ) from exc
+        self._checked_account()
+        return decision
 
     def _reconcile_once(
         self,
@@ -584,55 +578,56 @@ class EtradeOrderGateway:
         if context is None:
             return
         try:
-            reply = self.reader.query_order(
+            read_evidence = self.reader.query_order(
                 account, context.broker_order_id
             )
-        except Exception:
+        except ETradeBrokerReaderUnavailable:
             return
-        if type(reply) not in {BrokerOrderSnapshot, BrokerOrderNotFound}:
-            return
-        try:
-            _validate_order_read(
-                reply,
-                account,
-                context.broker_order_id,
-                self.runtime_safety.environment,
-                self._now(),
-            )
-        except (GatewayValidationError, RuntimeSafetyError):
-            return
-        if type(reply) is BrokerOrderNotFound:
-            return
-        if reply.outcome == "UNRESOLVED":
-            return
+        except ETradeBrokerReaderIntegrityError as exc:
+            raise GatewayValidationError(
+                "durable broker read integrity failed during reconciliation"
+            ) from exc
+        except ETradeBrokerReaderError as exc:
+            raise GatewayReconciliationRequired(
+                "broker reader could not safely reconcile the known order"
+            ) from exc
         if (
-            reply.order_payload_hash
-            != context.expected_order_payload_hash
+            type(read_evidence) is not BrokerReadEvidenceRef
+            or read_evidence.evidence_kind != "ORDER_QUERY"
         ):
-            return
-        evidence = BrokerEvidence(
-            account_id=account.account_id,
-            environment=self.runtime_safety.environment,
-            client_order_id=context.client_order_id,
-            broker_order_id=reply.broker_order_id,
-            operation=context.operation,
-            outcome=reply.outcome,
-            observed_at=reply.observed_at,
-            http_status=reply.http_status,
-            raw_response_digest=reply.raw_response_digest,
-        )
+            raise GatewayValidationError(
+                "order reader returned an invalid durable evidence reference"
+            )
         try:
-            if reply.outcome == "OPEN":
+            evidence = self.ledger.broker_evidence_from_read(
+                record.intent_id,
+                read_evidence,
+                operation=context.operation,
+            )
+        except OrderIntentLedgerError as exc:
+            raise GatewayValidationError(
+                "durable broker order evidence failed ledger validation"
+            ) from exc
+        if evidence is None:
+            return
+        try:
+            if evidence.outcome == "OPEN":
                 if record.pending_operation is not None:
                     self.ledger.reconcile_open(record.intent_id, evidence)
                 else:
                     self.ledger.mark_reconciled(record.intent_id, evidence)
             else:
                 self.ledger.reconcile_terminal(
-                    record.intent_id, reply.outcome, evidence
+                    record.intent_id, evidence.outcome, evidence
                 )
-        except OrderIntentLedgerError:
-            return
+        except OrderIntentBrokerTermsMismatch as exc:
+            raise GatewayReconciliationRequired(
+                "known broker order terms do not match the pending operation"
+            ) from exc
+        except OrderIntentLedgerError as exc:
+            raise GatewayValidationError(
+                "broker evidence could not be applied atomically"
+            ) from exc
 
     def _reconciliation_context(
         self, record: IntentRecord
@@ -646,7 +641,6 @@ class EtradeOrderGateway:
                 "ORDER_QUERY",
                 record.client_order_id,
                 record.broker_order_id,
-                self.ledger.expected_order_payload_hash(record.intent_id),
             )
         operation = (
             "SUBMIT_PLACE"
@@ -664,7 +658,6 @@ class EtradeOrderGateway:
             else "AMEND_QUERY",
             receipt.client_order_id,
             receipt.response.broker_order_id,
-            self.ledger.expected_order_payload_hash(record.intent_id),
         )
 
     def _pending_place_receipt(
@@ -909,67 +902,6 @@ def _require_same_account(
         raise RuntimeSafetyError(
             "broker account identity changed during the operation"
         )
-
-
-def _require_environment(expected: str, actual: str) -> None:
-    if (
-        type(expected) is not str
-        or expected not in {"sandbox", "production"}
-        or type(actual) is not str
-        or actual != expected
-    ):
-        raise RuntimeSafetyError(
-            "broker environment changed during the operation"
-        )
-
-
-def _validate_order_read(
-    reply: BrokerOrderSnapshot | BrokerOrderNotFound,
-    account: SelectedBrokerAccount,
-    broker_order_id: str,
-    environment: str,
-    now: datetime,
-) -> None:
-    _validate_account(reply.account)
-    _require_same_account(account, reply.account)
-    _require_environment(environment, reply.environment)
-    _exact_broker_id(reply.broker_order_id)
-    if reply.broker_order_id != broker_order_id:
-        raise GatewayValidationError(
-            "order read returned a different broker order id"
-        )
-    _fresh_time(reply.observed_at, now, "order observed_at")
-    if type(reply.http_status) is not int or reply.http_status not in {
-        200,
-        404,
-    }:
-        raise GatewayValidationError(
-            "order read has an unsupported HTTP status"
-        )
-    _exact_sha256(reply.raw_response_digest, "order raw_response_digest")
-    if reply.complete is not True:
-        raise GatewayValidationError("order read must be complete")
-    if type(reply) is BrokerOrderSnapshot:
-        _exact_sha256(
-            reply.order_payload_hash, "order_payload_hash"
-        )
-        if reply.http_status != 200 or reply.outcome not in {
-            "OPEN",
-            "FILLED",
-            "CANCELLED",
-            "REJECTED",
-            "EXPIRED",
-            "UNRESOLVED",
-        }:
-            raise GatewayValidationError(
-                "order snapshot outcome is invalid"
-            )
-
-
-def _fresh_time(value: datetime, now: datetime, name: str) -> None:
-    _exact_utc_time(value, name)
-    if value > now or (now - value).total_seconds() > _MAX_EVIDENCE_AGE_SECONDS:
-        raise GatewayValidationError(f"{name} is stale or future-dated")
 
 
 def _exact_payload_bytes(value: Any) -> None:

--- a/etrade_python_client/live_trading/order_intent_ledger.py
+++ b/etrade_python_client/live_trading/order_intent_ledger.py
@@ -25,8 +25,8 @@ from typing import Any, Callable, Iterator, Literal, Mapping
 from urllib.parse import quote
 
 
-SCHEMA_VERSION = 10
-_MIGRATABLE_SCHEMA_VERSIONS = frozenset({8, 9})
+SCHEMA_VERSION = 11
+_MIGRATABLE_SCHEMA_VERSIONS = frozenset({8, 9, 10})
 _BUSY_TIMEOUT_MS = 5_000
 _EVIDENCE_MAX_AGE_SECONDS = 300
 _DECIMAL_PRECISION = 50
@@ -37,6 +37,38 @@ _PREVIEW_RECEIPT_MAX_AGE_SECONDS = 180
 _TRANSPORT_OPERATIONS = frozenset(
     {"SUBMIT_PREVIEW", "SUBMIT_PLACE", "AMEND_PREVIEW", "AMEND_PLACE"}
 )
+_BROKER_READ_KINDS = frozenset(
+    {
+        "ACCOUNT_LIST",
+        "BALANCE",
+        "PORTFOLIO_PAGE",
+        "OPEN_ORDERS_PAGE",
+        "ORDER_DETAIL",
+    }
+)
+_BROKER_READ_COMPLETENESS = frozenset(
+    {"COMPLETE", "HAS_NEXT", "INELIGIBLE"}
+)
+_BROKER_READ_EVIDENCE_KINDS = frozenset({"CAPACITY", "ORDER_QUERY"})
+_BROKER_READ_EVIDENCE_COMPLETENESS = frozenset(
+    {"COMPLETE", "INCOMPLETE", "UNSTABLE"}
+)
+_ETRADE_ORIGINS = {
+    "sandbox": "https://apisb.etrade.com",
+    "production": "https://api.etrade.com",
+}
+_MAX_BROKER_READ_BYTES = 2 * 1024 * 1024
+_MAX_BROKER_READ_SPAN_SECONDS = 60
+_ACTIVE_ORDER_READ_LANES = (
+    "OPEN",
+    "CANCEL_REQUESTED",
+    "INDIVIDUAL_FILLS",
+)
+_READ_REQUEST_HASH_DOMAIN = b"etrade-read-request.v1\0"
+_READ_PARSED_HASH_DOMAIN = b"etrade-read-parsed.v1\0"
+_READ_RECEIPT_HASH_DOMAIN = b"etrade-read-receipt.v1\0"
+_READ_MANIFEST_HASH_DOMAIN = b"etrade-read-manifest.v1\0"
+_CAPACITY_DECISION_HASH_DOMAIN = b"etrade-capacity-decision.v1\0"
 _INTENT_KINDS = frozenset({"OPENING", "CLOSING"})
 _ENVIRONMENTS = frozenset({"sandbox", "production"})
 _TERMINAL_STATES = frozenset({"FILLED", "CANCELLED", "REJECTED", "EXPIRED", "FAILED"})
@@ -128,6 +160,12 @@ class OrderIntentLeaseConflict(OrderIntentLedgerError):
 
 class OrderIntentReconciliationRequired(OrderIntentLedgerError):
     """The account/environment has unfinished broker work to reconcile."""
+
+
+class OrderIntentBrokerTermsMismatch(
+    OrderIntentIntegrityError, OrderIntentReconciliationRequired
+):
+    """Known broker order terms do not yet match the durable operation."""
 
 
 class OrderIntentReservationError(OrderIntentLedgerError):
@@ -317,6 +355,81 @@ class TransportResponseReceipt:
     recorded_at: datetime
 
 
+@dataclass(frozen=True, repr=False)
+class BrokerReadResponseEvidence:
+    """One exact, bounded E*TRADE GET response before semantic assembly."""
+
+    read_kind: Literal[
+        "ACCOUNT_LIST",
+        "BALANCE",
+        "PORTFOLIO_PAGE",
+        "OPEN_ORDERS_PAGE",
+        "ORDER_DETAIL",
+    ]
+    account_id: str
+    account_id_key: str
+    institution_type: str
+    environment: Literal["sandbox", "production"]
+    origin: str
+    route: str
+    query_json: str
+    authorization_sha256: str
+    target_broker_order_id: str | None
+    request_started_at: datetime
+    response_completed_at: datetime
+    http_status: int
+    raw_response_bytes: bytes
+    parser_schema: str
+    parser_code_sha256: str
+    parser_config_sha256: str
+    canonical_parsed_json: str
+    completeness: Literal["COMPLETE", "HAS_NEXT", "INELIGIBLE"]
+
+
+@dataclass(frozen=True)
+class BrokerReadReceiptRef:
+    receipt_sha256: str
+
+
+@dataclass(frozen=True)
+class BrokerReadManifestMember:
+    role: str
+    receipt_sha256: str
+
+
+@dataclass(frozen=True, repr=False)
+class BrokerReadManifestEvidence:
+    """A typed result assembled only from durable raw-response receipts."""
+
+    evidence_kind: Literal["CAPACITY", "ORDER_QUERY"]
+    account_id: str
+    account_id_key: str
+    institution_type: str
+    environment: Literal["sandbox", "production"]
+    origin: str
+    target_broker_order_id: str | None
+    observed_at: datetime
+    completeness: Literal["COMPLETE", "INCOMPLETE", "UNSTABLE"]
+    canonical_result_json: str
+
+
+@dataclass(frozen=True)
+class BrokerReadEvidenceRef:
+    evidence_sha256: str
+    evidence_kind: Literal["CAPACITY", "ORDER_QUERY"]
+
+
+@dataclass(frozen=True)
+class CapacityDecisionReceipt:
+    decision_sha256: str
+    evidence_sha256: str
+    cap_amount: Decimal
+    broker_buying_power: Decimal
+    risk_budget: Decimal
+    observed_at: datetime
+    portfolio_snapshot_digest: str
+
+
 @dataclass(frozen=True)
 class MarginReservation:
     intent_id: str
@@ -329,6 +442,7 @@ class MarginReservation:
     quote_digest: str
     portfolio_observed_at: datetime
     portfolio_snapshot_digest: str
+    capacity_decision_sha256: str | None
     state: str
     released_reason_code: str | None
     created_at: datetime
@@ -348,6 +462,8 @@ class BrokerEvidence:
     observed_at: datetime
     http_status: int
     raw_response_digest: str
+    broker_read_evidence_sha256: str | None = None
+    order_payload_hashes: tuple[str, ...] = ()
 
     def validate(self, now: datetime) -> None:
         if type(self) is not BrokerEvidence:
@@ -368,6 +484,29 @@ class BrokerEvidence:
         if type(self.http_status) is not int or self.http_status < 200 or self.http_status > 299:
             raise OrderIntentValidationError("valid broker evidence requires successful 2xx http_status")
         _validate_sha256("raw_response_digest", self.raw_response_digest)
+        if self.operation in {"ORDER_QUERY", "AMEND_QUERY"}:
+            _validate_sha256(
+                "broker_read_evidence_sha256",
+                self.broker_read_evidence_sha256,
+            )
+            if (
+                type(self.order_payload_hashes) is not tuple
+                or not self.order_payload_hashes
+                or len(set(self.order_payload_hashes))
+                != len(self.order_payload_hashes)
+            ):
+                raise OrderIntentValidationError(
+                    "query evidence requires unique durable order payload hashes"
+                )
+            for payload_hash in self.order_payload_hashes:
+                _validate_sha256("order_payload_hash", payload_hash)
+        elif (
+            self.broker_read_evidence_sha256 is not None
+            or self.order_payload_hashes
+        ):
+            raise OrderIntentValidationError(
+                "transport acknowledgements cannot claim broker-read provenance"
+            )
 
 
 @dataclass(frozen=True)
@@ -379,6 +518,7 @@ class RiskEvidence:
     quote_digest: str
     portfolio_observed_at: datetime
     portfolio_snapshot_digest: str
+    capacity_decision_sha256: str
 
     def validate(self, now: datetime) -> None:
         if type(self) is not RiskEvidence:
@@ -397,6 +537,10 @@ class RiskEvidence:
         if self.portfolio_observed_at > now + timedelta(seconds=5) or now - self.portfolio_observed_at > timedelta(seconds=_EVIDENCE_MAX_AGE_SECONDS):
             raise OrderIntentValidationError("portfolio risk evidence is stale or from the future")
         _validate_sha256("portfolio_snapshot_digest", self.portfolio_snapshot_digest)
+        _validate_sha256(
+            "capacity_decision_sha256",
+            self.capacity_decision_sha256,
+        )
 
 
 @dataclass(frozen=True)
@@ -409,6 +553,7 @@ class AccountCapacityEvidence:
     risk_budget: Decimal
     observed_at: datetime
     portfolio_snapshot_digest: str
+    broker_read_evidence_sha256: str | None = None
 
     def validate(self, now: datetime) -> None:
         if type(self) is not AccountCapacityEvidence:
@@ -424,6 +569,11 @@ class AccountCapacityEvidence:
         if self.observed_at > now + timedelta(seconds=5) or now - self.observed_at > timedelta(seconds=_EVIDENCE_MAX_AGE_SECONDS):
             raise OrderIntentValidationError("capacity evidence is stale or from the future")
         _validate_sha256("portfolio_snapshot_digest", self.portfolio_snapshot_digest)
+        if self.broker_read_evidence_sha256 is not None:
+            _validate_sha256(
+                "broker_read_evidence_sha256",
+                self.broker_read_evidence_sha256,
+            )
 
 
 @dataclass(frozen=True)
@@ -444,6 +594,7 @@ class IntentEvent:
     evidence_operation: str | None
     http_status: int | None
     raw_response_digest: str | None
+    broker_read_evidence_sha256: str | None
     created_at: datetime
 
 
@@ -520,6 +671,22 @@ def _stable_amendment_client_order_id(intent: sqlite3.Row, idempotency_key: str)
     material = "\x1f".join((intent["account_id"], intent["environment"], intent["idempotency_scope"], intent["idempotency_key"], "amend", idempotency_key)).encode("utf-8")
     value = int.from_bytes(hashlib.sha256(_CLIENT_ID_DOMAIN + material).digest()[:8], "big")
     return str(1_000_000_000 + value % 9_000_000_000)
+
+
+def _execute_sql_script(conn: sqlite3.Connection, script: str) -> None:
+    """Execute a multi-statement schema script without SQLite's implicit commit."""
+
+    statement = ""
+    for line in script.splitlines():
+        statement += line + "\n"
+        if sqlite3.complete_statement(statement):
+            if statement.strip():
+                conn.execute(statement)
+            statement = ""
+    if statement.strip():
+        raise OrderIntentLedgerError(
+            "ledger schema script ended with an incomplete statement"
+        )
 
 
 class OrderIntentLedger:
@@ -642,47 +809,7 @@ class OrderIntentLedger:
         _validate_identity("intent_id", intent_id)
         with self._connection() as conn:
             intent = self._require_intent(conn, intent_id)
-            if intent["pending_operation"] == "AMEND":
-                amendment = conn.execute(
-                    "SELECT * FROM amendment_leases WHERE intent_id = ?",
-                    (intent_id,),
-                ).fetchone()
-                if (
-                    amendment is None
-                    or amendment["state"] != "IN_DOUBT"
-                    or int(amendment["fencing_token"])
-                    != int(intent["pending_fence"] or -1)
-                ):
-                    raise OrderIntentIntegrityError(
-                        "pending amendment lacks matching durable order terms"
-                    )
-                result = amendment["payload_hash"]
-            elif intent["pending_operation"] == "SUBMIT":
-                result = intent["payload_hash"]
-            else:
-                completed = conn.execute(
-                    """
-                    SELECT payload_hash, completed_at
-                    FROM amendment_history
-                    WHERE intent_id = ?
-                    ORDER BY completed_at DESC
-                    """,
-                    (intent_id,),
-                ).fetchall()
-                if not completed:
-                    result = intent["payload_hash"]
-                else:
-                    latest_at = int(completed[0]["completed_at"])
-                    latest_hashes = {
-                        row["payload_hash"]
-                        for row in completed
-                        if int(row["completed_at"]) == latest_at
-                    }
-                    if len(latest_hashes) != 1:
-                        raise OrderIntentIntegrityError(
-                            "latest durable amendment terms are ambiguous"
-                        )
-                    result = next(iter(latest_hashes))
+            result = self._expected_order_payload_hash_conn(conn, intent)
         _validate_sha256("expected_order_payload_hash", result)
         return result
 
@@ -746,55 +873,676 @@ class OrderIntentLedger:
             ).fetchall()
         return tuple(_transport_response_receipt(row) for row in rows)
 
-    def set_reservation_cap(self, evidence: AccountCapacityEvidence) -> Decimal:
-        if type(evidence) is not AccountCapacityEvidence:
-            raise OrderIntentValidationError("set_reservation_cap requires typed AccountCapacityEvidence")
+    def record_broker_read_response(
+        self, evidence: BrokerReadResponseEvidence
+    ) -> BrokerReadReceiptRef:
+        """Persist one exact bounded GET response before returning it to a reader."""
+
         now = self._now_us()
-        AccountCapacityEvidence.validate(evidence, _from_us(now))
-        cap = _canonical_amount(min(evidence.broker_buying_power, evidence.risk_budget))
+        _validate_broker_read_response_evidence(evidence, _from_us(now))
+        from live_trading.etrade_broker_reader import (
+            _PARSER_CODE_SHA256,
+            _PARSER_CONFIG_SHA256,
+            _PARSER_SCHEMA,
+            _reparse_broker_read_response,
+        )
+
+        if (
+            evidence.parser_schema != _PARSER_SCHEMA
+            or evidence.parser_code_sha256 != _PARSER_CODE_SHA256
+            or evidence.parser_config_sha256 != _PARSER_CONFIG_SHA256
+        ):
+            raise OrderIntentIntegrityError(
+                "broker read response did not use the installed parser"
+            )
+        reparsed_json, reparsed_completeness = (
+            _reparse_broker_read_response(evidence)
+        )
+        if (
+            not hmac.compare_digest(
+                reparsed_json, evidence.canonical_parsed_json
+            )
+            or reparsed_completeness != evidence.completeness
+        ):
+            raise OrderIntentIntegrityError(
+                "broker read parser output does not match raw response bytes"
+            )
+        request_material = {
+            "read_kind": evidence.read_kind,
+            "account_id": evidence.account_id,
+            "account_id_key": evidence.account_id_key,
+            "institution_type": evidence.institution_type,
+            "environment": evidence.environment,
+            "origin": evidence.origin,
+            "http_method": "GET",
+            "route": evidence.route,
+            "query_json": evidence.query_json,
+            "authorization_sha256": evidence.authorization_sha256,
+            "target_broker_order_id": evidence.target_broker_order_id,
+        }
+        request_sha256 = _domain_json_hash(
+            _READ_REQUEST_HASH_DOMAIN, request_material
+        )
+        raw_response_sha256 = hashlib.sha256(
+            evidence.raw_response_bytes
+        ).hexdigest()
+        canonical_parsed_sha256 = _domain_bytes_hash(
+            _READ_PARSED_HASH_DOMAIN,
+            evidence.canonical_parsed_json.encode("utf-8"),
+        )
+        request_started_at = _to_us(evidence.request_started_at)
+        response_completed_at = _to_us(evidence.response_completed_at)
+        # The broker-observed completion time is deterministic, so a crash
+        # after commit but before return can replay to the same content ID.
+        recorded_at = response_completed_at
+        receipt_material = {
+            "request_sha256": request_sha256,
+            "request_started_at": request_started_at,
+            "response_completed_at": response_completed_at,
+            "http_status": evidence.http_status,
+            "raw_byte_length": len(evidence.raw_response_bytes),
+            "raw_response_sha256": raw_response_sha256,
+            "parser_schema": evidence.parser_schema,
+            "parser_code_sha256": evidence.parser_code_sha256,
+            "parser_config_sha256": evidence.parser_config_sha256,
+            "canonical_parsed_sha256": canonical_parsed_sha256,
+            "completeness": evidence.completeness,
+            "recorded_at": recorded_at,
+        }
+        receipt_sha256 = _domain_json_hash(
+            _READ_RECEIPT_HASH_DOMAIN, receipt_material
+        )
+        values = (
+            receipt_sha256,
+            evidence.read_kind,
+            evidence.account_id,
+            evidence.account_id_key,
+            evidence.institution_type,
+            evidence.environment,
+            evidence.origin,
+            "GET",
+            evidence.route,
+            evidence.query_json,
+            evidence.authorization_sha256,
+            request_sha256,
+            evidence.target_broker_order_id,
+            request_started_at,
+            response_completed_at,
+            evidence.http_status,
+            evidence.raw_response_bytes,
+            len(evidence.raw_response_bytes),
+            raw_response_sha256,
+            evidence.parser_schema,
+            evidence.parser_code_sha256,
+            evidence.parser_config_sha256,
+            evidence.canonical_parsed_json,
+            canonical_parsed_sha256,
+            evidence.completeness,
+            recorded_at,
+        )
         with self._transaction() as conn:
             existing = conn.execute(
+                """
+                SELECT * FROM broker_read_receipts
+                WHERE receipt_sha256 = ?
+                """,
+                (receipt_sha256,),
+            ).fetchone()
+            if existing is None:
+                conn.execute(
+                    """
+                    INSERT INTO broker_read_receipts (
+                        receipt_sha256, read_kind, account_id, account_id_key,
+                        institution_type, environment, origin, http_method,
+                        route, query_json, authorization_sha256,
+                        request_sha256,
+                        target_broker_order_id, request_started_at,
+                        response_completed_at, http_status, raw_response_bytes,
+                        raw_byte_length, raw_response_sha256, parser_schema,
+                        parser_code_sha256, parser_config_sha256,
+                        canonical_parsed_json, canonical_parsed_sha256,
+                        completeness, recorded_at
+                    ) VALUES (
+                        ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?,
+                        ?, ?, ?, ?, ?, ?, ?, ?, ?
+                    )
+                    """,
+                    values,
+                )
+            else:
+                columns = (
+                    "receipt_sha256",
+                    "read_kind",
+                    "account_id",
+                    "account_id_key",
+                    "institution_type",
+                    "environment",
+                    "origin",
+                    "http_method",
+                    "route",
+                    "query_json",
+                    "authorization_sha256",
+                    "request_sha256",
+                    "target_broker_order_id",
+                    "request_started_at",
+                    "response_completed_at",
+                    "http_status",
+                    "raw_response_bytes",
+                    "raw_byte_length",
+                    "raw_response_sha256",
+                    "parser_schema",
+                    "parser_code_sha256",
+                    "parser_config_sha256",
+                    "canonical_parsed_json",
+                    "canonical_parsed_sha256",
+                    "completeness",
+                    "recorded_at",
+                )
+                if tuple(existing[column] for column in columns) != values:
+                    raise OrderIntentIntegrityError(
+                        "broker read receipt content-address collision"
+                    )
+        return BrokerReadReceiptRef(receipt_sha256)
+
+    def record_broker_read_manifest(
+        self,
+        evidence: BrokerReadManifestEvidence,
+        members: tuple[BrokerReadManifestMember, ...],
+    ) -> BrokerReadEvidenceRef:
+        """Persist one immutable typed result and its ordered response lineage."""
+
+        now = self._now_us()
+        _validate_broker_read_manifest_evidence(evidence, _from_us(now))
+        _validate_broker_read_manifest_members(members)
+        canonical_result_sha256 = _domain_bytes_hash(
+            _READ_PARSED_HASH_DOMAIN,
+            evidence.canonical_result_json.encode("utf-8"),
+        )
+        observed_at = _to_us(evidence.observed_at)
+        created_at = observed_at
+        member_material = [
+            {
+                "ordinal": ordinal,
+                "role": member.role,
+                "receipt_sha256": member.receipt_sha256,
+            }
+            for ordinal, member in enumerate(members)
+        ]
+        manifest_material = {
+            "evidence_kind": evidence.evidence_kind,
+            "account_id": evidence.account_id,
+            "account_id_key": evidence.account_id_key,
+            "institution_type": evidence.institution_type,
+            "environment": evidence.environment,
+            "origin": evidence.origin,
+            "target_broker_order_id": evidence.target_broker_order_id,
+            "observed_at": observed_at,
+            "completeness": evidence.completeness,
+            "canonical_result_sha256": canonical_result_sha256,
+            "members": member_material,
+            "created_at": created_at,
+        }
+        evidence_sha256 = _domain_json_hash(
+            _READ_MANIFEST_HASH_DOMAIN, manifest_material
+        )
+        manifest_values = (
+            evidence_sha256,
+            evidence.evidence_kind,
+            evidence.account_id,
+            evidence.account_id_key,
+            evidence.institution_type,
+            evidence.environment,
+            evidence.origin,
+            evidence.target_broker_order_id,
+            observed_at,
+            evidence.completeness,
+            evidence.canonical_result_json,
+            canonical_result_sha256,
+            created_at,
+        )
+        with self._transaction() as conn:
+            receipt_rows = []
+            for member in members:
+                receipt = conn.execute(
+                    """
+                    SELECT * FROM broker_read_receipts
+                    WHERE receipt_sha256 = ?
+                    """,
+                    (member.receipt_sha256,),
+                ).fetchone()
+                if receipt is None:
+                    raise OrderIntentIntegrityError(
+                        "broker read manifest references an unknown receipt"
+                    )
+                _verify_broker_read_receipt_row(receipt)
+                if (
+                    receipt["account_id"] != evidence.account_id
+                    or receipt["account_id_key"] != evidence.account_id_key
+                    or receipt["institution_type"]
+                    != evidence.institution_type
+                    or receipt["environment"] != evidence.environment
+                    or receipt["origin"] != evidence.origin
+                    or int(receipt["response_completed_at"]) > observed_at
+                ):
+                    raise OrderIntentIntegrityError(
+                        "broker read manifest member binding is inconsistent"
+                    )
+                receipt_rows.append(receipt)
+            if evidence.completeness == "COMPLETE" and any(
+                row["completeness"] == "INELIGIBLE"
+                for row in receipt_rows
+            ):
+                raise OrderIntentIntegrityError(
+                    "complete broker read evidence has an ineligible member"
+                )
+            result = _load_canonical_json_object(
+                evidence.canonical_result_json,
+                "broker read manifest result",
+            )
+            _validate_broker_read_manifest_semantics(
+                evidence_kind=evidence.evidence_kind,
+                account_id=evidence.account_id,
+                account_id_key=evidence.account_id_key,
+                institution_type=evidence.institution_type,
+                target_broker_order_id=evidence.target_broker_order_id,
+                observed_at=observed_at,
+                completeness=evidence.completeness,
+                result=result,
+                member_roles=tuple(member.role for member in members),
+                receipt_rows=tuple(receipt_rows),
+            )
+            existing = conn.execute(
+                """
+                SELECT * FROM broker_read_manifests
+                WHERE evidence_sha256 = ?
+                """,
+                (evidence_sha256,),
+            ).fetchone()
+            if existing is None:
+                conn.execute(
+                    """
+                    INSERT INTO broker_read_manifests (
+                        evidence_sha256, evidence_kind, account_id,
+                        account_id_key, institution_type, environment, origin,
+                        target_broker_order_id, observed_at, completeness,
+                        canonical_result_json, canonical_result_sha256,
+                        created_at
+                    ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+                    """,
+                    manifest_values,
+                )
+                conn.executemany(
+                    """
+                    INSERT INTO broker_read_manifest_members (
+                        evidence_sha256, member_ordinal, member_role,
+                        receipt_sha256
+                    ) VALUES (?, ?, ?, ?)
+                    """,
+                    (
+                        (
+                            evidence_sha256,
+                            ordinal,
+                            member.role,
+                            member.receipt_sha256,
+                        )
+                        for ordinal, member in enumerate(members)
+                    ),
+                )
+            else:
+                columns = (
+                    "evidence_sha256",
+                    "evidence_kind",
+                    "account_id",
+                    "account_id_key",
+                    "institution_type",
+                    "environment",
+                    "origin",
+                    "target_broker_order_id",
+                    "observed_at",
+                    "completeness",
+                    "canonical_result_json",
+                    "canonical_result_sha256",
+                    "created_at",
+                )
+                if tuple(existing[column] for column in columns) != manifest_values:
+                    raise OrderIntentIntegrityError(
+                        "broker read manifest content-address collision"
+                    )
+                existing_members = conn.execute(
+                    """
+                    SELECT member_role, receipt_sha256
+                    FROM broker_read_manifest_members
+                    WHERE evidence_sha256 = ?
+                    ORDER BY member_ordinal
+                    """,
+                    (evidence_sha256,),
+                ).fetchall()
+                if tuple(
+                    (row["member_role"], row["receipt_sha256"])
+                    for row in existing_members
+                ) != tuple(
+                    (member.role, member.receipt_sha256)
+                    for member in members
+                ):
+                    raise OrderIntentIntegrityError(
+                        "broker read manifest membership conflicts"
+                    )
+        return BrokerReadEvidenceRef(
+            evidence_sha256, evidence.evidence_kind
+        )
+
+    def broker_read_evidence(
+        self, evidence_sha256: str
+    ) -> BrokerReadEvidenceRef:
+        """Verify and return a redacted reference to immutable read evidence."""
+
+        _validate_sha256("evidence_sha256", evidence_sha256)
+        with self._connection() as conn:
+            row, _ = self._verified_broker_read_manifest(
+                conn, evidence_sha256
+            )
+        return BrokerReadEvidenceRef(
+            evidence_sha256, row["evidence_kind"]
+        )
+
+    def set_reservation_cap_from_read(
+        self,
+        evidence: BrokerReadEvidenceRef,
+        *,
+        risk_budget: Decimal,
+    ) -> CapacityDecisionReceipt:
+        """Derive and persist a cap only from a complete durable capacity read."""
+
+        if (
+            type(evidence) is not BrokerReadEvidenceRef
+            or evidence.evidence_kind != "CAPACITY"
+        ):
+            raise OrderIntentValidationError(
+                "capacity requires an exact CAPACITY evidence reference"
+            )
+        _validate_sha256("capacity evidence", evidence.evidence_sha256)
+        if (
+            type(risk_budget) is not Decimal
+            or not risk_budget.is_finite()
+            or risk_budget < 0
+        ):
+            raise OrderIntentValidationError(
+                "risk_budget must be a non-negative finite Decimal"
+            )
+        now = self._now_us()
+        with self._transaction() as conn:
+            manifest, result = self._verified_broker_read_manifest(
+                conn, evidence.evidence_sha256
+            )
+            if (
+                manifest["evidence_kind"] != "CAPACITY"
+                or manifest["completeness"] != "COMPLETE"
+                or manifest["target_broker_order_id"] is not None
+            ):
+                raise OrderIntentIntegrityError(
+                    "capacity evidence is not a complete capacity manifest"
+                )
+            _validate_capacity_manifest_result(result)
+            observed_at = int(manifest["observed_at"])
+            if (
+                observed_at > now + 5_000_000
+                or now - observed_at
+                > _EVIDENCE_MAX_AGE_SECONDS * 1_000_000
+            ):
+                raise OrderIntentValidationError(
+                    "capacity evidence is stale or from the future"
+                )
+            broker_buying_power = Decimal(
+                result["broker_buying_power"]
+            )
+            canonical_risk_budget = _canonical_amount(risk_budget)
+            cap_amount = _canonical_amount(
+                min(broker_buying_power, risk_budget)
+            )
+            snapshot_digest = result["state_sha256"]
+            decided_at = observed_at
+            decision_material = {
+                "evidence_sha256": evidence.evidence_sha256,
+                "account_id": manifest["account_id"],
+                "environment": manifest["environment"],
+                "broker_buying_power": _canonical_amount(
+                    broker_buying_power
+                ),
+                "risk_budget": canonical_risk_budget,
+                "cap_amount": cap_amount,
+                "observed_at": observed_at,
+                "capacity_snapshot_sha256": snapshot_digest,
+                "decided_at": decided_at,
+            }
+            decision_sha256 = _domain_json_hash(
+                _CAPACITY_DECISION_HASH_DOMAIN, decision_material
+            )
+            decision_values = (
+                decision_sha256,
+                evidence.evidence_sha256,
+                manifest["account_id"],
+                manifest["environment"],
+                _canonical_amount(broker_buying_power),
+                canonical_risk_budget,
+                cap_amount,
+                observed_at,
+                snapshot_digest,
+                decided_at,
+            )
+            existing_decision = conn.execute(
+                """
+                SELECT * FROM capacity_decisions
+                WHERE capacity_decision_sha256 = ?
+                """,
+                (decision_sha256,),
+            ).fetchone()
+            if existing_decision is None:
+                conn.execute(
+                    """
+                    INSERT INTO capacity_decisions (
+                        capacity_decision_sha256, evidence_sha256,
+                        account_id, environment, broker_buying_power,
+                        risk_budget, cap_amount, observed_at,
+                        capacity_snapshot_sha256, decided_at
+                    ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+                    """,
+                    decision_values,
+                )
+            else:
+                columns = (
+                    "capacity_decision_sha256",
+                    "evidence_sha256",
+                    "account_id",
+                    "environment",
+                    "broker_buying_power",
+                    "risk_budget",
+                    "cap_amount",
+                    "observed_at",
+                    "capacity_snapshot_sha256",
+                    "decided_at",
+                )
+                if tuple(
+                    existing_decision[column] for column in columns
+                ) != decision_values:
+                    raise OrderIntentIntegrityError(
+                        "capacity decision content-address collision"
+                    )
+            existing_cap = conn.execute(
                 """
                 SELECT * FROM reservation_caps
                 WHERE account_id = ? AND environment = ?
                 """,
-                (evidence.account_id, evidence.environment),
+                (manifest["account_id"], manifest["environment"]),
             ).fetchone()
-            observed_at = _to_us(evidence.observed_at)
-            if existing is not None and observed_at == int(existing["observed_at"]):
-                expected = (
-                    cap,
-                    _canonical_amount(evidence.broker_buying_power),
-                    _canonical_amount(evidence.risk_budget),
-                    evidence.portfolio_snapshot_digest,
-                )
-                actual = (
-                    existing["cap_amount"],
-                    existing["broker_buying_power"],
-                    existing["risk_budget"],
-                    existing["portfolio_snapshot_digest"],
-                )
-                if actual == expected:
-                    return Decimal(existing["cap_amount"])
-                raise OrderIntentIntegrityError(
-                    "equal-time capacity evidence conflicts with the persisted snapshot"
-                )
-            if existing is not None and observed_at < int(existing["observed_at"]):
+            if (
+                existing_cap is not None
+                and observed_at < int(existing_cap["observed_at"])
+            ):
                 raise OrderIntentIntegrityError(
                     "capacity evidence must not predate the persisted account snapshot"
                 )
+            if (
+                existing_cap is not None
+                and observed_at == int(existing_cap["observed_at"])
+                and existing_cap["capacity_decision_sha256"]
+                not in {None, decision_sha256}
+            ):
+                raise OrderIntentIntegrityError(
+                    "equal-time capacity evidence conflicts with the persisted snapshot"
+                )
             conn.execute(
                 """
-                INSERT INTO reservation_caps (account_id, environment, cap_amount, broker_buying_power, risk_budget, observed_at, portfolio_snapshot_digest, updated_at)
-                VALUES (?, ?, ?, ?, ?, ?, ?, ?)
+                INSERT INTO reservation_caps (
+                    account_id, environment, cap_amount,
+                    broker_buying_power, risk_budget, observed_at,
+                    portfolio_snapshot_digest, updated_at,
+                    capacity_decision_sha256
+                ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)
                 ON CONFLICT(account_id, environment) DO UPDATE SET
-                    cap_amount = excluded.cap_amount, broker_buying_power = excluded.broker_buying_power,
-                    risk_budget = excluded.risk_budget, observed_at = excluded.observed_at,
-                    portfolio_snapshot_digest = excluded.portfolio_snapshot_digest, updated_at = excluded.updated_at
+                    cap_amount = excluded.cap_amount,
+                    broker_buying_power = excluded.broker_buying_power,
+                    risk_budget = excluded.risk_budget,
+                    observed_at = excluded.observed_at,
+                    portfolio_snapshot_digest =
+                        excluded.portfolio_snapshot_digest,
+                    updated_at = excluded.updated_at,
+                    capacity_decision_sha256 =
+                        excluded.capacity_decision_sha256
                 """,
-                (evidence.account_id, evidence.environment, cap, _canonical_amount(evidence.broker_buying_power), _canonical_amount(evidence.risk_budget), observed_at, evidence.portfolio_snapshot_digest, now),
+                (
+                    manifest["account_id"],
+                    manifest["environment"],
+                    cap_amount,
+                    _canonical_amount(broker_buying_power),
+                    canonical_risk_budget,
+                    observed_at,
+                    snapshot_digest,
+                    now,
+                    decision_sha256,
+                ),
             )
-        return Decimal(cap)
+        return CapacityDecisionReceipt(
+            decision_sha256=decision_sha256,
+            evidence_sha256=evidence.evidence_sha256,
+            cap_amount=Decimal(cap_amount),
+            broker_buying_power=broker_buying_power,
+            risk_budget=Decimal(canonical_risk_budget),
+            observed_at=_from_us(observed_at),
+            portfolio_snapshot_digest=snapshot_digest,
+        )
+
+    def broker_evidence_from_read(
+        self,
+        intent_id: str,
+        evidence: BrokerReadEvidenceRef,
+        *,
+        operation: Literal["ORDER_QUERY", "AMEND_QUERY"],
+    ) -> BrokerEvidence | None:
+        """Derive reconciliation facts from a durable known-order manifest."""
+
+        _validate_identity("intent_id", intent_id)
+        if (
+            type(evidence) is not BrokerReadEvidenceRef
+            or evidence.evidence_kind != "ORDER_QUERY"
+        ):
+            raise OrderIntentValidationError(
+                "order reconciliation requires exact ORDER_QUERY evidence"
+            )
+        if type(operation) is not str or operation not in {
+            "ORDER_QUERY",
+            "AMEND_QUERY",
+        }:
+            raise OrderIntentValidationError(
+                "read evidence operation is invalid"
+            )
+        now = self._now_us()
+        with self._connection() as conn:
+            intent = self._require_intent(conn, intent_id)
+            manifest, result = self._verified_broker_read_manifest(
+                conn, evidence.evidence_sha256
+            )
+            _validate_order_query_manifest_result(result)
+            if (
+                manifest["evidence_kind"] != "ORDER_QUERY"
+                or manifest["account_id"] != intent["account_id"]
+                or manifest["environment"] != intent["environment"]
+                or manifest["target_broker_order_id"]
+                != result["broker_order_id"]
+            ):
+                raise OrderIntentIntegrityError(
+                    "order read evidence does not match the durable intent"
+                )
+            if (
+                manifest["completeness"] != "COMPLETE"
+                or result["not_found"] is True
+                or result["outcome"] == "UNRESOLVED"
+            ):
+                return None
+            observed_at = int(manifest["observed_at"])
+            if (
+                observed_at > now + 5_000_000
+                or now - observed_at
+                > _EVIDENCE_MAX_AGE_SECONDS * 1_000_000
+            ):
+                raise OrderIntentValidationError(
+                    "order read evidence is stale or from the future"
+                )
+            expected_client_id = intent["client_order_id"]
+            if operation == "AMEND_QUERY":
+                amendment = conn.execute(
+                    """
+                    SELECT client_order_id FROM amendment_leases
+                    WHERE intent_id = ?
+                    """,
+                    (intent_id,),
+                ).fetchone()
+                if amendment is None:
+                    raise OrderIntentIntegrityError(
+                        "amendment query lacks a durable amendment operation"
+                    )
+                expected_client_id = amendment["client_order_id"]
+        return BrokerEvidence(
+            account_id=manifest["account_id"],
+            environment=manifest["environment"],
+            client_order_id=expected_client_id,
+            broker_order_id=result["broker_order_id"],
+            operation=operation,
+            outcome=result["outcome"],
+            observed_at=_from_us(observed_at),
+            http_status=result["http_status"],
+            raw_response_digest=result["raw_response_digest"],
+            broker_read_evidence_sha256=evidence.evidence_sha256,
+            order_payload_hashes=tuple(result["order_payload_hashes"]),
+        )
+
+    def set_reservation_cap(self, evidence: AccountCapacityEvidence) -> Decimal:
+        """Compatibility wrapper that still requires durable broker evidence."""
+
+        if type(evidence) is not AccountCapacityEvidence:
+            raise OrderIntentValidationError("set_reservation_cap requires typed AccountCapacityEvidence")
+        AccountCapacityEvidence.validate(
+            evidence, _from_us(self._now_us())
+        )
+        if evidence.broker_read_evidence_sha256 is None:
+            raise OrderIntentValidationError(
+                "capacity evidence must reference a durable broker-read manifest"
+            )
+        decision = self.set_reservation_cap_from_read(
+            BrokerReadEvidenceRef(
+                evidence.broker_read_evidence_sha256, "CAPACITY"
+            ),
+            risk_budget=evidence.risk_budget,
+        )
+        if (
+            decision.broker_buying_power != evidence.broker_buying_power
+            or decision.observed_at != evidence.observed_at
+            or decision.portfolio_snapshot_digest
+            != evidence.portfolio_snapshot_digest
+        ):
+            raise OrderIntentIntegrityError(
+                "capacity wrapper conflicts with durable read evidence"
+            )
+        return decision.cap_amount
 
     def reserve_margin(self, intent_id: str, evidence: RiskEvidence) -> MarginReservation:
         _validate_identity("intent_id", intent_id)
@@ -815,11 +1563,24 @@ class OrderIntentLedger:
                     "risk evidence is below the immutable opening exposure floor"
                 )
             cap = conn.execute(
-                "SELECT cap_amount, observed_at, portfolio_snapshot_digest FROM reservation_caps WHERE account_id = ? AND environment = ?",
+                """
+                SELECT cap_amount, observed_at, portfolio_snapshot_digest,
+                       capacity_decision_sha256
+                FROM reservation_caps
+                WHERE account_id = ? AND environment = ?
+                """,
                 (intent["account_id"], intent["environment"]),
             ).fetchone()
             if cap is None:
                 raise OrderIntentReservationError("opening reservations require an account/environment cap")
+            if (
+                cap["capacity_decision_sha256"] is None
+                or evidence.capacity_decision_sha256
+                != cap["capacity_decision_sha256"]
+            ):
+                raise OrderIntentIntegrityError(
+                    "reservation must name the exact durable capacity decision"
+                )
             if (
                 int(cap["observed_at"]) != _to_us(evidence.portfolio_observed_at)
                 or cap["portfolio_snapshot_digest"] != evidence.portfolio_snapshot_digest
@@ -837,6 +1598,8 @@ class OrderIntentLedger:
                     and reservation.max_loss_amount == evidence.max_loss_amount and reservation.quote_observed_at == evidence.quote_observed_at
                     and reservation.quote_digest == evidence.quote_digest and reservation.portfolio_observed_at == evidence.portfolio_observed_at
                     and reservation.portfolio_snapshot_digest == evidence.portfolio_snapshot_digest
+                    and reservation.capacity_decision_sha256
+                    == evidence.capacity_decision_sha256
                 ):
                     return reservation
                 raise OrderIntentTransitionError("reservation already exists and is immutable")
@@ -850,10 +1613,25 @@ class OrderIntentLedger:
                 """
                 INSERT INTO margin_reservations (
                     intent_id, account_id, environment, amount, risk_decision_id, max_loss_amount,
-                    quote_observed_at, quote_digest, portfolio_observed_at, portfolio_snapshot_digest, state, released_reason_code, created_at, released_at
-                ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, 'ACTIVE', NULL, ?, NULL)
+                    quote_observed_at, quote_digest, portfolio_observed_at,
+                    portfolio_snapshot_digest, capacity_decision_sha256,
+                    state, released_reason_code, created_at, released_at
+                ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, 'ACTIVE', NULL, ?, NULL)
                 """,
-                (intent_id, intent["account_id"], intent["environment"], value, evidence.decision_id, _canonical_amount(evidence.max_loss_amount), _to_us(evidence.quote_observed_at), evidence.quote_digest, _to_us(evidence.portfolio_observed_at), evidence.portfolio_snapshot_digest, now),
+                (
+                    intent_id,
+                    intent["account_id"],
+                    intent["environment"],
+                    value,
+                    evidence.decision_id,
+                    _canonical_amount(evidence.max_loss_amount),
+                    _to_us(evidence.quote_observed_at),
+                    evidence.quote_digest,
+                    _to_us(evidence.portfolio_observed_at),
+                    evidence.portfolio_snapshot_digest,
+                    evidence.capacity_decision_sha256,
+                    now,
+                ),
             )
             self._append_event(conn, intent_id, "RESERVATION_CREATED", "INTENT", "INTENT", "system", "RESERVATION_CREATED", now)
             return self._reservation_from_row(
@@ -1885,7 +2663,12 @@ class OrderIntentLedger:
         try:
             os.fchmod(descriptor, 0o600)
             info = os.fstat(descriptor)
-            if not stat.S_ISREG(info.st_mode) or info.st_uid != os.getuid() or info.st_mode & 0o077:
+            if (
+                not stat.S_ISREG(info.st_mode)
+                or info.st_uid != os.getuid()
+                or info.st_mode & 0o077
+                or info.st_nlink != 1
+            ):
                 raise OrderIntentValidationError("new ledger database is not owner-only")
         finally:
             os.close(descriptor)
@@ -1920,7 +2703,12 @@ class OrderIntentLedger:
             raise OrderIntentValidationError(f"could not safely open {label}") from exc
         try:
             info = os.fstat(descriptor)
-            if not stat.S_ISREG(info.st_mode) or info.st_uid != os.getuid() or info.st_mode & 0o077:
+            if (
+                not stat.S_ISREG(info.st_mode)
+                or info.st_uid != os.getuid()
+                or info.st_mode & 0o077
+                or info.st_nlink != 1
+            ):
                 raise OrderIntentValidationError(f"{label} must be regular, current-user, and owner-only")
         finally:
             os.close(descriptor)
@@ -1946,13 +2734,17 @@ class OrderIntentLedger:
                 mode = conn.execute("PRAGMA journal_mode = DELETE").fetchone()[0]
                 if str(mode).lower() != "delete":
                     raise OrderIntentLedgerError("ledger requires SQLite DELETE journaling in its private directory")
+            conn.execute("BEGIN EXCLUSIVE")
+            if metadata_table is None:
                 conn.execute("CREATE TABLE ledger_metadata (singleton INTEGER PRIMARY KEY CHECK (singleton = 1), schema_version INTEGER NOT NULL)")
             conn.execute("INSERT OR IGNORE INTO ledger_metadata (singleton, schema_version) VALUES (1, ?)", (SCHEMA_VERSION,))
             metadata = conn.execute("SELECT schema_version FROM ledger_metadata WHERE singleton = 1").fetchone()
             current_schema_version = int(metadata["schema_version"])
             if current_schema_version != SCHEMA_VERSION and current_schema_version not in _MIGRATABLE_SCHEMA_VERSIONS:
                 raise OrderIntentLedgerError(f"unsupported ledger schema {metadata['schema_version']}; expected {SCHEMA_VERSION}")
-            conn.executescript(
+            self._ensure_broker_read_schema(conn)
+            _execute_sql_script(
+                conn,
                 """
                 CREATE TABLE IF NOT EXISTS order_intents (
                     intent_id TEXT PRIMARY KEY,
@@ -1993,6 +2785,7 @@ class OrderIntentLedger:
                     observed_at INTEGER NOT NULL,
                     portfolio_snapshot_digest TEXT NOT NULL,
                     updated_at INTEGER NOT NULL,
+                    capacity_decision_sha256 TEXT REFERENCES capacity_decisions(capacity_decision_sha256),
                     PRIMARY KEY (account_id, environment),
                     CHECK (CAST(cap_amount AS REAL) >= 0 AND CAST(broker_buying_power AS REAL) >= 0 AND CAST(risk_budget AS REAL) >= 0),
                     CHECK (length(portfolio_snapshot_digest) = 64)
@@ -2008,6 +2801,7 @@ class OrderIntentLedger:
                     quote_digest TEXT NOT NULL,
                     portfolio_observed_at INTEGER NOT NULL,
                     portfolio_snapshot_digest TEXT NOT NULL,
+                    capacity_decision_sha256 TEXT REFERENCES capacity_decisions(capacity_decision_sha256),
                     state TEXT NOT NULL CHECK (state IN ('ACTIVE', 'FILLED_PENDING_ABSORPTION', 'RELEASED')),
                     released_reason_code TEXT,
                     created_at INTEGER NOT NULL,
@@ -2139,6 +2933,7 @@ class OrderIntentLedger:
                     evidence_operation TEXT,
                     http_status INTEGER,
                     raw_response_digest TEXT,
+                    broker_read_evidence_sha256 TEXT REFERENCES broker_read_manifests(evidence_sha256),
                     created_at INTEGER NOT NULL,
                     CHECK (http_status IS NULL OR http_status BETWEEN 100 AND 599),
                     CHECK (raw_response_digest IS NULL OR length(raw_response_digest) = 64)
@@ -2164,6 +2959,14 @@ class OrderIntentLedger:
                 CREATE TRIGGER IF NOT EXISTS prevent_transport_response_receipt_delete BEFORE DELETE ON transport_response_receipts BEGIN SELECT RAISE(ABORT, 'transport response receipts are immutable'); END;
                 CREATE TRIGGER IF NOT EXISTS prevent_broker_order_history_update BEFORE UPDATE ON broker_order_history BEGIN SELECT RAISE(ABORT, 'broker order history is immutable'); END;
                 CREATE TRIGGER IF NOT EXISTS prevent_broker_order_history_delete BEFORE DELETE ON broker_order_history BEGIN SELECT RAISE(ABORT, 'broker order history is immutable'); END;
+                CREATE TRIGGER IF NOT EXISTS prevent_broker_read_receipt_update BEFORE UPDATE ON broker_read_receipts BEGIN SELECT RAISE(ABORT, 'broker read receipts are append-only'); END;
+                CREATE TRIGGER IF NOT EXISTS prevent_broker_read_receipt_delete BEFORE DELETE ON broker_read_receipts BEGIN SELECT RAISE(ABORT, 'broker read receipts are append-only'); END;
+                CREATE TRIGGER IF NOT EXISTS prevent_broker_read_manifest_update BEFORE UPDATE ON broker_read_manifests BEGIN SELECT RAISE(ABORT, 'broker read manifests are append-only'); END;
+                CREATE TRIGGER IF NOT EXISTS prevent_broker_read_manifest_delete BEFORE DELETE ON broker_read_manifests BEGIN SELECT RAISE(ABORT, 'broker read manifests are append-only'); END;
+                CREATE TRIGGER IF NOT EXISTS prevent_broker_read_member_update BEFORE UPDATE ON broker_read_manifest_members BEGIN SELECT RAISE(ABORT, 'broker read manifest members are append-only'); END;
+                CREATE TRIGGER IF NOT EXISTS prevent_broker_read_member_delete BEFORE DELETE ON broker_read_manifest_members BEGIN SELECT RAISE(ABORT, 'broker read manifest members are append-only'); END;
+                CREATE TRIGGER IF NOT EXISTS prevent_capacity_decision_update BEFORE UPDATE ON capacity_decisions BEGIN SELECT RAISE(ABORT, 'capacity decisions are append-only'); END;
+                CREATE TRIGGER IF NOT EXISTS prevent_capacity_decision_delete BEFORE DELETE ON capacity_decisions BEGIN SELECT RAISE(ABORT, 'capacity decisions are append-only'); END;
                 CREATE TRIGGER IF NOT EXISTS prevent_intent_identity_mutation BEFORE UPDATE ON order_intents
                 WHEN OLD.account_id != NEW.account_id OR OLD.environment != NEW.environment OR OLD.strategy_id != NEW.strategy_id
                    OR OLD.decision_id != NEW.decision_id OR OLD.idempotency_scope != NEW.idempotency_scope
@@ -2178,7 +2981,390 @@ class OrderIntentLedger:
             )
             if current_schema_version != SCHEMA_VERSION:
                 conn.execute("UPDATE ledger_metadata SET schema_version = ? WHERE singleton = 1", (SCHEMA_VERSION,))
+            self._verify_schema_structure(conn)
+            conn.execute("COMMIT")
             self._secure_sqlite_sidecars()
+
+    @staticmethod
+    def _ensure_broker_read_schema(conn: sqlite3.Connection) -> None:
+        """Create schema-11 provenance tables before dependent column upgrades."""
+
+        statements = (
+            """
+            CREATE TABLE IF NOT EXISTS broker_read_receipts (
+                receipt_sha256 TEXT NOT NULL PRIMARY KEY
+                    CHECK (length(receipt_sha256) = 64),
+                read_kind TEXT NOT NULL CHECK (read_kind IN (
+                    'ACCOUNT_LIST','BALANCE','PORTFOLIO_PAGE',
+                    'OPEN_ORDERS_PAGE','ORDER_DETAIL'
+                )),
+                account_id TEXT NOT NULL,
+                account_id_key TEXT NOT NULL,
+                institution_type TEXT NOT NULL,
+                environment TEXT NOT NULL
+                    CHECK (environment IN ('sandbox', 'production')),
+                origin TEXT NOT NULL,
+                http_method TEXT NOT NULL CHECK (http_method = 'GET'),
+                route TEXT NOT NULL,
+                query_json TEXT NOT NULL,
+                authorization_sha256 TEXT NOT NULL
+                    CHECK (length(authorization_sha256) = 64),
+                request_sha256 TEXT NOT NULL
+                    CHECK (length(request_sha256) = 64),
+                target_broker_order_id TEXT,
+                request_started_at INTEGER NOT NULL,
+                response_completed_at INTEGER NOT NULL,
+                http_status INTEGER NOT NULL
+                    CHECK (http_status BETWEEN 100 AND 599),
+                raw_response_bytes BLOB NOT NULL,
+                raw_byte_length INTEGER NOT NULL
+                    CHECK (
+                        raw_byte_length = length(raw_response_bytes)
+                        AND raw_byte_length <= 2097152
+                    ),
+                raw_response_sha256 TEXT NOT NULL
+                    CHECK (length(raw_response_sha256) = 64),
+                parser_schema TEXT NOT NULL,
+                parser_code_sha256 TEXT NOT NULL
+                    CHECK (length(parser_code_sha256) = 64),
+                parser_config_sha256 TEXT NOT NULL
+                    CHECK (length(parser_config_sha256) = 64),
+                canonical_parsed_json TEXT NOT NULL,
+                canonical_parsed_sha256 TEXT NOT NULL
+                    CHECK (length(canonical_parsed_sha256) = 64),
+                completeness TEXT NOT NULL CHECK (
+                    completeness IN ('COMPLETE','HAS_NEXT','INELIGIBLE')
+                ),
+                recorded_at INTEGER NOT NULL,
+                CHECK (response_completed_at >= request_started_at),
+                CHECK (
+                    (environment = 'production'
+                     AND origin = 'https://api.etrade.com')
+                    OR
+                    (environment = 'sandbox'
+                     AND origin = 'https://apisb.etrade.com')
+                ),
+                CHECK (
+                    (read_kind = 'ORDER_DETAIL')
+                    = (target_broker_order_id IS NOT NULL)
+                )
+            )
+            """,
+            """
+            CREATE TABLE IF NOT EXISTS broker_read_manifests (
+                evidence_sha256 TEXT NOT NULL PRIMARY KEY
+                    CHECK (length(evidence_sha256) = 64),
+                evidence_kind TEXT NOT NULL
+                    CHECK (evidence_kind IN ('CAPACITY','ORDER_QUERY')),
+                account_id TEXT NOT NULL,
+                account_id_key TEXT NOT NULL,
+                institution_type TEXT NOT NULL,
+                environment TEXT NOT NULL
+                    CHECK (environment IN ('sandbox', 'production')),
+                origin TEXT NOT NULL,
+                target_broker_order_id TEXT,
+                observed_at INTEGER NOT NULL,
+                completeness TEXT NOT NULL CHECK (
+                    completeness IN ('COMPLETE','INCOMPLETE','UNSTABLE')
+                ),
+                canonical_result_json TEXT NOT NULL,
+                canonical_result_sha256 TEXT NOT NULL
+                    CHECK (length(canonical_result_sha256) = 64),
+                created_at INTEGER NOT NULL,
+                CHECK (
+                    (evidence_kind = 'ORDER_QUERY')
+                    = (target_broker_order_id IS NOT NULL)
+                ),
+                CHECK (
+                    (environment = 'production'
+                     AND origin = 'https://api.etrade.com')
+                    OR
+                    (environment = 'sandbox'
+                     AND origin = 'https://apisb.etrade.com')
+                )
+            )
+            """,
+            """
+            CREATE TABLE IF NOT EXISTS broker_read_manifest_members (
+                evidence_sha256 TEXT NOT NULL
+                    REFERENCES broker_read_manifests(evidence_sha256),
+                member_ordinal INTEGER NOT NULL
+                    CHECK (member_ordinal >= 0),
+                member_role TEXT NOT NULL,
+                receipt_sha256 TEXT NOT NULL
+                    REFERENCES broker_read_receipts(receipt_sha256),
+                PRIMARY KEY (evidence_sha256, member_ordinal),
+                UNIQUE (evidence_sha256, member_role),
+                UNIQUE (evidence_sha256, receipt_sha256)
+            )
+            """,
+            """
+            CREATE TABLE IF NOT EXISTS capacity_decisions (
+                capacity_decision_sha256 TEXT NOT NULL PRIMARY KEY
+                    CHECK (length(capacity_decision_sha256) = 64),
+                evidence_sha256 TEXT NOT NULL
+                    REFERENCES broker_read_manifests(evidence_sha256),
+                account_id TEXT NOT NULL,
+                environment TEXT NOT NULL
+                    CHECK (environment IN ('sandbox', 'production')),
+                broker_buying_power TEXT NOT NULL,
+                risk_budget TEXT NOT NULL,
+                cap_amount TEXT NOT NULL,
+                observed_at INTEGER NOT NULL,
+                capacity_snapshot_sha256 TEXT NOT NULL
+                    CHECK (length(capacity_snapshot_sha256) = 64),
+                decided_at INTEGER NOT NULL,
+                CHECK (
+                    CAST(broker_buying_power AS REAL) >= 0
+                    AND CAST(risk_budget AS REAL) >= 0
+                    AND CAST(cap_amount AS REAL) >= 0
+                )
+            )
+            """,
+            """
+            CREATE INDEX IF NOT EXISTS idx_broker_read_receipts_binding
+            ON broker_read_receipts (
+                account_id, environment, response_completed_at
+            )
+            """,
+            """
+            CREATE INDEX IF NOT EXISTS idx_broker_read_manifests_binding
+            ON broker_read_manifests (
+                account_id, environment, evidence_kind, observed_at
+            )
+            """,
+        )
+        for statement in statements:
+            conn.execute(statement)
+        column_upgrades = (
+            (
+                "broker_read_receipts",
+                "authorization_sha256",
+                "TEXT",
+            ),
+            (
+                "reservation_caps",
+                "capacity_decision_sha256",
+                "TEXT REFERENCES capacity_decisions(capacity_decision_sha256)",
+            ),
+            (
+                "margin_reservations",
+                "capacity_decision_sha256",
+                "TEXT REFERENCES capacity_decisions(capacity_decision_sha256)",
+            ),
+            (
+                "order_events",
+                "broker_read_evidence_sha256",
+                "TEXT REFERENCES broker_read_manifests(evidence_sha256)",
+            ),
+        )
+        for table, column, definition in column_upgrades:
+            table_exists = conn.execute(
+                """
+                SELECT 1 FROM sqlite_master
+                WHERE type = 'table' AND name = ?
+                """,
+                (table,),
+            ).fetchone()
+            if table_exists is None:
+                continue
+            columns = {
+                row["name"]
+                for row in conn.execute(f"PRAGMA table_info({table})")
+            }
+            if column not in columns:
+                conn.execute(
+                    f"ALTER TABLE {table} ADD COLUMN {column} {definition}"
+                )
+
+    @staticmethod
+    def _verify_schema_structure(conn: sqlite3.Connection) -> None:
+        if (
+            str(conn.execute("PRAGMA journal_mode").fetchone()[0]).lower()
+            != "delete"
+            or int(conn.execute("PRAGMA foreign_keys").fetchone()[0]) != 1
+        ):
+            raise OrderIntentLedgerError(
+                "ledger SQLite safety pragmas are not active"
+            )
+        required_columns = {
+            "broker_read_receipts": {
+                "receipt_sha256",
+                "read_kind",
+                "account_id",
+                "account_id_key",
+                "institution_type",
+                "environment",
+                "origin",
+                "http_method",
+                "route",
+                "query_json",
+                "authorization_sha256",
+                "request_sha256",
+                "target_broker_order_id",
+                "request_started_at",
+                "response_completed_at",
+                "http_status",
+                "raw_response_bytes",
+                "raw_byte_length",
+                "raw_response_sha256",
+                "parser_schema",
+                "parser_code_sha256",
+                "parser_config_sha256",
+                "canonical_parsed_json",
+                "canonical_parsed_sha256",
+                "completeness",
+                "recorded_at",
+            },
+            "broker_read_manifests": {
+                "evidence_sha256",
+                "evidence_kind",
+                "account_id",
+                "account_id_key",
+                "institution_type",
+                "environment",
+                "origin",
+                "target_broker_order_id",
+                "observed_at",
+                "completeness",
+                "canonical_result_json",
+                "canonical_result_sha256",
+                "created_at",
+            },
+            "broker_read_manifest_members": {
+                "evidence_sha256",
+                "member_ordinal",
+                "member_role",
+                "receipt_sha256",
+            },
+            "capacity_decisions": {
+                "capacity_decision_sha256",
+                "evidence_sha256",
+                "account_id",
+                "environment",
+                "broker_buying_power",
+                "risk_budget",
+                "cap_amount",
+                "observed_at",
+                "capacity_snapshot_sha256",
+                "decided_at",
+            },
+            "reservation_caps": {"capacity_decision_sha256"},
+            "margin_reservations": {"capacity_decision_sha256"},
+            "order_events": {"broker_read_evidence_sha256"},
+        }
+        table_columns: dict[str, dict[str, sqlite3.Row]] = {}
+        for table, required in required_columns.items():
+            rows = conn.execute(f"PRAGMA table_info({table})").fetchall()
+            columns = {row["name"]: row for row in rows}
+            if not required.issubset(columns):
+                raise OrderIntentLedgerError(
+                    f"ledger table {table} is structurally incomplete"
+                )
+            table_columns[table] = columns
+        for column in (
+            "receipt_sha256",
+            "read_kind",
+            "account_id",
+            "account_id_key",
+            "institution_type",
+            "environment",
+            "origin",
+            "http_method",
+            "route",
+            "query_json",
+            "authorization_sha256",
+            "request_sha256",
+            "request_started_at",
+            "response_completed_at",
+            "http_status",
+            "raw_response_bytes",
+            "raw_byte_length",
+            "raw_response_sha256",
+            "parser_schema",
+            "parser_code_sha256",
+            "parser_config_sha256",
+            "canonical_parsed_json",
+            "canonical_parsed_sha256",
+            "completeness",
+            "recorded_at",
+        ):
+            if int(
+                table_columns["broker_read_receipts"][column]["notnull"]
+            ) != 1:
+                raise OrderIntentLedgerError(
+                    "broker read receipt schema permits missing provenance"
+                )
+        required_triggers = {
+            "prevent_broker_read_receipt_update",
+            "prevent_broker_read_receipt_delete",
+            "prevent_broker_read_manifest_update",
+            "prevent_broker_read_manifest_delete",
+            "prevent_broker_read_member_update",
+            "prevent_broker_read_member_delete",
+            "prevent_capacity_decision_update",
+            "prevent_capacity_decision_delete",
+        }
+        trigger_rows = conn.execute(
+            """
+            SELECT name, sql FROM sqlite_master
+            WHERE type = 'trigger'
+            """
+        ).fetchall()
+        triggers = {row["name"]: row["sql"] for row in trigger_rows}
+        if not required_triggers.issubset(triggers):
+            raise OrderIntentLedgerError(
+                "ledger append-only provenance triggers are incomplete"
+            )
+        for name in required_triggers:
+            sql = " ".join(str(triggers[name]).lower().split())
+            expected_action = (
+                "before update" if name.endswith("_update") else "before delete"
+            )
+            if expected_action not in sql or "raise(abort" not in sql:
+                raise OrderIntentLedgerError(
+                    "ledger provenance trigger definition is invalid"
+                )
+        required_foreign_keys = {
+            ("broker_read_manifest_members", "broker_read_manifests"),
+            ("broker_read_manifest_members", "broker_read_receipts"),
+            ("capacity_decisions", "broker_read_manifests"),
+            ("reservation_caps", "capacity_decisions"),
+            ("margin_reservations", "capacity_decisions"),
+            ("order_events", "broker_read_manifests"),
+        }
+        actual_foreign_keys = {
+            (table, row["table"])
+            for table in required_columns
+            for row in conn.execute(f"PRAGMA foreign_key_list({table})")
+        }
+        if not required_foreign_keys.issubset(actual_foreign_keys):
+            raise OrderIntentLedgerError(
+                "ledger provenance foreign keys are incomplete"
+            )
+        if conn.execute("PRAGMA foreign_key_check").fetchone() is not None:
+            raise OrderIntentLedgerError(
+                "ledger contains foreign-key violations"
+            )
+        quick_check = conn.execute("PRAGMA quick_check").fetchall()
+        if [row[0] for row in quick_check] != ["ok"]:
+            raise OrderIntentLedgerError(
+                "ledger structural integrity check failed"
+            )
+        metadata = conn.execute(
+            """
+            SELECT singleton, schema_version FROM ledger_metadata
+            ORDER BY singleton
+            """
+        ).fetchall()
+        if (
+            len(metadata) != 1
+            or int(metadata[0]["singleton"]) != 1
+            or int(metadata[0]["schema_version"]) != SCHEMA_VERSION
+        ):
+            raise OrderIntentLedgerError(
+                "ledger schema metadata is inconsistent"
+            )
 
     @contextmanager
     def _connection(self) -> Iterator[sqlite3.Connection]:
@@ -2359,8 +3545,24 @@ class OrderIntentLedger:
 
     def _require_active_opening_reservation(self, conn: sqlite3.Connection, intent: sqlite3.Row, now: int) -> None:
         reservation = conn.execute("SELECT * FROM margin_reservations WHERE intent_id = ?", (intent["intent_id"],)).fetchone()
-        cap = conn.execute("SELECT cap_amount, observed_at, portfolio_snapshot_digest FROM reservation_caps WHERE account_id = ? AND environment = ?", (intent["account_id"], intent["environment"])).fetchone()
-        if reservation is None or reservation["state"] != "ACTIVE" or cap is None:
+        cap = conn.execute(
+            """
+            SELECT cap_amount, observed_at, portfolio_snapshot_digest,
+                   capacity_decision_sha256
+            FROM reservation_caps
+            WHERE account_id = ? AND environment = ?
+            """,
+            (intent["account_id"], intent["environment"]),
+        ).fetchone()
+        if (
+            reservation is None
+            or reservation["state"] != "ACTIVE"
+            or cap is None
+            or reservation["capacity_decision_sha256"] is None
+            or cap["capacity_decision_sha256"] is None
+            or reservation["capacity_decision_sha256"]
+            != cap["capacity_decision_sha256"]
+        ):
             raise OrderIntentReservationError("opening submission requires an active capped margin reservation")
         if now - int(reservation["quote_observed_at"]) > _EVIDENCE_MAX_AGE_SECONDS * 1_000_000 or now - int(reservation["portfolio_observed_at"]) > _EVIDENCE_MAX_AGE_SECONDS * 1_000_000 or now - int(cap["observed_at"]) > _EVIDENCE_MAX_AGE_SECONDS * 1_000_000:
             raise OrderIntentReservationError("opening submission requires fresh quote, portfolio, and capacity evidence")
@@ -2770,8 +3972,7 @@ class OrderIntentLedger:
         if completed is not None and (completed["intent_id"], completed["idempotency_key"]) != (intent_id, idempotency_key):
             raise OrderIntentIntegrityError("amendment client order id collides with completed amendment history")
 
-    @staticmethod
-    def _validate_broker_evidence(conn: sqlite3.Connection, intent: sqlite3.Row, evidence: BrokerEvidence, *, allowed_operations: set[str], allowed_outcomes: set[str]) -> None:
+    def _validate_broker_evidence(self, conn: sqlite3.Connection, intent: sqlite3.Row, evidence: BrokerEvidence, *, allowed_operations: set[str], allowed_outcomes: set[str]) -> None:
         if evidence.operation not in allowed_operations or evidence.outcome not in allowed_outcomes:
             raise OrderIntentValidationError("broker evidence operation/outcome is not valid for this transition")
         if evidence.account_id != intent["account_id"] or evidence.environment != intent["environment"]:
@@ -2784,6 +3985,93 @@ class OrderIntentLedger:
             expected_client_id = amendment["client_order_id"]
         if evidence.client_order_id != expected_client_id:
             raise OrderIntentIntegrityError("broker evidence client order id does not match durable intent")
+        if evidence.operation in {"ORDER_QUERY", "AMEND_QUERY"}:
+            if evidence.broker_read_evidence_sha256 is None:
+                raise OrderIntentIntegrityError(
+                    "query evidence lacks durable broker-read provenance"
+                )
+            manifest, result = self._verified_broker_read_manifest(
+                conn, evidence.broker_read_evidence_sha256
+            )
+            _validate_order_query_manifest_result(result)
+            if (
+                manifest["evidence_kind"] != "ORDER_QUERY"
+                or manifest["completeness"] != "COMPLETE"
+                or manifest["account_id"] != evidence.account_id
+                or manifest["environment"] != evidence.environment
+                or manifest["target_broker_order_id"]
+                != evidence.broker_order_id
+                or int(manifest["observed_at"])
+                != _to_us(evidence.observed_at)
+                or result["broker_order_id"]
+                != evidence.broker_order_id
+                or result["outcome"] != evidence.outcome
+                or result["http_status"] != evidence.http_status
+                or result["raw_response_digest"]
+                != evidence.raw_response_digest
+                or tuple(result["order_payload_hashes"])
+                != evidence.order_payload_hashes
+                or result["not_found"] is not False
+            ):
+                raise OrderIntentIntegrityError(
+                    "broker evidence conflicts with its durable read manifest"
+                )
+            expected_payload_hash = self._expected_order_payload_hash_conn(
+                conn, intent
+            )
+            if expected_payload_hash not in evidence.order_payload_hashes:
+                raise OrderIntentBrokerTermsMismatch(
+                    "broker order terms do not match the durable intent"
+                )
+
+    @staticmethod
+    def _expected_order_payload_hash_conn(
+        conn: sqlite3.Connection, intent: sqlite3.Row
+    ) -> str:
+        intent_id = intent["intent_id"]
+        if intent["pending_operation"] == "AMEND":
+            amendment = conn.execute(
+                "SELECT * FROM amendment_leases WHERE intent_id = ?",
+                (intent_id,),
+            ).fetchone()
+            if (
+                amendment is None
+                or amendment["state"] != "IN_DOUBT"
+                or int(amendment["fencing_token"])
+                != int(intent["pending_fence"] or -1)
+            ):
+                raise OrderIntentIntegrityError(
+                    "pending amendment lacks matching durable order terms"
+                )
+            result = amendment["payload_hash"]
+        elif intent["pending_operation"] == "SUBMIT":
+            result = intent["payload_hash"]
+        else:
+            completed = conn.execute(
+                """
+                SELECT payload_hash, completed_at
+                FROM amendment_history
+                WHERE intent_id = ?
+                ORDER BY completed_at DESC
+                """,
+                (intent_id,),
+            ).fetchall()
+            if not completed:
+                result = intent["payload_hash"]
+            else:
+                latest_at = int(completed[0]["completed_at"])
+                latest_hashes = {
+                    row["payload_hash"]
+                    for row in completed
+                    if int(row["completed_at"]) == latest_at
+                }
+                if len(latest_hashes) != 1:
+                    raise OrderIntentIntegrityError(
+                        "latest durable amendment terms are ambiguous"
+                    )
+                result = next(iter(latest_hashes))
+        _validate_sha256("expected_order_payload_hash", result)
+        return result
 
     @staticmethod
     def _active_reservation_total(conn: sqlite3.Connection, account_id: str, environment: str) -> Decimal:
@@ -2801,9 +4089,9 @@ class OrderIntentLedger:
         self._append_event(conn, intent_id, "RESERVATION_RELEASED", intent["state"], intent["state"], "system", "RESERVATION_RELEASED", now, broker_order_id=intent["broker_order_id"])
 
     def _append_reconciliation_event(self, conn: sqlite3.Connection, intent_id: str, from_state: str, to_state: str, event_type: str, reason_code: str, evidence: BrokerEvidence, now: int) -> None:
-        self._append_event(conn, intent_id, event_type, from_state, to_state, "broker-evidence", reason_code, now, broker_status=evidence.outcome, broker_order_id=evidence.broker_order_id, observed_at=_to_us(evidence.observed_at), evidence_operation=evidence.operation, http_status=evidence.http_status, raw_response_digest=evidence.raw_response_digest)
+        self._append_event(conn, intent_id, event_type, from_state, to_state, "broker-evidence", reason_code, now, broker_status=evidence.outcome, broker_order_id=evidence.broker_order_id, observed_at=_to_us(evidence.observed_at), evidence_operation=evidence.operation, http_status=evidence.http_status, raw_response_digest=evidence.raw_response_digest, broker_read_evidence_sha256=evidence.broker_read_evidence_sha256)
 
-    def _append_event(self, conn: sqlite3.Connection, intent_id: str, event_type: str, from_state: str | None, to_state: str | None, actor: str, reason_code: str, now: int, *, broker_status: str | None = None, broker_order_id: str | None = None, observed_at: int | None = None, evidence_operation: str | None = None, http_status: int | None = None, raw_response_digest: str | None = None) -> None:
+    def _append_event(self, conn: sqlite3.Connection, intent_id: str, event_type: str, from_state: str | None, to_state: str | None, actor: str, reason_code: str, now: int, *, broker_status: str | None = None, broker_order_id: str | None = None, observed_at: int | None = None, evidence_operation: str | None = None, http_status: int | None = None, raw_response_digest: str | None = None, broker_read_evidence_sha256: str | None = None) -> None:
         if reason_code not in _REASON_CODES:
             raise OrderIntentValidationError("reason_code is not allowlisted")
         _validate_identity("actor", actor)
@@ -2812,11 +4100,153 @@ class OrderIntentLedger:
             raise OrderIntentValidationError("cannot append event for unknown intent")
         conn.execute(
             """
-            INSERT INTO order_events (intent_id, account_id, environment, client_order_id, event_type, from_state, to_state, actor, reason_code, broker_status, broker_order_id, observed_at, evidence_operation, http_status, raw_response_digest, created_at)
-            VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+            INSERT INTO order_events (
+                intent_id, account_id, environment, client_order_id,
+                event_type, from_state, to_state, actor, reason_code,
+                broker_status, broker_order_id, observed_at,
+                evidence_operation, http_status, raw_response_digest,
+                broker_read_evidence_sha256, created_at
+            )
+            VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
             """,
-            (intent_id, identity["account_id"], identity["environment"], identity["client_order_id"], event_type, from_state, to_state, actor, reason_code, broker_status, broker_order_id, observed_at, evidence_operation, http_status, raw_response_digest, now),
+            (intent_id, identity["account_id"], identity["environment"], identity["client_order_id"], event_type, from_state, to_state, actor, reason_code, broker_status, broker_order_id, observed_at, evidence_operation, http_status, raw_response_digest, broker_read_evidence_sha256, now),
         )
+
+    @staticmethod
+    def _verified_broker_read_manifest(
+        conn: sqlite3.Connection, evidence_sha256: str
+    ) -> tuple[sqlite3.Row, dict[str, Any]]:
+        _validate_sha256("evidence_sha256", evidence_sha256)
+        manifest = conn.execute(
+            """
+            SELECT * FROM broker_read_manifests
+            WHERE evidence_sha256 = ?
+            """,
+            (evidence_sha256,),
+        ).fetchone()
+        if manifest is None:
+            raise OrderIntentIntegrityError(
+                "unknown durable broker read evidence"
+            )
+        members = conn.execute(
+            """
+            SELECT member_ordinal, member_role, receipt_sha256
+            FROM broker_read_manifest_members
+            WHERE evidence_sha256 = ?
+            ORDER BY member_ordinal
+            """,
+            (evidence_sha256,),
+        ).fetchall()
+        if not members or tuple(
+            int(row["member_ordinal"]) for row in members
+        ) != tuple(range(len(members))):
+            raise OrderIntentIntegrityError(
+                "broker read manifest member sequence is incomplete"
+            )
+        member_material = []
+        receipt_rows: list[sqlite3.Row] = []
+        seen_roles: set[str] = set()
+        seen_receipts: set[str] = set()
+        for member in members:
+            role = member["member_role"]
+            receipt_sha256 = member["receipt_sha256"]
+            if (
+                type(role) is not str
+                or not role
+                or role in seen_roles
+                or receipt_sha256 in seen_receipts
+            ):
+                raise OrderIntentIntegrityError(
+                    "broker read manifest membership is ambiguous"
+                )
+            receipt = conn.execute(
+                """
+                SELECT * FROM broker_read_receipts
+                WHERE receipt_sha256 = ?
+                """,
+                (receipt_sha256,),
+            ).fetchone()
+            if receipt is None:
+                raise OrderIntentIntegrityError(
+                    "broker read manifest receipt is missing"
+                )
+            _verify_broker_read_receipt_row(receipt)
+            if (
+                receipt["account_id"] != manifest["account_id"]
+                or receipt["account_id_key"]
+                != manifest["account_id_key"]
+                or receipt["institution_type"]
+                != manifest["institution_type"]
+                or receipt["environment"] != manifest["environment"]
+                or receipt["origin"] != manifest["origin"]
+                or int(receipt["response_completed_at"])
+                > int(manifest["observed_at"])
+            ):
+                raise OrderIntentIntegrityError(
+                    "broker read receipt binding changed after persistence"
+                )
+            seen_roles.add(role)
+            seen_receipts.add(receipt_sha256)
+            receipt_rows.append(receipt)
+            member_material.append(
+                {
+                    "ordinal": int(member["member_ordinal"]),
+                    "role": role,
+                    "receipt_sha256": receipt_sha256,
+                }
+            )
+        canonical_result_json = manifest["canonical_result_json"]
+        result = _load_canonical_json_object(
+            canonical_result_json, "broker read manifest result"
+        )
+        result_sha256 = _domain_bytes_hash(
+            _READ_PARSED_HASH_DOMAIN,
+            canonical_result_json.encode("utf-8"),
+        )
+        if result_sha256 != manifest["canonical_result_sha256"]:
+            raise OrderIntentIntegrityError(
+                "broker read manifest parsed digest does not verify"
+            )
+        _validate_broker_read_manifest_semantics(
+            evidence_kind=manifest["evidence_kind"],
+            account_id=manifest["account_id"],
+            account_id_key=manifest["account_id_key"],
+            institution_type=manifest["institution_type"],
+            target_broker_order_id=manifest["target_broker_order_id"],
+            observed_at=int(manifest["observed_at"]),
+            completeness=manifest["completeness"],
+            result=result,
+            member_roles=tuple(
+                member["member_role"] for member in members
+            ),
+            receipt_rows=tuple(receipt_rows),
+        )
+        manifest_material = {
+            "evidence_kind": manifest["evidence_kind"],
+            "account_id": manifest["account_id"],
+            "account_id_key": manifest["account_id_key"],
+            "institution_type": manifest["institution_type"],
+            "environment": manifest["environment"],
+            "origin": manifest["origin"],
+            "target_broker_order_id": manifest[
+                "target_broker_order_id"
+            ],
+            "observed_at": int(manifest["observed_at"]),
+            "completeness": manifest["completeness"],
+            "canonical_result_sha256": result_sha256,
+            "members": member_material,
+            "created_at": int(manifest["created_at"]),
+        }
+        expected_evidence_sha256 = _domain_json_hash(
+            _READ_MANIFEST_HASH_DOMAIN, manifest_material
+        )
+        if not hmac.compare_digest(
+            expected_evidence_sha256, evidence_sha256
+        ):
+            raise OrderIntentIntegrityError(
+                "broker read manifest content hash does not verify"
+            )
+        return manifest, result
 
     def _require_intent(self, conn: sqlite3.Connection, intent_id: str) -> sqlite3.Row:
         row = conn.execute("SELECT * FROM order_intents WHERE intent_id = ?", (intent_id,)).fetchone()
@@ -2866,11 +4296,11 @@ class OrderIntentLedger:
 
     @staticmethod
     def _reservation_from_row(row: sqlite3.Row) -> MarginReservation:
-        return MarginReservation(intent_id=row["intent_id"], account_id=row["account_id"], environment=row["environment"], amount=Decimal(row["amount"]), risk_decision_id=row["risk_decision_id"], max_loss_amount=Decimal(row["max_loss_amount"]), quote_observed_at=_from_us(row["quote_observed_at"]), quote_digest=row["quote_digest"], portfolio_observed_at=_from_us(row["portfolio_observed_at"]), portfolio_snapshot_digest=row["portfolio_snapshot_digest"], state=row["state"], released_reason_code=row["released_reason_code"], created_at=_from_us(row["created_at"]), released_at=_from_us(row["released_at"]) if row["released_at"] is not None else None)
+        return MarginReservation(intent_id=row["intent_id"], account_id=row["account_id"], environment=row["environment"], amount=Decimal(row["amount"]), risk_decision_id=row["risk_decision_id"], max_loss_amount=Decimal(row["max_loss_amount"]), quote_observed_at=_from_us(row["quote_observed_at"]), quote_digest=row["quote_digest"], portfolio_observed_at=_from_us(row["portfolio_observed_at"]), portfolio_snapshot_digest=row["portfolio_snapshot_digest"], capacity_decision_sha256=row["capacity_decision_sha256"], state=row["state"], released_reason_code=row["released_reason_code"], created_at=_from_us(row["created_at"]), released_at=_from_us(row["released_at"]) if row["released_at"] is not None else None)
 
     @staticmethod
     def _event_from_row(row: sqlite3.Row) -> IntentEvent:
-        return IntentEvent(sequence=int(row["sequence"]), intent_id=row["intent_id"], account_id=row["account_id"], environment=row["environment"], client_order_id=row["client_order_id"], event_type=row["event_type"], from_state=row["from_state"], to_state=row["to_state"], actor=row["actor"], reason_code=row["reason_code"], broker_status=row["broker_status"], broker_order_id=row["broker_order_id"], observed_at=_from_us(row["observed_at"]) if row["observed_at"] is not None else None, evidence_operation=row["evidence_operation"], http_status=row["http_status"], raw_response_digest=row["raw_response_digest"], created_at=_from_us(row["created_at"]))
+        return IntentEvent(sequence=int(row["sequence"]), intent_id=row["intent_id"], account_id=row["account_id"], environment=row["environment"], client_order_id=row["client_order_id"], event_type=row["event_type"], from_state=row["from_state"], to_state=row["to_state"], actor=row["actor"], reason_code=row["reason_code"], broker_status=row["broker_status"], broker_order_id=row["broker_order_id"], observed_at=_from_us(row["observed_at"]) if row["observed_at"] is not None else None, evidence_operation=row["evidence_operation"], http_status=row["http_status"], raw_response_digest=row["raw_response_digest"], broker_read_evidence_sha256=row["broker_read_evidence_sha256"], created_at=_from_us(row["created_at"]))
 
 
 def _transport_response_receipt(
@@ -3203,6 +4633,1124 @@ def _outbound_authorization(
         payload_bytes=payload_bytes,
         payload_digest=hashlib.sha256(payload_bytes).hexdigest(),
     )
+
+
+def _domain_bytes_hash(domain: bytes, payload: bytes) -> str:
+    if type(domain) is not bytes or not domain.endswith(b"\0"):
+        raise OrderIntentValidationError("hash domain is invalid")
+    if type(payload) is not bytes:
+        raise OrderIntentValidationError("hash payload must be exact bytes")
+    return hashlib.sha256(domain + payload).hexdigest()
+
+
+def _domain_json_hash(domain: bytes, value: Any) -> str:
+    return _domain_bytes_hash(
+        domain, _canonical_read_json(value).encode("utf-8")
+    )
+
+
+def _canonical_read_json(value: Any) -> str:
+    _validate_read_json_tree(value)
+    return json.dumps(
+        value,
+        sort_keys=True,
+        separators=(",", ":"),
+        ensure_ascii=True,
+    )
+
+
+def _load_canonical_json(value: str, label: str) -> Any:
+    if (
+        type(value) is not str
+        or not value
+        or len(value.encode("utf-8")) > _MAX_BROKER_READ_BYTES
+    ):
+        raise OrderIntentValidationError(
+            f"{label} must be bounded canonical JSON"
+        )
+
+    def strict_object(
+        pairs: list[tuple[str, Any]],
+    ) -> dict[str, Any]:
+        result: dict[str, Any] = {}
+        for key, item in pairs:
+            if type(key) is not str or key in result:
+                raise OrderIntentValidationError(
+                    f"{label} contains duplicate or invalid keys"
+                )
+            result[key] = item
+        return result
+
+    def reject_constant(_constant: str) -> Any:
+        raise OrderIntentValidationError(
+            f"{label} contains a non-finite number"
+        )
+
+    try:
+        parsed = json.loads(
+            value,
+            object_pairs_hook=strict_object,
+            parse_constant=reject_constant,
+        )
+    except OrderIntentValidationError:
+        raise
+    except Exception as exc:
+        raise OrderIntentValidationError(
+            f"{label} is not valid JSON"
+        ) from exc
+    _validate_read_json_tree(parsed)
+    if _canonical_read_json(parsed) != value:
+        raise OrderIntentValidationError(
+            f"{label} is not in canonical form"
+        )
+    return parsed
+
+
+def _load_canonical_json_object(
+    value: str, label: str
+) -> dict[str, Any]:
+    parsed = _load_canonical_json(value, label)
+    if type(parsed) is not dict:
+        raise OrderIntentValidationError(
+            f"{label} must be a JSON object"
+        )
+    return parsed
+
+
+def _validate_read_json_tree(value: Any) -> None:
+    stack: list[tuple[Any, int]] = [(value, 0)]
+    nodes = 0
+    while stack:
+        item, depth = stack.pop()
+        nodes += 1
+        if nodes > 50_000 or depth > 48:
+            raise OrderIntentValidationError(
+                "canonical broker read JSON is too complex"
+            )
+        item_type = type(item)
+        if item is None or item_type in {str, bool, int}:
+            if item_type is str and len(item) > _MAX_BROKER_READ_BYTES:
+                raise OrderIntentValidationError(
+                    "canonical broker read string is too large"
+                )
+            continue
+        if item_type is list:
+            stack.extend((child, depth + 1) for child in item)
+            continue
+        if item_type is dict:
+            if any(type(key) is not str for key in item):
+                raise OrderIntentValidationError(
+                    "canonical broker read keys must be strings"
+                )
+            stack.extend((child, depth + 1) for child in item.values())
+            continue
+        raise OrderIntentValidationError(
+            "canonical broker read JSON uses an unsupported scalar"
+        )
+
+
+def _validate_broker_read_response_evidence(
+    evidence: BrokerReadResponseEvidence, now: datetime
+) -> None:
+    if type(evidence) is not BrokerReadResponseEvidence:
+        raise OrderIntentValidationError(
+            "broker read response must use its exact evidence type"
+        )
+    if (
+        type(evidence.read_kind) is not str
+        or evidence.read_kind not in _BROKER_READ_KINDS
+        or type(evidence.completeness) is not str
+        or evidence.completeness not in _BROKER_READ_COMPLETENESS
+    ):
+        raise OrderIntentValidationError(
+            "broker read response kind/completeness is invalid"
+        )
+    _validate_identity("read account id", evidence.account_id)
+    _validate_identity("read account key", evidence.account_id_key)
+    _validate_identity(
+        "read institution type", evidence.institution_type
+    )
+    _validate_environment(evidence.environment)
+    if evidence.origin != _ETRADE_ORIGINS[evidence.environment]:
+        raise OrderIntentValidationError(
+            "broker read origin is not pinned to its environment"
+        )
+    if (
+        type(evidence.route) is not str
+        or not evidence.route.startswith("/v1/accounts/")
+        or len(evidence.route) > 1024
+        or "?" in evidence.route
+        or "#" in evidence.route
+        or any(ord(char) < 33 or ord(char) > 126 for char in evidence.route)
+    ):
+        raise OrderIntentValidationError("broker read route is invalid")
+    query = _load_canonical_json(
+        evidence.query_json, "broker read query"
+    )
+    if (
+        type(query) is not list
+        or any(
+            type(pair) is not list
+            or len(pair) != 2
+            or any(type(item) is not str for item in pair)
+            for pair in query
+        )
+        or query != sorted(query)
+        or len({pair[0] for pair in query}) != len(query)
+    ):
+        raise OrderIntentValidationError(
+            "broker read query must be a canonical unique string pair list"
+        )
+    _validate_sha256(
+        "broker read authorization digest",
+        evidence.authorization_sha256,
+    )
+    if evidence.read_kind == "ORDER_DETAIL":
+        _validate_identity(
+            "target broker order id",
+            evidence.target_broker_order_id,
+        )
+    elif evidence.target_broker_order_id is not None:
+        raise OrderIntentValidationError(
+            "only an order-detail read may name a broker order id"
+        )
+    _validate_timestamp(evidence.request_started_at)
+    _validate_timestamp(evidence.response_completed_at)
+    _validate_timestamp(now)
+    if (
+        evidence.response_completed_at < evidence.request_started_at
+        or evidence.response_completed_at > now + timedelta(seconds=5)
+        or now - evidence.response_completed_at
+        > timedelta(seconds=_EVIDENCE_MAX_AGE_SECONDS)
+    ):
+        raise OrderIntentValidationError(
+            "broker read response time is invalid or stale"
+        )
+    if (
+        type(evidence.http_status) is not int
+        or not 100 <= evidence.http_status <= 599
+        or type(evidence.raw_response_bytes) is not bytes
+        or len(evidence.raw_response_bytes) > _MAX_BROKER_READ_BYTES
+    ):
+        raise OrderIntentValidationError(
+            "broker read response status/body is invalid"
+        )
+    _validate_identity("parser schema", evidence.parser_schema)
+    _validate_sha256("parser code digest", evidence.parser_code_sha256)
+    _validate_sha256(
+        "parser config digest", evidence.parser_config_sha256
+    )
+    _load_canonical_json(
+        evidence.canonical_parsed_json, "parsed broker response"
+    )
+
+
+def _validate_broker_read_manifest_evidence(
+    evidence: BrokerReadManifestEvidence, now: datetime
+) -> None:
+    if type(evidence) is not BrokerReadManifestEvidence:
+        raise OrderIntentValidationError(
+            "broker read manifest must use its exact evidence type"
+        )
+    if (
+        type(evidence.evidence_kind) is not str
+        or evidence.evidence_kind not in _BROKER_READ_EVIDENCE_KINDS
+        or type(evidence.completeness) is not str
+        or evidence.completeness
+        not in _BROKER_READ_EVIDENCE_COMPLETENESS
+    ):
+        raise OrderIntentValidationError(
+            "broker read manifest kind/completeness is invalid"
+        )
+    _validate_identity("manifest account id", evidence.account_id)
+    _validate_identity("manifest account key", evidence.account_id_key)
+    _validate_identity(
+        "manifest institution type", evidence.institution_type
+    )
+    _validate_environment(evidence.environment)
+    if evidence.origin != _ETRADE_ORIGINS[evidence.environment]:
+        raise OrderIntentValidationError(
+            "broker read manifest origin is invalid"
+        )
+    if evidence.evidence_kind == "ORDER_QUERY":
+        _validate_identity(
+            "manifest broker order id",
+            evidence.target_broker_order_id,
+        )
+    elif evidence.target_broker_order_id is not None:
+        raise OrderIntentValidationError(
+            "capacity manifests cannot target an order"
+        )
+    _validate_timestamp(evidence.observed_at)
+    _validate_timestamp(now)
+    if (
+        evidence.observed_at > now + timedelta(seconds=5)
+        or now - evidence.observed_at
+        > timedelta(seconds=_EVIDENCE_MAX_AGE_SECONDS)
+    ):
+        raise OrderIntentValidationError(
+            "broker read manifest is stale or from the future"
+        )
+    _load_canonical_json_object(
+        evidence.canonical_result_json, "broker read manifest result"
+    )
+
+
+def _validate_broker_read_manifest_members(
+    members: tuple[BrokerReadManifestMember, ...],
+) -> None:
+    if (
+        type(members) is not tuple
+        or not members
+        or len(members) > 2_048
+        or any(type(member) is not BrokerReadManifestMember for member in members)
+    ):
+        raise OrderIntentValidationError(
+            "broker read manifest members are invalid"
+        )
+    roles: set[str] = set()
+    receipts: set[str] = set()
+    for member in members:
+        _validate_identity("broker read member role", member.role)
+        _validate_sha256(
+            "broker read member receipt", member.receipt_sha256
+        )
+        if member.role in roles or member.receipt_sha256 in receipts:
+            raise OrderIntentValidationError(
+                "broker read manifest members must be unique"
+            )
+        roles.add(member.role)
+        receipts.add(member.receipt_sha256)
+
+
+def _validate_broker_read_manifest_semantics(
+    *,
+    evidence_kind: str,
+    account_id: str,
+    account_id_key: str,
+    institution_type: str,
+    target_broker_order_id: str | None,
+    observed_at: int,
+    completeness: str,
+    result: dict[str, Any],
+    member_roles: tuple[str, ...],
+    receipt_rows: tuple[sqlite3.Row, ...],
+) -> None:
+    """Rebuild complete manifest results from their ordered durable receipts."""
+
+    if len(member_roles) != len(receipt_rows) or not receipt_rows:
+        raise OrderIntentIntegrityError(
+            "broker read manifest receipt lineage is incomplete"
+        )
+    if any(
+        int(row["response_completed_at"]) > observed_at
+        or observed_at - int(row["request_started_at"])
+        > _MAX_BROKER_READ_SPAN_SECONDS * 1_000_000
+        for row in receipt_rows
+    ):
+        raise OrderIntentIntegrityError(
+            "broker read manifest exceeds its bounded observation window"
+        )
+    if any(
+        int(previous["response_completed_at"])
+        > int(current["request_started_at"])
+        for previous, current in zip(receipt_rows, receipt_rows[1:])
+    ):
+        raise OrderIntentIntegrityError(
+            "broker read manifest receipts are not chronologically ordered"
+        )
+    if int(receipt_rows[-1]["response_completed_at"]) != observed_at:
+        raise OrderIntentIntegrityError(
+            "broker read manifest timestamp is not its final response"
+        )
+    authorization_digests = tuple(
+        row["authorization_sha256"] for row in receipt_rows
+    )
+    if (
+        any(type(value) is not str for value in authorization_digests)
+        or len(set(authorization_digests)) != len(authorization_digests)
+    ):
+        raise OrderIntentIntegrityError(
+            "broker read manifest does not prove distinct OAuth exchanges"
+        )
+
+    parser_provenance = {
+        (
+            row["parser_schema"],
+            row["parser_code_sha256"],
+            row["parser_config_sha256"],
+        )
+        for row in receipt_rows
+    }
+    if len(parser_provenance) != 1:
+        raise OrderIntentIntegrityError(
+            "broker read manifest mixes parser versions"
+        )
+    if completeness != "COMPLETE":
+        return
+    if any(row["completeness"] == "INELIGIBLE" for row in receipt_rows):
+        raise OrderIntentIntegrityError(
+            "complete broker read manifest contains ineligible evidence"
+        )
+    if evidence_kind == "ORDER_QUERY":
+        _validate_order_query_receipt_lineage(
+            account_id=account_id,
+            account_id_key=account_id_key,
+            institution_type=institution_type,
+            target_broker_order_id=target_broker_order_id,
+            result=result,
+            member_roles=member_roles,
+            receipt_rows=receipt_rows,
+        )
+        return
+    if evidence_kind == "CAPACITY":
+        _validate_capacity_receipt_lineage(
+            account_id=account_id,
+            account_id_key=account_id_key,
+            institution_type=institution_type,
+            result=result,
+            member_roles=member_roles,
+            receipt_rows=receipt_rows,
+        )
+        return
+    raise OrderIntentIntegrityError(
+        "broker read manifest evidence kind is unsupported"
+    )
+
+
+def _validate_order_query_receipt_lineage(
+    *,
+    account_id: str,
+    account_id_key: str,
+    institution_type: str,
+    target_broker_order_id: str | None,
+    result: dict[str, Any],
+    member_roles: tuple[str, ...],
+    receipt_rows: tuple[sqlite3.Row, ...],
+) -> None:
+    if (
+        target_broker_order_id is None
+        or member_roles
+        != ("binding.start", "order.detail", "binding.end")
+        or tuple(row["read_kind"] for row in receipt_rows)
+        != ("ACCOUNT_LIST", "ORDER_DETAIL", "ACCOUNT_LIST")
+    ):
+        raise OrderIntentIntegrityError(
+            "order query manifest lacks its exact read sequence"
+        )
+    binding_start = _verified_binding_receipt(
+        receipt_rows[0],
+        account_id=account_id,
+        account_id_key=account_id_key,
+        institution_type=institution_type,
+    )
+    binding_end = _verified_binding_receipt(
+        receipt_rows[2],
+        account_id=account_id,
+        account_id_key=account_id_key,
+        institution_type=institution_type,
+    )
+    if binding_start != binding_end:
+        raise OrderIntentIntegrityError(
+            "order query account binding changed during observation"
+        )
+    detail = receipt_rows[1]
+    encoded_account = quote(account_id_key, safe="")
+    encoded_order = quote(target_broker_order_id, safe="")
+    if (
+        detail["route"]
+        != f"/v1/accounts/{encoded_account}/orders/{encoded_order}.json"
+        or _receipt_query(detail)
+        or detail["target_broker_order_id"] != target_broker_order_id
+        or detail["completeness"] != "COMPLETE"
+        or receipt_rows[0]["completeness"] != "COMPLETE"
+        or receipt_rows[2]["completeness"] != "COMPLETE"
+    ):
+        raise OrderIntentIntegrityError(
+            "order query receipt is not bound to the exact known order"
+        )
+    parsed = _receipt_parsed_object(detail)
+    expected_parsed_keys = {
+        "not_found",
+        "raw_status",
+        "outcome",
+        "order_payload_hashes",
+        "replacement_links",
+        "normalized_order",
+    }
+    if set(parsed) != expected_parsed_keys:
+        raise OrderIntentIntegrityError(
+            "order query receipt parser result has an unexpected shape"
+        )
+    expected_result = {
+        "schema": "etrade-order-query.v1",
+        "broker_order_id": target_broker_order_id,
+        "raw_status": parsed["raw_status"],
+        "outcome": parsed["outcome"],
+        "order_payload_hashes": parsed["order_payload_hashes"],
+        "http_status": int(detail["http_status"]),
+        "raw_response_digest": detail["raw_response_sha256"],
+        "not_found": parsed["not_found"],
+        "replacement_links": parsed["replacement_links"],
+    }
+    if result != expected_result:
+        raise OrderIntentIntegrityError(
+            "order query manifest result is disconnected from its receipt"
+        )
+    _validate_order_query_manifest_result(result)
+
+
+def _validate_capacity_receipt_lineage(
+    *,
+    account_id: str,
+    account_id_key: str,
+    institution_type: str,
+    result: dict[str, Any],
+    member_roles: tuple[str, ...],
+    receipt_rows: tuple[sqlite3.Row, ...],
+) -> None:
+    if member_roles[0] != "binding.start" or member_roles[-1] != "binding.end":
+        raise OrderIntentIntegrityError(
+            "capacity manifest lacks account-binding brackets"
+        )
+    binding_start = _verified_binding_receipt(
+        receipt_rows[0],
+        account_id=account_id,
+        account_id_key=account_id_key,
+        institution_type=institution_type,
+    )
+    binding_end = _verified_binding_receipt(
+        receipt_rows[-1],
+        account_id=account_id,
+        account_id_key=account_id_key,
+        institution_type=institution_type,
+    )
+    if binding_start != binding_end:
+        raise OrderIntentIntegrityError(
+            "capacity account binding changed during observation"
+        )
+    cursor = 1
+    scans: list[dict[str, Any]] = []
+    for scan_name in ("scan_a", "scan_b"):
+        if (
+            cursor >= len(receipt_rows) - 1
+            or member_roles[cursor] != f"{scan_name}.balance"
+        ):
+            raise OrderIntentIntegrityError(
+                "capacity manifest lacks both balance scans"
+            )
+        balance_row = receipt_rows[cursor]
+        _validate_capacity_route(
+            balance_row,
+            account_id_key=account_id_key,
+            expected_kind="BALANCE",
+        )
+        if (
+            _receipt_query(balance_row)
+            != {
+                "instType": institution_type,
+                "realTimeNAV": "true",
+            }
+            or balance_row["completeness"] != "COMPLETE"
+        ):
+            raise OrderIntentIntegrityError(
+                "capacity balance request is not the reviewed real-time read"
+            )
+        balance = _receipt_parsed_object(balance_row)
+        if (
+            set(balance)
+            != {
+                "account_id",
+                "institution_type",
+                "margin_buying_power",
+                "as_of_date",
+            }
+            or balance["account_id"] != account_id
+            or balance["institution_type"] not in {None, institution_type}
+            or type(balance["margin_buying_power"]) is not str
+            or type(balance["as_of_date"]) is not str
+            or len(balance["as_of_date"]) != 13
+            or not balance["as_of_date"].isdigit()
+        ):
+            raise OrderIntentIntegrityError(
+                "capacity balance parser result is invalid"
+            )
+        balance_as_of_us = int(balance["as_of_date"]) * 1_000
+        balance_completed_us = int(
+            balance_row["response_completed_at"]
+        )
+        if (
+            balance_as_of_us > balance_completed_us + 5_000_000
+            or balance_completed_us - balance_as_of_us
+            > _EVIDENCE_MAX_AGE_SECONDS * 1_000_000
+        ):
+            raise OrderIntentIntegrityError(
+                "capacity balance effective time is stale or future"
+            )
+        cursor += 1
+
+        portfolio_rows: list[sqlite3.Row] = []
+        portfolio_roles: list[str] = []
+        portfolio_prefix = f"{scan_name}.portfolio."
+        while (
+            cursor < len(receipt_rows) - 1
+            and member_roles[cursor].startswith(portfolio_prefix)
+        ):
+            portfolio_roles.append(member_roles[cursor])
+            portfolio_rows.append(receipt_rows[cursor])
+            cursor += 1
+        if not portfolio_rows:
+            raise OrderIntentIntegrityError(
+                "capacity scan lacks a complete portfolio traversal"
+            )
+        positions = _rebuild_portfolio_scan(
+            portfolio_rows,
+            portfolio_roles,
+            account_id_key=account_id_key,
+        )
+
+        orders: list[dict[str, Any]] = []
+        seen_order_ids: set[str] = set()
+        for lane in _ACTIVE_ORDER_READ_LANES:
+            lane_rows: list[sqlite3.Row] = []
+            lane_roles: list[str] = []
+            lane_prefix = f"{scan_name}.orders.{lane}."
+            while (
+                cursor < len(receipt_rows) - 1
+                and member_roles[cursor].startswith(lane_prefix)
+            ):
+                lane_roles.append(member_roles[cursor])
+                lane_rows.append(receipt_rows[cursor])
+                cursor += 1
+            if not lane_rows:
+                raise OrderIntentIntegrityError(
+                    "capacity scan lacks an active-order status traversal"
+                )
+            for order in _rebuild_order_lane(
+                lane_rows,
+                lane_roles,
+                account_id_key=account_id_key,
+                lane=lane,
+            ):
+                order_id = order.get("order_id")
+                if type(order_id) is not str or order_id in seen_order_ids:
+                    raise OrderIntentIntegrityError(
+                        "capacity scan contains ambiguous active orders"
+                    )
+                seen_order_ids.add(order_id)
+                orders.append(order)
+        orders.sort(key=lambda item: item["order_id"])
+        scans.append(
+            {
+                "schema": "etrade-capacity.v1",
+                "account_status": binding_start["account_status"],
+                "account_mode": binding_start["account_mode"],
+                "account_type": binding_start["account_type"],
+                "broker_buying_power": balance["margin_buying_power"],
+                "broker_buying_power_as_of": balance["as_of_date"],
+                "positions": positions,
+                "open_orders": orders,
+            }
+        )
+    if cursor != len(receipt_rows) - 1:
+        raise OrderIntentIntegrityError(
+            "capacity manifest contains an unrecognized receipt role"
+        )
+    economic_scans = []
+    for scan in scans:
+        economic = dict(scan)
+        economic.pop("broker_buying_power_as_of")
+        economic_scans.append(economic)
+    if economic_scans[0] != economic_scans[1]:
+        raise OrderIntentIntegrityError(
+            "capacity manifest scans are not semantically stable"
+        )
+    if int(scans[1]["broker_buying_power_as_of"]) < int(
+        scans[0]["broker_buying_power_as_of"]
+    ):
+        raise OrderIntentIntegrityError(
+            "capacity balance effective time moved backward"
+        )
+    rebuilt = dict(scans[1])
+    rebuilt["state_sha256"] = _domain_json_hash(
+        b"etrade-capacity-state.v1\0", economic_scans[1]
+    )
+    if result != rebuilt:
+        raise OrderIntentIntegrityError(
+            "capacity manifest result is disconnected from its receipts"
+        )
+    _validate_capacity_manifest_result(result)
+
+
+def _verified_binding_receipt(
+    row: sqlite3.Row,
+    *,
+    account_id: str,
+    account_id_key: str,
+    institution_type: str,
+) -> dict[str, Any]:
+    if (
+        row["read_kind"] != "ACCOUNT_LIST"
+        or row["route"] != "/v1/accounts/list.json"
+        or _receipt_query(row)
+        or row["target_broker_order_id"] is not None
+        or row["http_status"] != 200
+        or row["completeness"] != "COMPLETE"
+    ):
+        raise OrderIntentIntegrityError(
+            "account binding receipt is not an exact account-list read"
+        )
+    parsed = _receipt_parsed_object(row)
+    if (
+        set(parsed)
+        != {
+            "account_id",
+            "account_id_key",
+            "institution_type",
+            "account_status",
+            "account_mode",
+            "account_type",
+        }
+        or parsed["account_id"] != account_id
+        or parsed["account_id_key"] != account_id_key
+        or parsed["institution_type"] != institution_type
+        or parsed["account_status"] != "ACTIVE"
+        or parsed["account_mode"] != "MARGIN"
+        or type(parsed["account_type"]) is not str
+        or not parsed["account_type"]
+    ):
+        raise OrderIntentIntegrityError(
+            "account binding receipt is not the configured active margin account"
+        )
+    return parsed
+
+
+def _validate_capacity_route(
+    row: sqlite3.Row,
+    *,
+    account_id_key: str,
+    expected_kind: str,
+) -> None:
+    suffixes = {
+        "BALANCE": "balance.json",
+        "PORTFOLIO_PAGE": "portfolio.json",
+        "OPEN_ORDERS_PAGE": "orders.json",
+    }
+    suffix = suffixes.get(expected_kind)
+    if (
+        suffix is None
+        or row["read_kind"] != expected_kind
+        or row["route"]
+        != f"/v1/accounts/{quote(account_id_key, safe='')}/{suffix}"
+        or row["target_broker_order_id"] is not None
+        or row["http_status"] not in {200, 204}
+    ):
+        raise OrderIntentIntegrityError(
+            "capacity receipt route or account binding is invalid"
+        )
+
+
+def _rebuild_portfolio_scan(
+    rows: list[sqlite3.Row],
+    roles: list[str],
+    *,
+    account_id_key: str,
+) -> list[dict[str, Any]]:
+    positions: list[dict[str, Any]] = []
+    seen_ids: set[str] = set()
+    previous_next: int | None = None
+    for ordinal, (row, role) in enumerate(zip(rows, roles), start=1):
+        expected_role = role.rsplit(".", 1)[0] + f".{ordinal:04d}"
+        if role != expected_role:
+            raise OrderIntentIntegrityError(
+                "portfolio manifest roles are not contiguous"
+            )
+        _validate_capacity_route(
+            row,
+            account_id_key=account_id_key,
+            expected_kind="PORTFOLIO_PAGE",
+        )
+        expected_query = {
+            "count": "50",
+            "lotsRequired": "false",
+            "marketSession": "REGULAR",
+            "pageNumber": str(ordinal),
+            "sortBy": "SYMBOL",
+            "sortOrder": "ASC",
+            "totalsRequired": "false",
+            "view": "COMPLETE",
+        }
+        if _receipt_query(row) != expected_query:
+            raise OrderIntentIntegrityError(
+                "portfolio page query is not the fixed complete traversal"
+            )
+        parsed = _receipt_parsed_object(row)
+        if (
+            set(parsed)
+            != {
+                "page_number",
+                "total_pages",
+                "metadata_field",
+                "next_page",
+                "positions",
+            }
+            or parsed["page_number"] != ordinal
+            or type(parsed["positions"]) is not list
+            or (
+                ordinal > 1
+                and previous_next != ordinal
+            )
+        ):
+            raise OrderIntentIntegrityError(
+                "portfolio parser result is not contiguous"
+            )
+        is_last = ordinal == len(rows)
+        if (
+            row["completeness"]
+            != ("COMPLETE" if is_last else "HAS_NEXT")
+            or (
+                not is_last
+                and parsed["next_page"] != ordinal + 1
+            )
+            or (is_last and parsed["next_page"] is not None)
+        ):
+            raise OrderIntentIntegrityError(
+                "portfolio receipt completeness conflicts with pagination"
+            )
+        previous_next = parsed["next_page"]
+        for position in parsed["positions"]:
+            if type(position) is not dict:
+                raise OrderIntentIntegrityError(
+                    "portfolio position result is not an object"
+                )
+            position_id = position.get("position_id")
+            if type(position_id) is not str or position_id in seen_ids:
+                raise OrderIntentIntegrityError(
+                    "portfolio position identity is ambiguous"
+                )
+            seen_ids.add(position_id)
+            positions.append(position)
+    positions.sort(key=lambda item: item["position_id"])
+    return positions
+
+
+def _rebuild_order_lane(
+    rows: list[sqlite3.Row],
+    roles: list[str],
+    *,
+    account_id_key: str,
+    lane: str,
+) -> list[dict[str, Any]]:
+    orders: list[dict[str, Any]] = []
+    previous_marker: str | None = None
+    for ordinal, (row, role) in enumerate(zip(rows, roles)):
+        expected_role = role.rsplit(".", 1)[0] + f".{ordinal:04d}"
+        if role != expected_role:
+            raise OrderIntentIntegrityError(
+                "order manifest roles are not contiguous"
+            )
+        _validate_capacity_route(
+            row,
+            account_id_key=account_id_key,
+            expected_kind="OPEN_ORDERS_PAGE",
+        )
+        query = _receipt_query(row)
+        expected_query = {"count": "100", "status": lane}
+        if ordinal:
+            expected_query["marker"] = previous_marker
+        if query != expected_query:
+            raise OrderIntentIntegrityError(
+                "active-order marker traversal is incomplete"
+            )
+        parsed = _receipt_parsed_object(row)
+        if (
+            set(parsed) != {"status_lane", "orders", "marker"}
+            or parsed["status_lane"] != lane
+            or type(parsed["orders"]) is not list
+        ):
+            raise OrderIntentIntegrityError(
+                "active-order parser result is invalid"
+            )
+        is_last = ordinal == len(rows) - 1
+        if (
+            row["completeness"]
+            != ("COMPLETE" if is_last else "HAS_NEXT")
+            or (is_last and parsed["marker"] is not None)
+            or (
+                not is_last
+                and (
+                    type(parsed["marker"]) is not str
+                    or not parsed["marker"]
+                )
+            )
+        ):
+            raise OrderIntentIntegrityError(
+                "active-order receipt completeness conflicts with markers"
+            )
+        previous_marker = parsed["marker"]
+        orders.extend(parsed["orders"])
+    return orders
+
+
+def _receipt_query(row: sqlite3.Row) -> dict[str, str]:
+    parsed = _load_canonical_json(
+        row["query_json"], "broker read receipt query"
+    )
+    if (
+        type(parsed) is not list
+        or any(
+            type(pair) is not list
+            or len(pair) != 2
+            or any(type(item) is not str for item in pair)
+            for pair in parsed
+        )
+    ):
+        raise OrderIntentIntegrityError(
+            "broker read receipt query shape is invalid"
+        )
+    return {pair[0]: pair[1] for pair in parsed}
+
+
+def _receipt_parsed_object(row: sqlite3.Row) -> dict[str, Any]:
+    try:
+        return _load_canonical_json_object(
+            row["canonical_parsed_json"],
+            "broker read receipt parser result",
+        )
+    except OrderIntentValidationError as exc:
+        raise OrderIntentIntegrityError(
+            "broker read receipt parser result is corrupt"
+        ) from exc
+
+
+def _verify_broker_read_receipt_row(row: sqlite3.Row) -> None:
+    raw = row["raw_response_bytes"]
+    if (
+        type(raw) is not bytes
+        or len(raw) != int(row["raw_byte_length"])
+        or len(raw) > _MAX_BROKER_READ_BYTES
+    ):
+        raise OrderIntentIntegrityError(
+            "broker read receipt raw bytes are corrupt"
+        )
+    raw_digest = hashlib.sha256(raw).hexdigest()
+    if not hmac.compare_digest(raw_digest, row["raw_response_sha256"]):
+        raise OrderIntentIntegrityError(
+            "broker read receipt raw digest does not verify"
+        )
+    _load_canonical_json(row["query_json"], "persisted broker query")
+    _load_canonical_json(
+        row["canonical_parsed_json"], "persisted parsed broker response"
+    )
+    parsed_digest = _domain_bytes_hash(
+        _READ_PARSED_HASH_DOMAIN,
+        row["canonical_parsed_json"].encode("utf-8"),
+    )
+    if parsed_digest != row["canonical_parsed_sha256"]:
+        raise OrderIntentIntegrityError(
+            "broker read receipt parsed digest does not verify"
+        )
+    request_material = {
+        "read_kind": row["read_kind"],
+        "account_id": row["account_id"],
+        "account_id_key": row["account_id_key"],
+        "institution_type": row["institution_type"],
+        "environment": row["environment"],
+        "origin": row["origin"],
+        "http_method": row["http_method"],
+        "route": row["route"],
+        "query_json": row["query_json"],
+        "authorization_sha256": row["authorization_sha256"],
+        "target_broker_order_id": row["target_broker_order_id"],
+    }
+    request_digest = _domain_json_hash(
+        _READ_REQUEST_HASH_DOMAIN, request_material
+    )
+    if request_digest != row["request_sha256"]:
+        raise OrderIntentIntegrityError(
+            "broker read request digest does not verify"
+        )
+    receipt_material = {
+        "request_sha256": request_digest,
+        "request_started_at": int(row["request_started_at"]),
+        "response_completed_at": int(row["response_completed_at"]),
+        "http_status": int(row["http_status"]),
+        "raw_byte_length": int(row["raw_byte_length"]),
+        "raw_response_sha256": raw_digest,
+        "parser_schema": row["parser_schema"],
+        "parser_code_sha256": row["parser_code_sha256"],
+        "parser_config_sha256": row["parser_config_sha256"],
+        "canonical_parsed_sha256": parsed_digest,
+        "completeness": row["completeness"],
+        "recorded_at": int(row["recorded_at"]),
+    }
+    receipt_digest = _domain_json_hash(
+        _READ_RECEIPT_HASH_DOMAIN, receipt_material
+    )
+    if not hmac.compare_digest(receipt_digest, row["receipt_sha256"]):
+        raise OrderIntentIntegrityError(
+            "broker read receipt content hash does not verify"
+        )
+
+
+def _validate_capacity_manifest_result(result: dict[str, Any]) -> None:
+    expected = {
+        "schema",
+        "account_status",
+        "account_mode",
+        "account_type",
+        "broker_buying_power",
+        "broker_buying_power_as_of",
+        "positions",
+        "open_orders",
+        "state_sha256",
+    }
+    if set(result) != expected:
+        raise OrderIntentIntegrityError(
+            "capacity manifest result shape is invalid"
+        )
+    if (
+        result["schema"] != "etrade-capacity.v1"
+        or result["account_status"] != "ACTIVE"
+        or result["account_mode"] != "MARGIN"
+        or type(result["account_type"]) is not str
+        or not result["account_type"]
+        or type(result["positions"]) is not list
+        or type(result["open_orders"]) is not list
+        or type(result["broker_buying_power_as_of"]) is not str
+        or len(result["broker_buying_power_as_of"]) != 13
+        or not result["broker_buying_power_as_of"].isdigit()
+    ):
+        raise OrderIntentIntegrityError(
+            "capacity manifest is not eligible for margin opening risk"
+        )
+    buying_power = result["broker_buying_power"]
+    if (
+        type(buying_power) is not str
+        or _canonical_amount(buying_power) != buying_power
+    ):
+        raise OrderIntentIntegrityError(
+            "capacity manifest buying power is not canonical"
+        )
+    _validate_sha256("capacity state digest", result["state_sha256"])
+    state = {
+        key: result[key]
+        for key in expected
+        if key not in {"state_sha256", "broker_buying_power_as_of"}
+    }
+    expected_digest = _domain_json_hash(
+        b"etrade-capacity-state.v1\0", state
+    )
+    if not hmac.compare_digest(expected_digest, result["state_sha256"]):
+        raise OrderIntentIntegrityError(
+            "capacity manifest state digest does not verify"
+        )
+
+
+def _validate_order_query_manifest_result(
+    result: dict[str, Any],
+) -> None:
+    expected = {
+        "schema",
+        "broker_order_id",
+        "raw_status",
+        "outcome",
+        "order_payload_hashes",
+        "http_status",
+        "raw_response_digest",
+        "not_found",
+        "replacement_links",
+    }
+    if set(result) != expected:
+        raise OrderIntentIntegrityError(
+            "order query manifest result shape is invalid"
+        )
+    if (
+        result["schema"] != "etrade-order-query.v1"
+        or type(result["broker_order_id"]) is not str
+        or type(result["raw_status"]) is not str
+        or result["outcome"]
+        not in {
+            "OPEN",
+            "FILLED",
+            "CANCELLED",
+            "REJECTED",
+            "EXPIRED",
+            "UNRESOLVED",
+        }
+        or type(result["order_payload_hashes"]) is not list
+        or type(result["http_status"]) is not int
+        or not 100 <= result["http_status"] <= 599
+        or type(result["not_found"]) is not bool
+        or type(result["replacement_links"]) is not dict
+    ):
+        raise OrderIntentIntegrityError(
+            "order query manifest contains invalid typed values"
+        )
+    _validate_identity("manifest broker order id", result["broker_order_id"])
+    _validate_sha256(
+        "order query raw response digest",
+        result["raw_response_digest"],
+    )
+    hashes = result["order_payload_hashes"]
+    if (
+        len(hashes) > 2
+        or len(set(hashes)) != len(hashes)
+        or hashes != sorted(hashes)
+    ):
+        raise OrderIntentIntegrityError(
+            "order query payload hashes are ambiguous"
+        )
+    for payload_hash in hashes:
+        _validate_sha256("order query payload hash", payload_hash)
+    replacement_links = result["replacement_links"]
+    if result["not_found"]:
+        if replacement_links:
+            raise OrderIntentIntegrityError(
+                "negative order evidence cannot contain replacement links"
+            )
+    else:
+        expected_replacement_keys = {
+            "replaces_order_id",
+            "replaced_by_order_id",
+        }
+        if set(replacement_links) != expected_replacement_keys:
+            raise OrderIntentIntegrityError(
+                "order replacement-link shape is invalid"
+            )
+        for name, broker_order_id in replacement_links.items():
+            if broker_order_id is not None:
+                _validate_identity(name, broker_order_id)
+        if (
+            any(
+                broker_order_id is not None
+                for broker_order_id in replacement_links.values()
+            )
+            and result["outcome"] != "UNRESOLVED"
+        ):
+            raise OrderIntentIntegrityError(
+                "replacement-linked order evidence must stay unresolved"
+            )
+    if result["not_found"]:
+        if (
+            result["http_status"] != 404
+            or result["outcome"] != "UNRESOLVED"
+            or result["raw_status"] != "NOT_FOUND"
+            or hashes
+        ):
+            raise OrderIntentIntegrityError(
+                "negative order evidence is inconsistent"
+            )
+    elif (
+        result["http_status"] != 200
+        or (
+            result["outcome"] != "UNRESOLVED"
+            and not hashes
+        )
+    ):
+        raise OrderIntentIntegrityError(
+            "resolved order evidence is incomplete"
+        )
 
 
 def _validate_mapping_keys(value: Mapping[str, Any], allowed: frozenset[str], context: str) -> None:

--- a/etrade_python_client/tests/test_broker_read_ledger.py
+++ b/etrade_python_client/tests/test_broker_read_ledger.py
@@ -1,0 +1,1258 @@
+from __future__ import annotations
+
+import hashlib
+import json
+import os
+import sqlite3
+import tempfile
+import unittest
+from dataclasses import replace
+from datetime import datetime, timedelta, timezone
+from decimal import Decimal
+from pathlib import Path
+from typing import Any
+
+from live_trading.etrade_broker_reader import (
+    _PARSER_CODE_SHA256,
+    _PARSER_CONFIG_SHA256,
+    _PARSER_SCHEMA,
+    _reparse_broker_read_response,
+)
+from live_trading.order_intent_ledger import (
+    SCHEMA_VERSION,
+    AccountCapacityEvidence,
+    BrokerReadEvidenceRef,
+    BrokerReadManifestEvidence,
+    BrokerReadManifestMember,
+    BrokerReadResponseEvidence,
+    OrderIntent,
+    OrderIntentIntegrityError,
+    OrderIntentLedger,
+    OrderIntentLedgerError,
+    OrderIntentValidationError,
+    RiskEvidence,
+    canonical_order_payload_hash,
+)
+
+
+ACCOUNT_ID = "842468410"
+ACCOUNT_ID_KEY = "account-key-1"
+INSTITUTION_TYPE = "BROKERAGE"
+ENVIRONMENT = "production"
+ORIGIN = "https://api.etrade.com"
+_DERIVE_PARSED = object()
+
+
+class Clock:
+    def __init__(self) -> None:
+        self.now = datetime(2026, 7, 27, 16, 0, tzinfo=timezone.utc)
+
+    def __call__(self) -> datetime:
+        return self.now
+
+
+def _canonical_json(value: Any) -> str:
+    return json.dumps(
+        value,
+        sort_keys=True,
+        separators=(",", ":"),
+        ensure_ascii=True,
+    )
+
+
+def _domain_json_sha256(domain: bytes, value: Any) -> str:
+    return hashlib.sha256(
+        domain + _canonical_json(value).encode("utf-8")
+    ).hexdigest()
+
+
+def _opening_payload() -> dict[str, Any]:
+    return {
+        "securityType": "OPTN",
+        "orderAction": "SPREAD",
+        "priceType": "NET_CREDIT",
+        "limitPrice": 1.25,
+        "orderTerm": "GOOD_FOR_DAY",
+        "spreadType": "VERTICAL",
+        "legs": [
+            {
+                "symbol": "SPY",
+                "callPut": "PUT",
+                "expiryYear": 2026,
+                "expiryMonth": 8,
+                "expiryDay": 21,
+                "strikePrice": 620,
+                "orderAction": "SELL_OPEN",
+                "quantity": 1,
+            },
+            {
+                "symbol": "SPY",
+                "callPut": "PUT",
+                "expiryYear": 2026,
+                "expiryMonth": 8,
+                "expiryDay": 21,
+                "strikePrice": 615,
+                "orderAction": "BUY_OPEN",
+                "quantity": 1,
+            },
+        ],
+    }
+
+
+def _opening_intent(*, key: str = "decision-key") -> OrderIntent:
+    return OrderIntent.build(
+        account_id=ACCOUNT_ID,
+        environment=ENVIRONMENT,
+        strategy_id="credit-spread",
+        decision_id=f"decision-{key}",
+        idempotency_scope="decision",
+        idempotency_key=key,
+        intent_kind="OPENING",
+        order_payload=_opening_payload(),
+    )
+
+
+def _account_list_raw() -> bytes:
+    return _canonical_json(
+        {
+            "AccountListResponse": {
+                "Accounts": {
+                    "Account": [
+                        {
+                            "accountId": ACCOUNT_ID,
+                            "accountIdKey": ACCOUNT_ID_KEY,
+                            "institutionType": INSTITUTION_TYPE,
+                            "accountStatus": "ACTIVE",
+                            "accountMode": "MARGIN",
+                            "accountType": "INDIVIDUAL",
+                        }
+                    ]
+                }
+            }
+        }
+    ).encode("ascii")
+
+
+def _balance_raw(buying_power: str, as_of_date: str) -> bytes:
+    return _canonical_json(
+        {
+            "BalanceResponse": {
+                "accountId": ACCOUNT_ID,
+                "institutionType": INSTITUTION_TYPE,
+                "asOfDate": as_of_date,
+                "Computed": {"marginBuyingPower": buying_power},
+            }
+        }
+    ).encode("ascii")
+
+
+def _portfolio_raw() -> bytes:
+    return _canonical_json(
+        {
+            "PortfolioResponse": {
+                "AccountPortfolio": [
+                    {
+                        "accountId": ACCOUNT_ID,
+                        "totalNoOfPages": "1",
+                        "Position": [],
+                    }
+                ]
+            }
+        }
+    ).encode("ascii")
+
+
+def _orders_raw() -> bytes:
+    return _canonical_json(
+        {"OrdersResponse": {"Order": []}}
+    ).encode("ascii")
+
+
+def _known_order_raw(
+    broker_order_id: str,
+    *,
+    limit_price: str = "1.25",
+    status: str = "OPEN",
+) -> bytes:
+    return _canonical_json(
+        {
+            "OrdersResponse": {
+                "Order": [
+                    {
+                        "orderId": broker_order_id,
+                        "orderType": "SPREADS",
+                        "OrderDetail": [
+                            {
+                                "accountId": ACCOUNT_ID,
+                                "orderNumber": broker_order_id,
+                                "status": status,
+                                "priceType": "NET_CREDIT",
+                                "limitPrice": limit_price,
+                                "orderTerm": "GOOD_FOR_DAY",
+                                "marketSession": "REGULAR",
+                                "allOrNone": False,
+                                "stopPrice": "0",
+                                "Instrument": [
+                                    {
+                                        "Product": {
+                                            "symbol": "SPY",
+                                            "securityType": "OPTN",
+                                            "callPut": "PUT",
+                                            "expiryYear": "2026",
+                                            "expiryMonth": "8",
+                                            "expiryDay": "21",
+                                            "strikePrice": "620",
+                                        },
+                                        "orderAction": "SELL_OPEN",
+                                        "quantityType": "QUANTITY",
+                                        "orderedQuantity": "1",
+                                        "filledQuantity": "0",
+                                        "cancelQuantity": "0",
+                                    },
+                                    {
+                                        "Product": {
+                                            "symbol": "SPY",
+                                            "securityType": "OPTN",
+                                            "callPut": "PUT",
+                                            "expiryYear": "2026",
+                                            "expiryMonth": "8",
+                                            "expiryDay": "21",
+                                            "strikePrice": "615",
+                                        },
+                                        "orderAction": "BUY_OPEN",
+                                        "quantityType": "QUANTITY",
+                                        "orderedQuantity": "1",
+                                        "filledQuantity": "0",
+                                        "cancelQuantity": "0",
+                                    },
+                                ],
+                            }
+                        ],
+                    }
+                ]
+            }
+        }
+    ).encode("ascii")
+
+
+def _vertical_hashes(limit_price: str) -> tuple[str, ...]:
+    payload = _opening_payload()
+    payload["limitPrice"] = Decimal(limit_price)
+    forward = canonical_order_payload_hash(payload)
+    reverse_payload = dict(payload)
+    reverse_payload["legs"] = list(reversed(payload["legs"]))
+    reverse = canonical_order_payload_hash(reverse_payload)
+    return tuple(sorted({forward, reverse}))
+
+
+class BrokerReadLedgerTests(unittest.TestCase):
+    def setUp(self) -> None:
+        self.tmp = tempfile.TemporaryDirectory()
+        os.chmod(self.tmp.name, 0o700)
+        self.path = Path(self.tmp.name) / "runtime" / "orders.sqlite3"
+        self.clock = Clock()
+        self.authorization_counter = 0
+        self.ledger = OrderIntentLedger(
+            self.path, clock=self.clock, run_id="reader-ledger-tests"
+        )
+
+    def tearDown(self) -> None:
+        self.tmp.cleanup()
+
+    def _record_response(
+        self,
+        *,
+        read_kind: str,
+        route: str,
+        raw: bytes,
+        parsed: Any = _DERIVE_PARSED,
+        query: tuple[tuple[str, str], ...] = (),
+        target_broker_order_id: str | None = None,
+        completeness: str = "COMPLETE",
+        account_id: str = ACCOUNT_ID,
+        account_id_key: str = ACCOUNT_ID_KEY,
+        final_response: bool = False,
+    ):
+        self.authorization_counter += 1
+        authorization_sha256 = hashlib.sha256(
+            (
+                "broker-read-test-authorization:"
+                f"{self.authorization_counter}"
+            ).encode("ascii")
+        ).hexdigest()
+        response_completed_at = (
+            self.clock.now
+            if final_response
+            else self.clock.now
+            - timedelta(seconds=30)
+            + timedelta(milliseconds=self.authorization_counter)
+        )
+        evidence = BrokerReadResponseEvidence(
+            read_kind=read_kind,
+            account_id=account_id,
+            account_id_key=account_id_key,
+            institution_type=INSTITUTION_TYPE,
+            environment=ENVIRONMENT,
+            origin=ORIGIN,
+            route=route,
+            query_json=_canonical_json(
+                [list(pair) for pair in sorted(query)]
+            ),
+            authorization_sha256=authorization_sha256,
+            target_broker_order_id=target_broker_order_id,
+            request_started_at=response_completed_at
+            - timedelta(microseconds=500),
+            response_completed_at=response_completed_at,
+            http_status=200,
+            raw_response_bytes=raw,
+            parser_schema=_PARSER_SCHEMA,
+            parser_code_sha256=_PARSER_CODE_SHA256,
+            parser_config_sha256=_PARSER_CONFIG_SHA256,
+            canonical_parsed_json=(
+                "null"
+                if parsed is _DERIVE_PARSED
+                else _canonical_json(parsed)
+            ),
+            completeness=completeness,
+        )
+        if parsed is _DERIVE_PARSED:
+            reparsed_json, reparsed_completeness = (
+                _reparse_broker_read_response(evidence)
+            )
+            if reparsed_completeness == "INELIGIBLE":
+                raise AssertionError(
+                    "valid broker-read fixture did not satisfy the concrete parser"
+                )
+            evidence = replace(
+                evidence,
+                canonical_parsed_json=reparsed_json,
+                completeness=reparsed_completeness,
+            )
+        return self.ledger.record_broker_read_response(evidence)
+
+    def _persisted_parsed(self, receipt_sha256: str) -> dict[str, Any]:
+        with sqlite3.connect(self.path) as connection:
+            row = connection.execute(
+                """
+                SELECT canonical_parsed_json
+                FROM broker_read_receipts
+                WHERE receipt_sha256 = ?
+                """,
+                (receipt_sha256,),
+            ).fetchone()
+        self.assertIsNotNone(row)
+        parsed = json.loads(row[0])
+        self.assertIs(type(parsed), dict)
+        return parsed
+
+    def _capacity_manifest(
+        self, *, buying_power: str = "1000"
+    ) -> tuple[BrokerReadEvidenceRef, str, tuple[str, ...]]:
+        buying_power_as_of = str(
+            int(
+                (
+                    self.clock.now - timedelta(seconds=30)
+                ).timestamp()
+                * 1_000
+            )
+        )
+        sources = [
+            (
+                "binding.start",
+                "ACCOUNT_LIST",
+                "/v1/accounts/list.json",
+                (),
+                _account_list_raw(),
+            ),
+        ]
+        for scan in ("a", "b"):
+            sources.extend(
+                (
+                    (
+                        f"scan_{scan}.balance",
+                        "BALANCE",
+                        f"/v1/accounts/{ACCOUNT_ID_KEY}/balance.json",
+                        (
+                            ("instType", "BROKERAGE"),
+                            ("realTimeNAV", "true"),
+                        ),
+                        (
+                            _balance_raw(
+                                buying_power, buying_power_as_of
+                            )
+                        ),
+                    ),
+                    (
+                        f"scan_{scan}.portfolio.0001",
+                        "PORTFOLIO_PAGE",
+                        f"/v1/accounts/{ACCOUNT_ID_KEY}/portfolio.json",
+                        (
+                            ("count", "50"),
+                            ("lotsRequired", "false"),
+                            ("marketSession", "REGULAR"),
+                            ("pageNumber", "1"),
+                            ("sortBy", "SYMBOL"),
+                            ("sortOrder", "ASC"),
+                            ("totalsRequired", "false"),
+                            ("view", "COMPLETE"),
+                        ),
+                        _portfolio_raw(),
+                    ),
+                )
+            )
+            for lane in (
+                "OPEN",
+                "CANCEL_REQUESTED",
+                "INDIVIDUAL_FILLS",
+            ):
+                sources.append(
+                    (
+                        f"scan_{scan}.orders.{lane}.0000",
+                        "OPEN_ORDERS_PAGE",
+                        f"/v1/accounts/{ACCOUNT_ID_KEY}/orders.json",
+                        (("count", "100"), ("status", lane)),
+                        _orders_raw(),
+                    )
+                )
+        sources.append(
+            (
+                "binding.end",
+                "ACCOUNT_LIST",
+                "/v1/accounts/list.json",
+                (),
+                _account_list_raw(),
+            )
+        )
+        members: list[BrokerReadManifestMember] = []
+        receipt_hashes: list[str] = []
+        for role, kind, route, query, raw in sources:
+            receipt = self._record_response(
+                read_kind=kind,
+                route=route,
+                query=query,
+                raw=raw,
+                final_response=role == "binding.end",
+            )
+            receipt_hashes.append(receipt.receipt_sha256)
+            members.append(
+                BrokerReadManifestMember(
+                    role=role, receipt_sha256=receipt.receipt_sha256
+                )
+            )
+
+        state = {
+            "schema": "etrade-capacity.v1",
+            "account_status": "ACTIVE",
+            "account_mode": "MARGIN",
+            "account_type": "INDIVIDUAL",
+            "broker_buying_power": buying_power,
+            "broker_buying_power_as_of": buying_power_as_of,
+            "positions": [],
+            "open_orders": [],
+        }
+        economic_state = dict(state)
+        economic_state.pop("broker_buying_power_as_of")
+        state_sha256 = _domain_json_sha256(
+            b"etrade-capacity-state.v1\0", economic_state
+        )
+        result = dict(state)
+        result["state_sha256"] = state_sha256
+        evidence = self.ledger.record_broker_read_manifest(
+            BrokerReadManifestEvidence(
+                evidence_kind="CAPACITY",
+                account_id=ACCOUNT_ID,
+                account_id_key=ACCOUNT_ID_KEY,
+                institution_type=INSTITUTION_TYPE,
+                environment=ENVIRONMENT,
+                origin=ORIGIN,
+                target_broker_order_id=None,
+                observed_at=self.clock.now,
+                completeness="COMPLETE",
+                canonical_result_json=_canonical_json(result),
+            ),
+            tuple(members),
+        )
+        return evidence, state_sha256, tuple(receipt_hashes)
+
+    def _order_query_manifest(
+        self,
+        *,
+        broker_order_id: str,
+        payload_hashes: tuple[str, ...],
+        outcome: str = "OPEN",
+    ) -> tuple[BrokerReadEvidenceRef, str]:
+        default_hashes = _vertical_hashes("1.25")
+        limit_price = (
+            "1.25"
+            if set(payload_hashes).intersection(default_hashes)
+            else "1.30"
+        )
+        raw = _known_order_raw(
+            broker_order_id,
+            limit_price=limit_price,
+            status=outcome,
+        )
+        binding_start = self._record_response(
+            read_kind="ACCOUNT_LIST",
+            route="/v1/accounts/list.json",
+            raw=_account_list_raw(),
+        )
+        receipt = self._record_response(
+            read_kind="ORDER_DETAIL",
+            route=(
+                f"/v1/accounts/{ACCOUNT_ID_KEY}/orders/"
+                f"{broker_order_id}.json"
+            ),
+            raw=raw,
+            target_broker_order_id=broker_order_id,
+        )
+        parsed = self._persisted_parsed(receipt.receipt_sha256)
+        binding_end = self._record_response(
+            read_kind="ACCOUNT_LIST",
+            route="/v1/accounts/list.json",
+            raw=_account_list_raw(),
+            final_response=True,
+        )
+        result = {
+            "schema": "etrade-order-query.v1",
+            "broker_order_id": broker_order_id,
+            "raw_status": parsed["raw_status"],
+            "outcome": parsed["outcome"],
+            "order_payload_hashes": parsed["order_payload_hashes"],
+            "http_status": 200,
+            "raw_response_digest": hashlib.sha256(raw).hexdigest(),
+            "not_found": parsed["not_found"],
+            "replacement_links": parsed["replacement_links"],
+        }
+        evidence = self.ledger.record_broker_read_manifest(
+            BrokerReadManifestEvidence(
+                evidence_kind="ORDER_QUERY",
+                account_id=ACCOUNT_ID,
+                account_id_key=ACCOUNT_ID_KEY,
+                institution_type=INSTITUTION_TYPE,
+                environment=ENVIRONMENT,
+                origin=ORIGIN,
+                target_broker_order_id=broker_order_id,
+                observed_at=self.clock.now,
+                completeness="COMPLETE",
+                canonical_result_json=_canonical_json(result),
+            ),
+            (
+                BrokerReadManifestMember(
+                    role="binding.start",
+                    receipt_sha256=binding_start.receipt_sha256,
+                ),
+                BrokerReadManifestMember(
+                    role="order.detail",
+                    receipt_sha256=receipt.receipt_sha256,
+                ),
+                BrokerReadManifestMember(
+                    role="binding.end",
+                    receipt_sha256=binding_end.receipt_sha256,
+                ),
+            ),
+        )
+        return evidence, receipt.receipt_sha256
+
+    def _capacity_decision(self):
+        capacity, state_sha256, receipt_hashes = (
+            self._capacity_manifest()
+        )
+        decision = self.ledger.set_reservation_cap_from_read(
+            capacity, risk_budget=Decimal("750")
+        )
+        return capacity, decision, state_sha256, receipt_hashes
+
+    def _create_reserved_unknown_intent(self):
+        _, decision, state_sha256, _ = self._capacity_decision()
+        record = self.ledger.create_intent(
+            _opening_intent(key="query-provenance")
+        ).intent
+        reservation = self.ledger.reserve_margin(
+            record.intent_id,
+            RiskEvidence(
+                decision_id=record.envelope.decision_id,
+                max_loss_amount=Decimal("500"),
+                collateral_amount=Decimal("500"),
+                quote_observed_at=self.clock.now,
+                quote_digest="c" * 64,
+                portfolio_observed_at=decision.observed_at,
+                portfolio_snapshot_digest=state_sha256,
+                capacity_decision_sha256=decision.decision_sha256,
+            ),
+        )
+        lease = self.ledger.claim_submission(
+            record.intent_id, "worker-1", lease_seconds=30
+        )
+        authorization = self.ledger.prepare_submission_payload(
+            record.intent_id, "worker-1", lease.fencing_token
+        )
+        unknown = self.ledger.begin_submission(
+            record.intent_id,
+            "worker-1",
+            lease.fencing_token,
+            authorization,
+        )
+        self.assertEqual(unknown.state, "SUBMISSION_UNKNOWN")
+        self.assertEqual(
+            reservation.capacity_decision_sha256,
+            decision.decision_sha256,
+        )
+        return record, decision
+
+    def test_self_attested_capacity_cannot_set_an_opening_cap(self) -> None:
+        with self.assertRaises(OrderIntentValidationError):
+            self.ledger.set_reservation_cap(
+                AccountCapacityEvidence(
+                    account_id=ACCOUNT_ID,
+                    environment=ENVIRONMENT,
+                    broker_buying_power=Decimal("1000"),
+                    risk_budget=Decimal("750"),
+                    observed_at=self.clock.now,
+                    portfolio_snapshot_digest="d" * 64,
+                )
+            )
+
+    def test_complete_capacity_manifest_drives_decision_and_reservation(
+        self,
+    ) -> None:
+        capacity, decision, state_sha256, receipt_hashes = (
+            self._capacity_decision()
+        )
+        self.assertEqual(capacity.evidence_kind, "CAPACITY")
+        self.assertEqual(decision.cap_amount, Decimal("750"))
+        self.assertEqual(
+            decision.broker_buying_power, Decimal("1000")
+        )
+        self.assertEqual(
+            decision.portfolio_snapshot_digest, state_sha256
+        )
+
+        replay = self.ledger.set_reservation_cap_from_read(
+            capacity, risk_budget=Decimal("750")
+        )
+        self.assertEqual(replay.decision_sha256, decision.decision_sha256)
+
+        record = self.ledger.create_intent(
+            _opening_intent(key="capacity-provenance")
+        ).intent
+        reservation = self.ledger.reserve_margin(
+            record.intent_id,
+            RiskEvidence(
+                decision_id=record.envelope.decision_id,
+                max_loss_amount=Decimal("500"),
+                collateral_amount=Decimal("500"),
+                quote_observed_at=self.clock.now,
+                quote_digest="e" * 64,
+                portfolio_observed_at=decision.observed_at,
+                portfolio_snapshot_digest=state_sha256,
+                capacity_decision_sha256=decision.decision_sha256,
+            ),
+        )
+        self.assertEqual(
+            reservation.capacity_decision_sha256,
+            decision.decision_sha256,
+        )
+        self.assertEqual(
+            reservation.portfolio_snapshot_digest, state_sha256
+        )
+
+        second = self.ledger.create_intent(
+            _opening_intent(key="wrong-capacity-decision")
+        ).intent
+        with self.assertRaises(OrderIntentIntegrityError):
+            self.ledger.reserve_margin(
+                second.intent_id,
+                RiskEvidence(
+                    decision_id=second.envelope.decision_id,
+                    max_loss_amount=Decimal("500"),
+                    collateral_amount=Decimal("500"),
+                    quote_observed_at=self.clock.now,
+                    quote_digest="f" * 64,
+                    portfolio_observed_at=decision.observed_at,
+                    portfolio_snapshot_digest=state_sha256,
+                    capacity_decision_sha256="0" * 64,
+                ),
+            )
+
+        with sqlite3.connect(self.path) as conn:
+            canonical_result_json = conn.execute(
+                """
+                SELECT canonical_result_json
+                FROM broker_read_manifests
+                WHERE evidence_sha256 = ?
+                """,
+                (capacity.evidence_sha256,),
+            ).fetchone()[0]
+        with self.assertRaises(OrderIntentIntegrityError):
+            self.ledger.record_broker_read_manifest(
+                BrokerReadManifestEvidence(
+                    evidence_kind="CAPACITY",
+                    account_id=ACCOUNT_ID,
+                    account_id_key=ACCOUNT_ID_KEY,
+                    institution_type=INSTITUTION_TYPE,
+                    environment=ENVIRONMENT,
+                    origin=ORIGIN,
+                    target_broker_order_id=None,
+                    observed_at=self.clock.now,
+                    completeness="COMPLETE",
+                    canonical_result_json=canonical_result_json,
+                ),
+                (
+                    BrokerReadManifestMember(
+                        role="binding.start",
+                        receipt_sha256=receipt_hashes[0],
+                    ),
+                ),
+            )
+
+    def test_query_manifest_provenance_and_economic_mismatch_rejection(
+        self,
+    ) -> None:
+        record, _ = self._create_reserved_unknown_intent()
+        wrong_query, _ = self._order_query_manifest(
+            broker_order_id="9000001",
+            payload_hashes=("f" * 64,),
+        )
+        wrong_evidence = self.ledger.broker_evidence_from_read(
+            record.intent_id, wrong_query, operation="ORDER_QUERY"
+        )
+        self.assertIsNotNone(wrong_evidence)
+        with self.assertRaises(OrderIntentIntegrityError):
+            self.ledger.reconcile_open(
+                record.intent_id, wrong_evidence
+            )
+
+        valid_query, _ = self._order_query_manifest(
+            broker_order_id="9000001",
+            payload_hashes=(record.envelope.payload_hash,),
+        )
+        evidence = self.ledger.broker_evidence_from_read(
+            record.intent_id, valid_query, operation="ORDER_QUERY"
+        )
+        self.assertIsNotNone(evidence)
+        self.assertEqual(
+            evidence.broker_read_evidence_sha256,
+            valid_query.evidence_sha256,
+        )
+        self.assertEqual(
+            tuple(
+                payload_hash
+                for payload_hash in evidence.order_payload_hashes
+                if payload_hash == record.envelope.payload_hash
+            ),
+            (record.envelope.payload_hash,),
+        )
+        reconciled = self.ledger.reconcile_open(
+            record.intent_id, evidence
+        )
+        self.assertEqual(reconciled.state, "SUBMITTED")
+        self.assertEqual(
+            self.ledger.events(record.intent_id)[-1]
+            .broker_read_evidence_sha256,
+            valid_query.evidence_sha256,
+        )
+
+    def test_query_manifest_rejects_receipt_for_a_different_order(
+        self,
+    ) -> None:
+        binding_start = self._record_response(
+            read_kind="ACCOUNT_LIST",
+            route="/v1/accounts/list.json",
+            raw=_account_list_raw(),
+        )
+        detail_raw = _known_order_raw("9000002")
+        receipt = self._record_response(
+            read_kind="ORDER_DETAIL",
+            route=(
+                f"/v1/accounts/{ACCOUNT_ID_KEY}/orders/"
+                "9000002.json"
+            ),
+            raw=detail_raw,
+            target_broker_order_id="9000002",
+        )
+        parsed = self._persisted_parsed(receipt.receipt_sha256)
+        binding_end = self._record_response(
+            read_kind="ACCOUNT_LIST",
+            route="/v1/accounts/list.json",
+            raw=_account_list_raw(),
+            final_response=True,
+        )
+        result = {
+            "schema": "etrade-order-query.v1",
+            "broker_order_id": "9000003",
+            "raw_status": parsed["raw_status"],
+            "outcome": parsed["outcome"],
+            "order_payload_hashes": parsed["order_payload_hashes"],
+            "http_status": 200,
+            "raw_response_digest": hashlib.sha256(
+                detail_raw
+            ).hexdigest(),
+            "not_found": parsed["not_found"],
+            "replacement_links": parsed["replacement_links"],
+        }
+        with self.assertRaises(OrderIntentIntegrityError):
+            self.ledger.record_broker_read_manifest(
+                BrokerReadManifestEvidence(
+                    evidence_kind="ORDER_QUERY",
+                    account_id=ACCOUNT_ID,
+                    account_id_key=ACCOUNT_ID_KEY,
+                    institution_type=INSTITUTION_TYPE,
+                    environment=ENVIRONMENT,
+                    origin=ORIGIN,
+                    target_broker_order_id="9000003",
+                    observed_at=self.clock.now,
+                    completeness="COMPLETE",
+                    canonical_result_json=_canonical_json(result),
+                ),
+                (
+                    BrokerReadManifestMember(
+                        role="binding.start",
+                        receipt_sha256=binding_start.receipt_sha256,
+                    ),
+                    BrokerReadManifestMember(
+                        role="order.detail",
+                        receipt_sha256=receipt.receipt_sha256,
+                    ),
+                    BrokerReadManifestMember(
+                        role="binding.end",
+                        receipt_sha256=binding_end.receipt_sha256,
+                    ),
+                ),
+            )
+
+    def test_query_manifest_rejects_nonchronological_binding_bracket(
+        self,
+    ) -> None:
+        order_id = "9000002"
+        detail_raw = _known_order_raw(order_id)
+        detail = self._record_response(
+            read_kind="ORDER_DETAIL",
+            route=(
+                f"/v1/accounts/{ACCOUNT_ID_KEY}/orders/"
+                f"{order_id}.json"
+            ),
+            raw=detail_raw,
+            target_broker_order_id=order_id,
+        )
+        binding_start = self._record_response(
+            read_kind="ACCOUNT_LIST",
+            route="/v1/accounts/list.json",
+            raw=_account_list_raw(),
+        )
+        binding_end = self._record_response(
+            read_kind="ACCOUNT_LIST",
+            route="/v1/accounts/list.json",
+            raw=_account_list_raw(),
+            final_response=True,
+        )
+        parsed = self._persisted_parsed(detail.receipt_sha256)
+        result = {
+            "schema": "etrade-order-query.v1",
+            "broker_order_id": order_id,
+            "raw_status": parsed["raw_status"],
+            "outcome": parsed["outcome"],
+            "order_payload_hashes": parsed["order_payload_hashes"],
+            "http_status": 200,
+            "raw_response_digest": hashlib.sha256(
+                detail_raw
+            ).hexdigest(),
+            "not_found": parsed["not_found"],
+            "replacement_links": parsed["replacement_links"],
+        }
+
+        with self.assertRaisesRegex(
+            OrderIntentIntegrityError,
+            "chronologically ordered",
+        ):
+            self.ledger.record_broker_read_manifest(
+                BrokerReadManifestEvidence(
+                    evidence_kind="ORDER_QUERY",
+                    account_id=ACCOUNT_ID,
+                    account_id_key=ACCOUNT_ID_KEY,
+                    institution_type=INSTITUTION_TYPE,
+                    environment=ENVIRONMENT,
+                    origin=ORIGIN,
+                    target_broker_order_id=order_id,
+                    observed_at=self.clock.now,
+                    completeness="COMPLETE",
+                    canonical_result_json=_canonical_json(result),
+                ),
+                (
+                    BrokerReadManifestMember(
+                        role="binding.start",
+                        receipt_sha256=binding_start.receipt_sha256,
+                    ),
+                    BrokerReadManifestMember(
+                        role="order.detail",
+                        receipt_sha256=detail.receipt_sha256,
+                    ),
+                    BrokerReadManifestMember(
+                        role="binding.end",
+                        receipt_sha256=binding_end.receipt_sha256,
+                    ),
+                ),
+            )
+
+    def test_raw_response_replay_rejects_inconsistent_parsed_json(
+        self,
+    ) -> None:
+        inconsistent = {
+            "account_id": ACCOUNT_ID,
+            "account_id_key": ACCOUNT_ID_KEY,
+            "institution_type": INSTITUTION_TYPE,
+            "account_status": "CLOSED",
+            "account_mode": "MARGIN",
+            "account_type": "INDIVIDUAL",
+        }
+        with self.assertRaisesRegex(
+            OrderIntentIntegrityError,
+            "parser output does not match raw response bytes",
+        ):
+            self._record_response(
+                read_kind="ACCOUNT_LIST",
+                route="/v1/accounts/list.json",
+                raw=_account_list_raw(),
+                parsed=inconsistent,
+            )
+        with sqlite3.connect(self.path) as connection:
+            self.assertEqual(
+                connection.execute(
+                    "SELECT COUNT(*) FROM broker_read_receipts"
+                ).fetchone()[0],
+                0,
+            )
+
+    def test_content_hashes_detect_raw_and_manifest_tampering(self) -> None:
+        capacity, _, _, receipt_hashes = self._capacity_decision()
+        query, _ = self._order_query_manifest(
+            broker_order_id="9000004",
+            payload_hashes=("1" * 64,),
+        )
+        with sqlite3.connect(self.path) as conn:
+            conn.execute(
+                "DROP TRIGGER prevent_broker_read_receipt_update"
+            )
+            conn.execute(
+                """
+                UPDATE broker_read_receipts
+                SET raw_response_bytes = zeroblob(raw_byte_length)
+                WHERE receipt_sha256 = ?
+                """,
+                (receipt_hashes[0],),
+            )
+            conn.execute(
+                "DROP TRIGGER prevent_broker_read_manifest_update"
+            )
+            conn.execute(
+                """
+                UPDATE broker_read_manifests
+                SET canonical_result_json = ?
+                WHERE evidence_sha256 = ?
+                """,
+                (_canonical_json({"tampered": True}), query.evidence_sha256),
+            )
+
+        with self.assertRaises(OrderIntentIntegrityError):
+            self.ledger.broker_read_evidence(
+                capacity.evidence_sha256
+            )
+        with self.assertRaises(OrderIntentIntegrityError):
+            self.ledger.broker_read_evidence(query.evidence_sha256)
+
+    def test_read_provenance_tables_are_append_only(self) -> None:
+        capacity, decision, _, receipt_hashes = (
+            self._capacity_decision()
+        )
+        mutations = (
+            (
+                "UPDATE broker_read_receipts SET completeness = 'INELIGIBLE' "
+                "WHERE receipt_sha256 = ?",
+                (receipt_hashes[0],),
+            ),
+            (
+                "DELETE FROM broker_read_receipts WHERE receipt_sha256 = ?",
+                (receipt_hashes[0],),
+            ),
+            (
+                "UPDATE broker_read_manifests SET completeness = 'UNSTABLE' "
+                "WHERE evidence_sha256 = ?",
+                (capacity.evidence_sha256,),
+            ),
+            (
+                "DELETE FROM broker_read_manifests WHERE evidence_sha256 = ?",
+                (capacity.evidence_sha256,),
+            ),
+            (
+                "UPDATE broker_read_manifest_members SET member_role = 'changed' "
+                "WHERE evidence_sha256 = ? AND member_ordinal = 0",
+                (capacity.evidence_sha256,),
+            ),
+            (
+                "DELETE FROM broker_read_manifest_members "
+                "WHERE evidence_sha256 = ? AND member_ordinal = 0",
+                (capacity.evidence_sha256,),
+            ),
+            (
+                "UPDATE capacity_decisions SET cap_amount = '1' "
+                "WHERE capacity_decision_sha256 = ?",
+                (decision.decision_sha256,),
+            ),
+            (
+                "DELETE FROM capacity_decisions "
+                "WHERE capacity_decision_sha256 = ?",
+                (decision.decision_sha256,),
+            ),
+        )
+        for statement, parameters in mutations:
+            with self.subTest(statement=statement):
+                with sqlite3.connect(self.path) as conn:
+                    with self.assertRaises(sqlite3.DatabaseError):
+                        conn.execute(statement, parameters)
+
+    def test_fresh_schema_has_provenance_foreign_keys_and_triggers(
+        self,
+    ) -> None:
+        required_foreign_keys = {
+            ("broker_read_manifest_members", "broker_read_manifests"),
+            ("broker_read_manifest_members", "broker_read_receipts"),
+            ("capacity_decisions", "broker_read_manifests"),
+            ("reservation_caps", "capacity_decisions"),
+            ("margin_reservations", "capacity_decisions"),
+            ("order_events", "broker_read_manifests"),
+        }
+        required_triggers = {
+            "prevent_broker_read_receipt_update": "before update",
+            "prevent_broker_read_receipt_delete": "before delete",
+            "prevent_broker_read_manifest_update": "before update",
+            "prevent_broker_read_manifest_delete": "before delete",
+            "prevent_broker_read_member_update": "before update",
+            "prevent_broker_read_member_delete": "before delete",
+            "prevent_capacity_decision_update": "before update",
+            "prevent_capacity_decision_delete": "before delete",
+        }
+        with sqlite3.connect(self.path) as connection:
+            actual_foreign_keys = {
+                (table, row[2])
+                for table in {
+                    table for table, _target in required_foreign_keys
+                }
+                for row in connection.execute(
+                    f"PRAGMA foreign_key_list({table})"
+                )
+            }
+            self.assertTrue(
+                required_foreign_keys.issubset(actual_foreign_keys)
+            )
+            rows = connection.execute(
+                """
+                SELECT name, sql FROM sqlite_master
+                WHERE type = 'trigger'
+                """
+            ).fetchall()
+            triggers = {name: sql for name, sql in rows}
+            self.assertTrue(required_triggers.keys() <= triggers.keys())
+            for name, expected_action in required_triggers.items():
+                normalized = " ".join(triggers[name].lower().split())
+                self.assertIn(expected_action, normalized)
+                self.assertIn("raise(abort", normalized)
+
+    def test_malformed_provenance_schema_does_not_promote_metadata(
+        self,
+    ) -> None:
+        malformed_table_path = (
+            Path(self.tmp.name)
+            / "malformed-table"
+            / "orders.sqlite3"
+        )
+        malformed_table_path.parent.mkdir(mode=0o700)
+        with sqlite3.connect(malformed_table_path) as connection:
+            connection.executescript(
+                """
+                CREATE TABLE ledger_metadata (
+                    singleton INTEGER PRIMARY KEY CHECK (singleton = 1),
+                    schema_version INTEGER NOT NULL
+                );
+                INSERT INTO ledger_metadata VALUES (1, 10);
+                CREATE TABLE broker_read_receipts (
+                    receipt_sha256 TEXT PRIMARY KEY
+                );
+                """
+            )
+        os.chmod(malformed_table_path, 0o600)
+        with self.assertRaises(
+            (sqlite3.DatabaseError, OrderIntentLedgerError)
+        ):
+            OrderIntentLedger(
+                malformed_table_path,
+                clock=self.clock,
+                run_id="malformed-table",
+            )
+        with sqlite3.connect(malformed_table_path) as connection:
+            self.assertEqual(
+                connection.execute(
+                    "SELECT schema_version FROM ledger_metadata"
+                ).fetchone()[0],
+                10,
+            )
+
+        malformed_trigger_path = (
+            Path(self.tmp.name)
+            / "malformed-trigger"
+            / "orders.sqlite3"
+        )
+        valid = OrderIntentLedger(
+            malformed_trigger_path,
+            clock=self.clock,
+            run_id="valid-before-trigger-tamper",
+        )
+        self.assertEqual(valid.path, malformed_trigger_path)
+        with sqlite3.connect(malformed_trigger_path) as connection:
+            connection.executescript(
+                """
+                DROP TRIGGER prevent_broker_read_receipt_update;
+                CREATE TRIGGER prevent_broker_read_receipt_update
+                AFTER UPDATE ON broker_read_receipts
+                BEGIN
+                    SELECT 1;
+                END;
+                UPDATE ledger_metadata SET schema_version = 10
+                WHERE singleton = 1;
+                """
+            )
+        with self.assertRaises(OrderIntentLedgerError):
+            OrderIntentLedger(
+                malformed_trigger_path,
+                clock=self.clock,
+                run_id="malformed-trigger",
+            )
+        with sqlite3.connect(malformed_trigger_path) as connection:
+            self.assertEqual(
+                connection.execute(
+                    "SELECT schema_version FROM ledger_metadata"
+                ).fetchone()[0],
+                10,
+            )
+
+    def test_schema_10_migration_adds_read_provenance_columns(self) -> None:
+        migration_path = (
+            Path(self.tmp.name) / "migration" / "orders.sqlite3"
+        )
+        migration_path.parent.mkdir(mode=0o700)
+        with sqlite3.connect(migration_path) as conn:
+            conn.executescript(
+                """
+                CREATE TABLE ledger_metadata (
+                    singleton INTEGER PRIMARY KEY CHECK (singleton = 1),
+                    schema_version INTEGER NOT NULL
+                );
+                INSERT INTO ledger_metadata VALUES (1, 10);
+                CREATE TABLE reservation_caps (
+                    account_id TEXT NOT NULL,
+                    environment TEXT NOT NULL,
+                    cap_amount TEXT NOT NULL,
+                    broker_buying_power TEXT NOT NULL,
+                    risk_budget TEXT NOT NULL,
+                    observed_at INTEGER NOT NULL,
+                    portfolio_snapshot_digest TEXT NOT NULL,
+                    updated_at INTEGER NOT NULL,
+                    PRIMARY KEY (account_id, environment)
+                );
+                CREATE TABLE margin_reservations (
+                    intent_id TEXT PRIMARY KEY,
+                    account_id TEXT NOT NULL,
+                    environment TEXT NOT NULL,
+                    amount TEXT NOT NULL,
+                    risk_decision_id TEXT NOT NULL,
+                    max_loss_amount TEXT NOT NULL,
+                    quote_observed_at INTEGER NOT NULL,
+                    quote_digest TEXT NOT NULL,
+                    portfolio_observed_at INTEGER NOT NULL,
+                    portfolio_snapshot_digest TEXT NOT NULL,
+                    state TEXT NOT NULL,
+                    released_reason_code TEXT,
+                    created_at INTEGER NOT NULL,
+                    released_at INTEGER
+                );
+                CREATE TABLE order_events (
+                    sequence INTEGER PRIMARY KEY AUTOINCREMENT,
+                    intent_id TEXT NOT NULL,
+                    account_id TEXT NOT NULL,
+                    environment TEXT NOT NULL,
+                    client_order_id TEXT NOT NULL,
+                    event_type TEXT NOT NULL,
+                    from_state TEXT,
+                    to_state TEXT,
+                    actor TEXT NOT NULL,
+                    reason_code TEXT NOT NULL,
+                    broker_status TEXT,
+                    broker_order_id TEXT,
+                    observed_at INTEGER,
+                    evidence_operation TEXT,
+                    http_status INTEGER,
+                    raw_response_digest TEXT,
+                    created_at INTEGER NOT NULL
+                );
+                """
+            )
+        os.chmod(migration_path, 0o600)
+
+        migrated = OrderIntentLedger(
+            migration_path,
+            clock=self.clock,
+            run_id="schema-10-migration",
+        )
+        self.assertEqual(migrated.path, migration_path)
+        with sqlite3.connect(migration_path) as conn:
+            self.assertEqual(
+                conn.execute(
+                    "SELECT schema_version FROM ledger_metadata"
+                ).fetchone()[0],
+                SCHEMA_VERSION,
+            )
+            self.assertIn(
+                "capacity_decision_sha256",
+                {
+                    row[1]
+                    for row in conn.execute(
+                        "PRAGMA table_info(reservation_caps)"
+                    )
+                },
+            )
+            self.assertIn(
+                "capacity_decision_sha256",
+                {
+                    row[1]
+                    for row in conn.execute(
+                        "PRAGMA table_info(margin_reservations)"
+                    )
+                },
+            )
+            self.assertIn(
+                "broker_read_evidence_sha256",
+                {
+                    row[1]
+                    for row in conn.execute(
+                        "PRAGMA table_info(order_events)"
+                    )
+                },
+            )
+            for table in (
+                "broker_read_receipts",
+                "broker_read_manifests",
+                "broker_read_manifest_members",
+                "capacity_decisions",
+            ):
+                self.assertIsNotNone(
+                    conn.execute(
+                        """
+                        SELECT 1 FROM sqlite_master
+                        WHERE type = 'table' AND name = ?
+                        """,
+                        (table,),
+                    ).fetchone()
+                )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/etrade_python_client/tests/test_etrade_broker_reader.py
+++ b/etrade_python_client/tests/test_etrade_broker_reader.py
@@ -1,0 +1,1058 @@
+from __future__ import annotations
+
+import hashlib
+import json
+import os
+import sqlite3
+import tempfile
+import unittest
+from dataclasses import dataclass
+from datetime import datetime, timedelta, timezone
+from decimal import Decimal
+from pathlib import Path
+from urllib.parse import parse_qs, urlsplit
+from unittest.mock import patch
+
+from rauth import OAuth1Session
+
+from live_trading.etrade_broker_reader import (
+    ETradeBrokerReader,
+    ETradeBrokerReaderIntegrityError,
+    ETradeBrokerReaderUnavailable,
+)
+from live_trading.etrade_broker_transport import (
+    SelectedBrokerAccount,
+    _ExchangeResult,
+)
+from live_trading.order_intent_ledger import (
+    OrderIntentLedger,
+    canonical_order_payload_hash,
+)
+from live_trading.runtime_safety import RuntimeSafetyBoundary
+
+
+ACCOUNT_ID = "842468410"
+ACCOUNT_KEY = "account/key"
+INSTITUTION_TYPE = "BROKERAGE"
+ORIGIN = "https://api.etrade.com"
+ORDER_ID = "94"
+
+
+class Clock:
+    def __init__(self) -> None:
+        self.value = datetime(2026, 7, 27, 16, 0, tzinfo=timezone.utc)
+
+    def __call__(self) -> datetime:
+        result = self.value
+        self.value += timedelta(milliseconds=1)
+        return result
+
+
+class FixedClock:
+    def __init__(self) -> None:
+        self.value = datetime(2026, 7, 27, 16, 0, tzinfo=timezone.utc)
+
+    def __call__(self) -> datetime:
+        return self.value
+
+
+@dataclass(frozen=True)
+class Reply:
+    status: int
+    raw: bytes
+
+    @classmethod
+    def json(cls, body: dict, *, status: int = 200) -> "Reply":
+        return cls(
+            status,
+            json.dumps(
+                body, sort_keys=True, separators=(",", ":")
+            ).encode("utf-8"),
+        )
+
+
+class ExchangeHarness:
+    def __init__(self, outcomes: list[Reply]) -> None:
+        self.outcomes = list(outcomes)
+        self.calls: list[tuple[object, float]] = []
+
+    def exchange(
+        self,
+        prepared,
+        *,
+        timeout_seconds: float,
+        max_response_bytes: int,
+    ):
+        if max_response_bytes != 2 * 1024 * 1024:
+            raise AssertionError(
+                "reader must pass its exact response-byte ceiling"
+            )
+        self.calls.append((prepared, timeout_seconds))
+        if not self.outcomes:
+            raise AssertionError("unexpected broker GET")
+        reply = self.outcomes.pop(0)
+        return _ExchangeResult(
+            "RESPONSE",
+            http_status=reply.status,
+            raw_response=reply.raw,
+        )
+
+
+@dataclass
+class ReaderCase:
+    temporary: tempfile.TemporaryDirectory
+    database: Path
+    ledger: OrderIntentLedger
+    reader: ETradeBrokerReader
+    account: SelectedBrokerAccount
+    adapter: ExchangeHarness
+    patcher: object
+
+
+def account(
+    *,
+    account_id: str = ACCOUNT_ID,
+    status: str = "ACTIVE",
+    mode: str = "MARGIN",
+) -> dict:
+    return {
+        "accountId": account_id,
+        "accountIdKey": ACCOUNT_KEY,
+        "institutionType": INSTITUTION_TYPE,
+        "accountStatus": status,
+        "accountMode": mode,
+        "accountType": "INDIVIDUAL",
+    }
+
+
+def account_list(*accounts: dict) -> Reply:
+    return Reply.json(
+        {
+            "AccountListResponse": {
+                "Accounts": {"Account": list(accounts)}
+            }
+        }
+    )
+
+
+def balance(
+    buying_power: str,
+    *,
+    as_of_date: str | None = "1785168000000",
+) -> Reply:
+    response = {
+        "accountId": ACCOUNT_ID,
+        "institutionType": INSTITUTION_TYPE,
+        "Computed": {"marginBuyingPower": buying_power},
+    }
+    if as_of_date is not None:
+        response["asOfDate"] = as_of_date
+    return Reply.json(
+        {"BalanceResponse": response}
+    )
+
+
+def position(position_id: str, strike: str) -> dict:
+    return {
+        "positionId": position_id,
+        "accountId": ACCOUNT_ID,
+        "quantity": "1",
+        "positionType": "LONG",
+        "positionIndicator": "TYPE1",
+        "osiKey": f"SPY---260821P00{strike}",
+        "Product": {
+            "symbol": "SPY",
+            "securityType": "OPTN",
+            "callPut": "PUT",
+            "expiryYear": "2026",
+            "expiryMonth": "8",
+            "expiryDay": "21",
+            "strikePrice": strike,
+        },
+    }
+
+
+def portfolio_page(
+    page_number: int,
+    total_pages: int,
+    positions: list[dict],
+    *,
+    next_page: int | None = None,
+    total_field: str = "totalNoOfPages",
+) -> Reply:
+    portfolio = {
+        "accountId": ACCOUNT_ID,
+        total_field: str(total_pages),
+        "Position": positions,
+    }
+    if next_page is not None:
+        portfolio["nextPageNo"] = str(next_page)
+    return Reply.json(
+        {
+            "PortfolioResponse": {
+                "AccountPortfolio": [portfolio]
+            }
+        }
+    )
+
+
+def no_content() -> Reply:
+    return Reply(204, b"")
+
+
+def orders_page(
+    *, marker: str | None, orders: list[dict] | None = None
+) -> Reply:
+    response: dict[str, object] = {"Order": orders or []}
+    if marker is not None:
+        response["marker"] = marker
+    return Reply.json({"OrdersResponse": response})
+
+
+def active_order_with_detail_statuses(*statuses: str) -> dict:
+    return {
+        "orderId": ORDER_ID,
+        "orderType": "SPREADS",
+        "OrderDetail": [
+            {
+                "accountId": ACCOUNT_ID,
+                "status": status,
+                "Instrument": [
+                    option_leg(
+                        "SELL_OPEN",
+                        "620",
+                        filled_quantity="0",
+                    )
+                ],
+            }
+            for status in statuses
+        ],
+    }
+
+
+def option_leg(
+    action: str,
+    strike: str,
+    *,
+    filled_quantity: str,
+) -> dict:
+    return {
+        "Product": {
+            "symbol": "SPY",
+            "securityType": "OPTN",
+            "callPut": "PUT",
+            "expiryYear": "2026",
+            "expiryMonth": "8",
+            "expiryDay": "21",
+            "strikePrice": strike,
+        },
+        "orderAction": action,
+        "quantityType": "QUANTITY",
+        "orderedQuantity": "1",
+        "filledQuantity": filled_quantity,
+        "cancelQuantity": "0",
+    }
+
+
+def known_order(
+    status: str,
+    *,
+    filled_quantity: str = "0",
+    second_filled_quantity: str | None = None,
+    order_id: str = ORDER_ID,
+    replaces_order_id: str | None = None,
+    replaced_by_order_id: str | None = None,
+) -> Reply:
+    outer_order = {
+        "orderId": order_id,
+        "orderType": "SPREADS",
+        "OrderDetail": [
+            {
+                "accountId": ACCOUNT_ID,
+                "orderNumber": order_id,
+                "status": status,
+                "priceType": "NET_CREDIT",
+                "limitPrice": "1.25",
+                "orderTerm": "GOOD_FOR_DAY",
+                "marketSession": "REGULAR",
+                "allOrNone": False,
+                "stopPrice": "0",
+                "Instrument": [
+                    option_leg(
+                        "SELL_OPEN",
+                        "620",
+                        filled_quantity=filled_quantity,
+                    ),
+                    option_leg(
+                        "BUY_OPEN",
+                        "615",
+                        filled_quantity=(
+                            filled_quantity
+                            if second_filled_quantity is None
+                            else second_filled_quantity
+                        ),
+                    ),
+                ],
+            }
+        ],
+    }
+    if replaces_order_id is not None:
+        outer_order["replacesOrderId"] = replaces_order_id
+    if replaced_by_order_id is not None:
+        outer_order["replacedByOrderId"] = replaced_by_order_id
+    return Reply.json(
+        {
+            "OrdersResponse": {
+                "Order": [outer_order]
+            }
+        }
+    )
+
+
+def expected_vertical_payload() -> dict:
+    return {
+        "securityType": "OPTN",
+        "orderAction": "SPREAD",
+        "priceType": "NET_CREDIT",
+        "limitPrice": Decimal("1.25"),
+        "orderTerm": "GOOD_FOR_DAY",
+        "spreadType": "VERTICAL",
+        "legs": [
+            {
+                "symbol": "SPY",
+                "callPut": "PUT",
+                "expiryYear": 2026,
+                "expiryMonth": 8,
+                "expiryDay": 21,
+                "strikePrice": Decimal("620"),
+                "orderAction": "SELL_OPEN",
+                "quantity": 1,
+            },
+            {
+                "symbol": "SPY",
+                "callPut": "PUT",
+                "expiryYear": 2026,
+                "expiryMonth": 8,
+                "expiryDay": 21,
+                "strikePrice": Decimal("615"),
+                "orderAction": "BUY_OPEN",
+                "quantity": 1,
+            },
+        ],
+    }
+
+
+def one_page_scan(buying_power: str) -> list[Reply]:
+    return [
+        balance(buying_power),
+        portfolio_page(1, 1, []),
+        no_content(),
+        no_content(),
+        no_content(),
+    ]
+
+
+class ETradeBrokerReaderTests(unittest.TestCase):
+    def setUp(self) -> None:
+        self.cases: list[ReaderCase] = []
+
+    def tearDown(self) -> None:
+        for case in reversed(self.cases):
+            case.patcher.stop()
+            case.temporary.cleanup()
+
+    def case(
+        self,
+        outcomes: list[Reply],
+        *,
+        clock: Clock | FixedClock | None = None,
+    ) -> ReaderCase:
+        temporary = tempfile.TemporaryDirectory()
+        os.chmod(temporary.name, 0o700)
+        database = Path(temporary.name) / "runtime" / "orders.sqlite3"
+        clock = clock or Clock()
+        ledger = OrderIntentLedger(
+            database,
+            clock=clock,
+            run_id="broker-reader-test",
+        )
+        runtime = RuntimeSafetyBoundary(
+            environment="production",
+            expected_account_id=ACCOUNT_ID,
+            expected_account_id_key=ACCOUNT_KEY,
+            expected_institution_type=INSTITUTION_TYPE,
+            arm_issued_at=clock.value - timedelta(seconds=1),
+            arm_expires_at=clock.value + timedelta(minutes=10),
+        )
+        selected = SelectedBrokerAccount(
+            ACCOUNT_ID, ACCOUNT_KEY, INSTITUTION_TYPE
+        )
+        reader = ETradeBrokerReader(
+            session=OAuth1Session(
+                "consumer-key",
+                "consumer-secret",
+                access_token="access-token",
+                access_token_secret="access-secret",
+            ),
+            ledger=ledger,
+            runtime_safety=runtime,
+            selected_account=selected,
+            clock=clock,
+        )
+        adapter = ExchangeHarness(outcomes)
+        patcher = patch(
+            "live_trading.etrade_broker_reader._isolated_exchange",
+            side_effect=adapter.exchange,
+        )
+        patcher.start()
+        result = ReaderCase(
+            temporary,
+            database,
+            ledger,
+            reader,
+            selected,
+            adapter,
+            patcher,
+        )
+        self.cases.append(result)
+        return result
+
+    @staticmethod
+    def rows(
+        case: ReaderCase, sql: str, parameters: tuple = ()
+    ) -> list[sqlite3.Row]:
+        with sqlite3.connect(case.database) as connection:
+            connection.row_factory = sqlite3.Row
+            return connection.execute(sql, parameters).fetchall()
+
+    def manifest_result(
+        self, case: ReaderCase, evidence_sha256: str
+    ) -> dict:
+        rows = self.rows(
+            case,
+            """
+            SELECT canonical_result_json
+            FROM broker_read_manifests
+            WHERE evidence_sha256 = ?
+            """,
+            (evidence_sha256,),
+        )
+        self.assertEqual(len(rows), 1)
+        return json.loads(rows[0]["canonical_result_json"])
+
+    def test_get_is_origin_pinned_and_an_ineligible_response_is_not_retried(
+        self,
+    ) -> None:
+        case = self.case(
+            [
+                account_list(account()),
+                Reply.json(
+                    {"Error": {"message": "temporarily unavailable"}},
+                    status=503,
+                ),
+            ]
+        )
+
+        with self.assertRaises(ETradeBrokerReaderUnavailable):
+            case.reader.query_order(case.account, ORDER_ID)
+
+        self.assertEqual(case.adapter.outcomes, [])
+        self.assertEqual(len(case.adapter.calls), 2)
+        for prepared, timeout_seconds in case.adapter.calls:
+            parsed = urlsplit(prepared.url)
+            self.assertEqual(prepared.method, "GET")
+            self.assertIsNone(prepared.body)
+            self.assertEqual(
+                f"{parsed.scheme}://{parsed.netloc}", ORIGIN
+            )
+            self.assertEqual(timeout_seconds, 15.0)
+            self.assertNotIn("Cookie", prepared.headers)
+        self.assertEqual(
+            case.adapter.calls[1][0].url,
+            f"{ORIGIN}/v1/accounts/account%2Fkey/orders/{ORDER_ID}.json",
+        )
+        rows = self.rows(
+            case,
+            """
+            SELECT http_status, completeness, http_method, origin
+            FROM broker_read_receipts
+            ORDER BY request_started_at
+            """,
+        )
+        self.assertEqual(
+            [
+                (
+                    row["http_status"],
+                    row["completeness"],
+                    row["http_method"],
+                    row["origin"],
+                )
+                for row in rows
+            ],
+            [
+                (200, "COMPLETE", "GET", ORIGIN),
+                (503, "INELIGIBLE", "GET", ORIGIN),
+            ],
+        )
+
+    def test_account_binding_requires_one_active_margin_match(self) -> None:
+        variants = (
+            (
+                [account(), account()],
+                ETradeBrokerReaderIntegrityError,
+            ),
+            (
+                [account(status="CLOSED")],
+                ETradeBrokerReaderUnavailable,
+            ),
+            (
+                [account(account_id="842468411")],
+                ETradeBrokerReaderIntegrityError,
+            ),
+        )
+        for accounts, expected_error in variants:
+            with self.subTest(
+                accounts=accounts, expected_error=expected_error
+            ):
+                case = self.case([account_list(*accounts)])
+                with self.assertRaises(expected_error):
+                    case.reader.query_order(case.account, ORDER_ID)
+                self.assertEqual(len(case.adapter.calls), 1)
+                rows = self.rows(
+                    case,
+                    """
+                    SELECT read_kind, completeness, canonical_parsed_json
+                    FROM broker_read_receipts
+                    """,
+                )
+                self.assertEqual(len(rows), 1)
+                self.assertEqual(rows[0]["read_kind"], "ACCOUNT_LIST")
+                self.assertEqual(rows[0]["completeness"], "INELIGIBLE")
+                self.assertEqual(rows[0]["canonical_parsed_json"], "null")
+
+    def test_capacity_uses_declared_portfolio_pages_and_persists_lineage(
+        self,
+    ) -> None:
+        pages = [
+            portfolio_page(
+                1,
+                2,
+                [position("12", "620")],
+                next_page=2,
+            ),
+            portfolio_page(2, 2, [position("11", "615")]),
+        ]
+        scan = [
+            balance("1000"),
+            *pages,
+            no_content(),
+            no_content(),
+            no_content(),
+        ]
+        case = self.case(
+            [
+                account_list(account()),
+                *scan,
+                *scan,
+                account_list(account()),
+            ]
+        )
+
+        evidence = case.reader.read_capacity(case.account)
+
+        self.assertEqual(evidence.evidence_kind, "CAPACITY")
+        self.assertEqual(case.adapter.outcomes, [])
+        self.assertEqual(len(case.adapter.calls), 14)
+        portfolio_calls = [
+            prepared
+            for prepared, _timeout in case.adapter.calls
+            if urlsplit(prepared.url).path.endswith("/portfolio.json")
+        ]
+        self.assertEqual(len(portfolio_calls), 4)
+        self.assertEqual(
+            [
+                parse_qs(urlsplit(prepared.url).query)["pageNumber"][0]
+                for prepared in portfolio_calls
+            ],
+            ["1", "2", "1", "2"],
+        )
+        result = self.manifest_result(
+            case, evidence.evidence_sha256
+        )
+        self.assertEqual(result["broker_buying_power"], "1000")
+        self.assertEqual(
+            [item["position_id"] for item in result["positions"]],
+            ["11", "12"],
+        )
+        self.assertEqual(result["open_orders"], [])
+        self.assertEqual(len(result["state_sha256"]), 64)
+        receipt_rows = self.rows(
+            case,
+            "SELECT * FROM broker_read_receipts ORDER BY request_started_at",
+        )
+        self.assertEqual(len(receipt_rows), 14)
+        for row in receipt_rows:
+            self.assertEqual(row["http_method"], "GET")
+            self.assertEqual(row["origin"], ORIGIN)
+            self.assertEqual(
+                row["raw_byte_length"], len(row["raw_response_bytes"])
+            )
+            self.assertEqual(
+                row["raw_response_sha256"],
+                hashlib.sha256(row["raw_response_bytes"]).hexdigest(),
+            )
+            self.assertIn(
+                row["completeness"], {"COMPLETE", "HAS_NEXT"}
+            )
+        member_rows = self.rows(
+            case,
+            """
+            SELECT member_role
+            FROM broker_read_manifest_members
+            WHERE evidence_sha256 = ?
+            ORDER BY member_ordinal
+            """,
+            (evidence.evidence_sha256,),
+        )
+        self.assertEqual(len(member_rows), 14)
+        self.assertEqual(member_rows[0]["member_role"], "binding.start")
+        self.assertEqual(member_rows[-1]["member_role"], "binding.end")
+        self.assertIn(
+            "scan_a.portfolio.0002",
+            {row["member_role"] for row in member_rows},
+        )
+        self.assertIn(
+            "scan_b.orders.INDIVIDUAL_FILLS.0000",
+            {row["member_role"] for row in member_rows},
+        )
+
+    def test_order_marker_cycle_fails_closed_after_durable_pages(self) -> None:
+        case = self.case(
+            [
+                account_list(account()),
+                balance("1000"),
+                no_content(),
+                orders_page(marker="M1"),
+                orders_page(marker="M1"),
+            ]
+        )
+
+        with self.assertRaisesRegex(
+            ETradeBrokerReaderIntegrityError,
+            "marker pagination repeated or cycled",
+        ):
+            case.reader.read_capacity(case.account)
+
+        self.assertEqual(case.adapter.outcomes, [])
+        self.assertEqual(len(case.adapter.calls), 5)
+        second_order_url = case.adapter.calls[-1][0].url
+        query = parse_qs(urlsplit(second_order_url).query)
+        self.assertEqual(query["status"], ["OPEN"])
+        self.assertEqual(query["marker"], ["M1"])
+        order_rows = self.rows(
+            case,
+            """
+            SELECT completeness, canonical_parsed_json
+            FROM broker_read_receipts
+            WHERE read_kind = 'OPEN_ORDERS_PAGE'
+            ORDER BY request_started_at
+            """,
+        )
+        self.assertEqual(
+            [row["completeness"] for row in order_rows],
+            ["HAS_NEXT", "HAS_NEXT"],
+        )
+        self.assertEqual(
+            [
+                json.loads(row["canonical_parsed_json"])["marker"]
+                for row in order_rows
+            ],
+            ["M1", "M1"],
+        )
+        self.assertEqual(
+            self.rows(case, "SELECT * FROM broker_read_manifests"), []
+        )
+
+    def test_capacity_requires_semantically_identical_complete_scans(
+        self,
+    ) -> None:
+        case = self.case(
+            [
+                account_list(account()),
+                *one_page_scan("1000"),
+                *one_page_scan("999"),
+                account_list(account()),
+            ]
+        )
+
+        with self.assertRaisesRegex(
+            ETradeBrokerReaderUnavailable,
+            "capacity state changed between complete scans",
+        ):
+            case.reader.read_capacity(case.account)
+
+        self.assertEqual(case.adapter.outcomes, [])
+        self.assertEqual(len(case.adapter.calls), 12)
+        self.assertEqual(
+            self.rows(case, "SELECT * FROM broker_read_manifests"), []
+        )
+        self.assertEqual(
+            len(
+                self.rows(
+                    case, "SELECT * FROM broker_read_receipts"
+                )
+            ),
+            12,
+        )
+
+    def test_balance_requires_a_present_and_fresh_as_of_date(self) -> None:
+        missing_scan = [
+            balance("1000", as_of_date=None),
+            portfolio_page(1, 1, []),
+            no_content(),
+            no_content(),
+            no_content(),
+        ]
+        missing = self.case(
+            [
+                account_list(account()),
+                *missing_scan,
+                *missing_scan,
+                account_list(account()),
+            ]
+        )
+        with self.assertRaises(ETradeBrokerReaderIntegrityError):
+            missing.reader.read_capacity(missing.account)
+        missing_receipt = self.rows(
+            missing,
+            """
+            SELECT completeness, canonical_parsed_json
+            FROM broker_read_receipts
+            WHERE read_kind = 'BALANCE'
+            """,
+        )
+        self.assertEqual(len(missing_receipt), 1)
+        self.assertEqual(
+            missing_receipt[0]["completeness"], "INELIGIBLE"
+        )
+        self.assertEqual(
+            missing_receipt[0]["canonical_parsed_json"], "null"
+        )
+
+        stale_scan = [
+            balance(
+                "1000",
+                as_of_date="1785153600000",
+            ),
+            portfolio_page(1, 1, []),
+            no_content(),
+            no_content(),
+            no_content(),
+        ]
+        stale = self.case(
+            [
+                account_list(account()),
+                *stale_scan,
+                *stale_scan,
+                account_list(account()),
+            ]
+        )
+        with self.assertRaises(ETradeBrokerReaderUnavailable):
+            stale.reader.read_capacity(stale.account)
+        stale_receipt = self.rows(
+            stale,
+            """
+            SELECT completeness, canonical_parsed_json
+            FROM broker_read_receipts
+            WHERE read_kind = 'BALANCE'
+            """,
+        )
+        self.assertEqual(len(stale_receipt), 1)
+        self.assertEqual(
+            stale_receipt[0]["completeness"], "INELIGIBLE"
+        )
+        self.assertEqual(
+            stale_receipt[0]["canonical_parsed_json"], "null"
+        )
+
+    def test_stable_capacity_has_unambiguous_lineage_with_a_fixed_clock(
+        self,
+    ) -> None:
+        case = self.case(
+            [
+                account_list(account()),
+                *one_page_scan("1000"),
+                *one_page_scan("1000"),
+                account_list(account()),
+            ],
+            clock=FixedClock(),
+        )
+
+        evidence = case.reader.read_capacity(case.account)
+
+        self.assertEqual(evidence.evidence_kind, "CAPACITY")
+        receipt_rows = self.rows(
+            case,
+            """
+            SELECT receipt_sha256
+            FROM broker_read_receipts
+            ORDER BY rowid
+            """,
+        )
+        member_rows = self.rows(
+            case,
+            """
+            SELECT receipt_sha256
+            FROM broker_read_manifest_members
+            WHERE evidence_sha256 = ?
+            ORDER BY member_ordinal
+            """,
+            (evidence.evidence_sha256,),
+        )
+        self.assertEqual(len(receipt_rows), 12)
+        self.assertEqual(len(member_rows), 12)
+        self.assertEqual(
+            len({row["receipt_sha256"] for row in receipt_rows}), 12
+        )
+        self.assertEqual(
+            len({row["receipt_sha256"] for row in member_rows}), 12
+        )
+
+    def test_active_order_first_detail_must_match_its_status_lane(
+        self,
+    ) -> None:
+        case = self.case(
+            [
+                account_list(account()),
+                balance("1000"),
+                no_content(),
+                orders_page(
+                    marker=None,
+                    orders=[
+                        active_order_with_detail_statuses(
+                            "CANCEL_REQUESTED", "OPEN"
+                        )
+                    ],
+                ),
+            ]
+        )
+
+        with self.assertRaisesRegex(
+            ETradeBrokerReaderIntegrityError,
+            "active order status does not match its requested lane",
+        ):
+            case.reader.read_capacity(case.account)
+
+        self.assertEqual(case.adapter.outcomes, [])
+        self.assertEqual(len(case.adapter.calls), 4)
+        order_receipts = self.rows(
+            case,
+            """
+            SELECT completeness, canonical_parsed_json
+            FROM broker_read_receipts
+            WHERE read_kind = 'OPEN_ORDERS_PAGE'
+            """,
+        )
+        self.assertEqual(len(order_receipts), 1)
+        self.assertEqual(
+            order_receipts[0]["completeness"], "INELIGIBLE"
+        )
+        self.assertEqual(
+            order_receipts[0]["canonical_parsed_json"], "null"
+        )
+        self.assertEqual(
+            self.rows(case, "SELECT * FROM broker_read_manifests"), []
+        )
+
+    def test_order_error_message_cannot_become_complete_empty_capacity(
+        self,
+    ) -> None:
+        for message_key in ("Messages", "messages"):
+            with self.subTest(message_key=message_key):
+                case = self.case(
+                    [
+                        account_list(account()),
+                        balance("1000"),
+                        no_content(),
+                        Reply.json(
+                            {
+                                "OrdersResponse": {
+                                    "Order": [],
+                                    message_key: {
+                                        "Message": [
+                                            {
+                                                "type": "ERROR",
+                                                "code": "100",
+                                                "description": "unavailable",
+                                            }
+                                        ]
+                                    },
+                                }
+                            }
+                        ),
+                    ]
+                )
+
+                with self.assertRaisesRegex(
+                    ETradeBrokerReaderIntegrityError,
+                    "broker messages",
+                ):
+                    case.reader.read_capacity(case.account)
+
+                order_receipts = self.rows(
+                    case,
+                    """
+                    SELECT completeness, canonical_parsed_json
+                    FROM broker_read_receipts
+                    WHERE read_kind = 'OPEN_ORDERS_PAGE'
+                    """,
+                )
+                self.assertEqual(len(order_receipts), 1)
+                self.assertEqual(
+                    order_receipts[0]["completeness"], "INELIGIBLE"
+                )
+                self.assertEqual(
+                    order_receipts[0]["canonical_parsed_json"], "null"
+                )
+                self.assertEqual(
+                    self.rows(
+                        case, "SELECT * FROM broker_read_manifests"
+                    ),
+                    [],
+                )
+
+    def test_known_order_statuses_map_to_closed_outcomes_and_payload_hash(
+        self,
+    ) -> None:
+        expected_hash = canonical_order_payload_hash(
+            expected_vertical_payload()
+        )
+        variants = (
+            ("OPEN", "0", "OPEN"),
+            ("EXECUTED", "1", "FILLED"),
+            ("CANCELLED", "0", "CANCELLED"),
+            ("REJECTED", "0", "REJECTED"),
+            ("EXPIRED", "0", "EXPIRED"),
+            ("CANCEL_REQUESTED", "0", "UNRESOLVED"),
+        )
+        for status, filled_quantity, expected_outcome in variants:
+            with self.subTest(status=status):
+                case = self.case(
+                    [
+                        account_list(account()),
+                        known_order(
+                            status,
+                            filled_quantity=filled_quantity,
+                        ),
+                        account_list(account()),
+                    ]
+                )
+                evidence = case.reader.query_order(
+                    case.account, ORDER_ID
+                )
+                result = self.manifest_result(
+                    case, evidence.evidence_sha256
+                )
+                self.assertEqual(result["raw_status"], status)
+                self.assertEqual(result["outcome"], expected_outcome)
+                self.assertFalse(result["not_found"])
+                self.assertIn(
+                    expected_hash, result["order_payload_hashes"]
+                )
+                self.assertEqual(
+                    result["raw_response_digest"],
+                    self.rows(
+                        case,
+                        """
+                        SELECT raw_response_sha256
+                        FROM broker_read_receipts
+                        WHERE read_kind = 'ORDER_DETAIL'
+                        """,
+                    )[0]["raw_response_sha256"],
+                )
+
+    def test_partial_terminal_and_replacement_link_stay_unresolved(
+        self,
+    ) -> None:
+        variants = (
+            known_order(
+                "CANCELLED",
+                filled_quantity="1",
+                second_filled_quantity="0",
+            ),
+            known_order("OPEN", replaced_by_order_id="95"),
+            known_order("EXECUTED", filled_quantity="1", replaces_order_id="93"),
+        )
+        for reply in variants:
+            with self.subTest(raw=reply.raw):
+                case = self.case(
+                    [
+                        account_list(account()),
+                        reply,
+                        account_list(account()),
+                    ]
+                )
+                evidence = case.reader.query_order(
+                    case.account, ORDER_ID
+                )
+                result = self.manifest_result(
+                    case, evidence.evidence_sha256
+                )
+                self.assertEqual(result["outcome"], "UNRESOLVED")
+
+    def test_order_404_is_complete_durable_but_remains_a_blocker(self) -> None:
+        case = self.case(
+            [
+                account_list(account()),
+                Reply(404, b""),
+                account_list(account()),
+            ]
+        )
+
+        evidence = case.reader.query_order(case.account, ORDER_ID)
+
+        result = self.manifest_result(
+            case, evidence.evidence_sha256
+        )
+        self.assertTrue(result["not_found"])
+        self.assertEqual(result["outcome"], "UNRESOLVED")
+        self.assertEqual(result["raw_status"], "NOT_FOUND")
+        self.assertEqual(result["order_payload_hashes"], [])
+        detail = self.rows(
+            case,
+            """
+            SELECT http_status, completeness, target_broker_order_id,
+                   raw_byte_length, raw_response_sha256
+            FROM broker_read_receipts
+            WHERE read_kind = 'ORDER_DETAIL'
+            """,
+        )
+        self.assertEqual(len(detail), 1)
+        self.assertEqual(detail[0]["http_status"], 404)
+        self.assertEqual(detail[0]["completeness"], "COMPLETE")
+        self.assertEqual(
+            detail[0]["target_broker_order_id"], ORDER_ID
+        )
+        self.assertEqual(detail[0]["raw_byte_length"], 0)
+        self.assertEqual(
+            detail[0]["raw_response_sha256"],
+            hashlib.sha256(b"").hexdigest(),
+        )
+        self.assertEqual(
+            len(
+                self.rows(
+                    case,
+                    """
+                    SELECT *
+                    FROM broker_read_manifest_members
+                    WHERE evidence_sha256 = ?
+                    """,
+                    (evidence.evidence_sha256,),
+                )
+            ),
+            3,
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/etrade_python_client/tests/test_etrade_broker_transport.py
+++ b/etrade_python_client/tests/test_etrade_broker_transport.py
@@ -12,6 +12,7 @@ from dataclasses import dataclass
 from datetime import datetime, timedelta, timezone
 from decimal import Decimal
 from pathlib import Path
+from urllib.parse import quote
 from unittest.mock import patch
 
 from rauth import OAuth1Session
@@ -35,9 +36,16 @@ from live_trading.etrade_broker_transport import (
     _transport_response_evidence,
     _write_exchange_result,
 )
+from live_trading.etrade_broker_reader import (
+    _PARSER_CODE_SHA256,
+    _PARSER_CONFIG_SHA256,
+    _PARSER_SCHEMA,
+)
 from live_trading.order_intent_ledger import (
-    AccountCapacityEvidence,
     BrokerEvidence,
+    BrokerReadManifestEvidence,
+    BrokerReadManifestMember,
+    BrokerReadResponseEvidence,
     OrderIntent,
     OrderIntentLedger,
     OrderIntentReconciliationRequired,
@@ -51,6 +59,260 @@ ACCOUNT_ID = "842468410"
 ACCOUNT_KEY = "account/key"
 INSTITUTION_TYPE = "BROKERAGE"
 OWNER = "worker-1"
+ORIGIN = "https://api.etrade.com"
+
+
+def canonical_read_json(value):
+    return json.dumps(
+        value, sort_keys=True, separators=(",", ":"), ensure_ascii=True
+    )
+
+
+def capacity_state_sha256(value):
+    return hashlib.sha256(
+        b"etrade-capacity-state.v1\0"
+        + canonical_read_json(value).encode("utf-8")
+    ).hexdigest()
+
+
+def provision_durable_capacity(
+    ledger,
+    *,
+    account_id=ACCOUNT_ID,
+    account_key=ACCOUNT_KEY,
+    observed_at,
+):
+    """Record the minimal exact two-pass CAPACITY lineage used by production."""
+
+    encoded_account = quote(account_key, safe="")
+    binding = {
+        "account_id": account_id,
+        "account_id_key": account_key,
+        "institution_type": INSTITUTION_TYPE,
+        "account_status": "ACTIVE",
+        "account_mode": "MARGIN",
+        "account_type": "INDIVIDUAL",
+    }
+    economic_state = {
+        "schema": "etrade-capacity.v1",
+        "account_status": "ACTIVE",
+        "account_mode": "MARGIN",
+        "account_type": "INDIVIDUAL",
+        "broker_buying_power": "1000",
+        "positions": [],
+        "open_orders": [],
+    }
+    entries = [
+        (
+            "binding.start",
+            "ACCOUNT_LIST",
+            "/v1/accounts/list.json",
+            (),
+            200,
+            {
+                "AccountListResponse": {
+                    "Accounts": {
+                        "Account": [
+                            {
+                                "accountId": account_id,
+                                "accountIdKey": account_key,
+                                "institutionType": INSTITUTION_TYPE,
+                                "accountStatus": "ACTIVE",
+                                "accountMode": "MARGIN",
+                                "accountType": "INDIVIDUAL",
+                            }
+                        ]
+                    }
+                }
+            },
+            binding,
+        )
+    ]
+    balance_as_of_by_scan = {}
+    for scan in ("scan_a", "scan_b"):
+        entries.extend(
+            [
+                (
+                    f"{scan}.balance",
+                    "BALANCE",
+                    f"/v1/accounts/{encoded_account}/balance.json",
+                    (
+                        ("instType", INSTITUTION_TYPE),
+                        ("realTimeNAV", "true"),
+                    ),
+                    200,
+                    None,
+                    None,
+                ),
+                (
+                    f"{scan}.portfolio.0001",
+                    "PORTFOLIO_PAGE",
+                    f"/v1/accounts/{encoded_account}/portfolio.json",
+                    (
+                        ("count", "50"),
+                        ("lotsRequired", "false"),
+                        ("marketSession", "REGULAR"),
+                        ("pageNumber", "1"),
+                        ("sortBy", "SYMBOL"),
+                        ("sortOrder", "ASC"),
+                        ("totalsRequired", "false"),
+                        ("view", "COMPLETE"),
+                    ),
+                    204,
+                    None,
+                    {
+                        "page_number": 1,
+                        "total_pages": 0,
+                        "metadata_field": "HTTP_204",
+                        "next_page": None,
+                        "positions": [],
+                    },
+                ),
+                *(
+                    (
+                        f"{scan}.orders.{lane}.0000",
+                        "OPEN_ORDERS_PAGE",
+                        f"/v1/accounts/{encoded_account}/orders.json",
+                        (("count", "100"), ("status", lane)),
+                        204,
+                        None,
+                        {
+                            "status_lane": lane,
+                            "orders": [],
+                            "marker": None,
+                        },
+                    )
+                    for lane in (
+                        "OPEN",
+                        "CANCEL_REQUESTED",
+                        "INDIVIDUAL_FILLS",
+                    )
+                ),
+            ]
+        )
+    entries.append(
+        (
+            "binding.end",
+            "ACCOUNT_LIST",
+            "/v1/accounts/list.json",
+            (),
+            200,
+            {
+                "AccountListResponse": {
+                    "Accounts": {
+                        "Account": [
+                            {
+                                "accountId": account_id,
+                                "accountIdKey": account_key,
+                                "institutionType": INSTITUTION_TYPE,
+                                "accountStatus": "ACTIVE",
+                                "accountMode": "MARGIN",
+                                "accountType": "INDIVIDUAL",
+                            }
+                        ]
+                    }
+                }
+            },
+            binding,
+        )
+    )
+
+    members = []
+    final_completed_at = observed_at
+    for ordinal, (
+        role,
+        read_kind,
+        route,
+        query,
+        http_status,
+        raw_document,
+        parsed,
+    ) in enumerate(entries):
+        completed_at = (
+            observed_at
+            - timedelta(seconds=1)
+            + timedelta(milliseconds=ordinal * 50)
+        )
+        started_at = completed_at - timedelta(milliseconds=10)
+        if read_kind == "BALANCE":
+            balance_as_of = str(
+                int(completed_at.timestamp() * 1_000)
+            )
+            balance_as_of_by_scan[role.split(".", 1)[0]] = balance_as_of
+            raw_document = {
+                "BalanceResponse": {
+                    "accountId": account_id,
+                    "institutionType": INSTITUTION_TYPE,
+                    "asOfDate": balance_as_of,
+                    "Computed": {"marginBuyingPower": "1000"},
+                }
+            }
+            parsed = {
+                "account_id": account_id,
+                "institution_type": INSTITUTION_TYPE,
+                "margin_buying_power": "1000",
+                "as_of_date": balance_as_of,
+            }
+        raw = (
+            b""
+            if raw_document is None
+            else canonical_read_json(raw_document).encode("utf-8")
+        )
+        receipt = ledger.record_broker_read_response(
+            BrokerReadResponseEvidence(
+                read_kind=read_kind,
+                account_id=account_id,
+                account_id_key=account_key,
+                institution_type=INSTITUTION_TYPE,
+                environment="production",
+                origin=ORIGIN,
+                route=route,
+                query_json=canonical_read_json(
+                    [list(pair) for pair in sorted(query)]
+                ),
+                authorization_sha256=hashlib.sha256(
+                    f"capacity-auth-{ordinal}".encode("ascii")
+                ).hexdigest(),
+                target_broker_order_id=None,
+                request_started_at=started_at,
+                response_completed_at=completed_at,
+                http_status=http_status,
+                raw_response_bytes=raw,
+                parser_schema=_PARSER_SCHEMA,
+                parser_code_sha256=_PARSER_CODE_SHA256,
+                parser_config_sha256=_PARSER_CONFIG_SHA256,
+                canonical_parsed_json=canonical_read_json(parsed),
+                completeness="COMPLETE",
+            )
+        )
+        members.append(
+            BrokerReadManifestMember(role, receipt.receipt_sha256)
+        )
+        final_completed_at = completed_at
+
+    result = {
+        **economic_state,
+        "broker_buying_power_as_of": balance_as_of_by_scan["scan_b"],
+        "state_sha256": capacity_state_sha256(economic_state),
+    }
+    evidence = ledger.record_broker_read_manifest(
+        BrokerReadManifestEvidence(
+            evidence_kind="CAPACITY",
+            account_id=account_id,
+            account_id_key=account_key,
+            institution_type=INSTITUTION_TYPE,
+            environment="production",
+            origin=ORIGIN,
+            target_broker_order_id=None,
+            observed_at=final_completed_at,
+            completeness="COMPLETE",
+            canonical_result_json=canonical_read_json(result),
+        ),
+        tuple(members),
+    )
+    return ledger.set_reservation_cap_from_read(
+        evidence, risk_budget=Decimal("1000")
+    )
 
 
 def vertical_payload(*, limit_price=1.25, symbol="SPY"):
@@ -136,9 +398,25 @@ class AdapterHarness:
         self.outcomes = list(outcomes)
         self.calls = []
 
-    def exchange(self, prepared, *, timeout_seconds):
+    def exchange(
+        self,
+        prepared,
+        *,
+        timeout_seconds,
+        max_response_bytes=64 * 1024,
+    ):
+        if max_response_bytes != 64 * 1024:
+            raise AssertionError(
+                "mutation exchange must retain its exact response-byte ceiling"
+            )
         self.calls.append(
-            (prepared, {"timeout_seconds": timeout_seconds})
+            (
+                prepared,
+                {
+                    "timeout_seconds": timeout_seconds,
+                    "max_response_bytes": max_response_bytes,
+                },
+            )
         )
         if not self.outcomes:
             raise AssertionError("unexpected broker request")
@@ -207,15 +485,11 @@ class ETradeBrokerTransportTests(unittest.TestCase):
         )
         record = ledger.create_intent(intent, intent_id="intent-1").intent
         observed_at = datetime.now(timezone.utc)
-        ledger.set_reservation_cap(
-            AccountCapacityEvidence(
-                account_id=account_id,
-                environment="production",
-                broker_buying_power=Decimal("1000"),
-                risk_budget=Decimal("1000"),
-                observed_at=observed_at,
-                portfolio_snapshot_digest="b" * 64,
-            )
+        capacity_decision = provision_durable_capacity(
+            ledger,
+            account_id=account_id,
+            account_key=account_key,
+            observed_at=observed_at,
         )
         ledger.reserve_margin(
             record.intent_id,
@@ -225,8 +499,13 @@ class ETradeBrokerTransportTests(unittest.TestCase):
                 collateral_amount=Decimal("500"),
                 quote_observed_at=observed_at,
                 quote_digest="a" * 64,
-                portfolio_observed_at=observed_at,
-                portfolio_snapshot_digest="b" * 64,
+                portfolio_observed_at=capacity_decision.observed_at,
+                portfolio_snapshot_digest=(
+                    capacity_decision.portfolio_snapshot_digest
+                ),
+                capacity_decision_sha256=(
+                    capacity_decision.decision_sha256
+                ),
             ),
         )
         lease = ledger.claim_submission(
@@ -507,7 +786,9 @@ class ETradeBrokerTransportTests(unittest.TestCase):
             return_value=response,
         ) as send:
             _exchange_worker(
-                output, _serialized_prepared_request(prepared)
+                output,
+                _serialized_prepared_request(prepared),
+                64 * 1024,
             )
 
         self.assertEqual(send.call_count, 1)

--- a/etrade_python_client/tests/test_etrade_order_gateway.py
+++ b/etrade_python_client/tests/test_etrade_order_gateway.py
@@ -1,28 +1,35 @@
 from __future__ import annotations
 
+import hashlib
 import inspect
 import json
 import os
 import tempfile
 import unittest
-from dataclasses import replace
+from dataclasses import dataclass, field, replace
 from datetime import datetime, timedelta, timezone
 from decimal import Decimal
 from pathlib import Path
+from typing import Literal
+from urllib.parse import quote
 from unittest.mock import patch
 
 from rauth import OAuth1Session
 
 import live_trading.etrade_order_gateway as gateway_module
+from live_trading.etrade_broker_reader import (
+    ETradeBrokerReader as ConcreteETradeBrokerReader,
+    _PARSER_CODE_SHA256,
+    _PARSER_CONFIG_SHA256,
+    _PARSER_SCHEMA,
+    _reparse_broker_read_response,
+)
 from live_trading.etrade_broker_transport import (
     ETradeBrokerTransport,
     SelectedBrokerAccount,
     _ExchangeResult,
 )
 from live_trading.etrade_order_gateway import (
-    BrokerCapacitySnapshot,
-    BrokerOrderNotFound,
-    BrokerOrderSnapshot,
     EtradeOrderGateway,
     GatewayReconciliationRequired,
     GatewayValidationError,
@@ -30,6 +37,9 @@ from live_trading.etrade_order_gateway import (
     SubmitOpeningCommand,
 )
 from live_trading.order_intent_ledger import (
+    BrokerReadManifestEvidence,
+    BrokerReadManifestMember,
+    BrokerReadResponseEvidence,
     OrderIntentLedger,
     OrderIntentReconciliationRequired,
     OrderIntentReservationError,
@@ -45,6 +55,49 @@ ACCOUNT_ID = "842468410"
 ACCOUNT_KEY = "account/key"
 INSTITUTION_TYPE = "BROKERAGE"
 OWNER = "gateway-worker"
+
+
+@dataclass(frozen=True)
+class BrokerOrderSnapshot:
+    account: SelectedBrokerAccount
+    environment: Literal["sandbox", "production"]
+    broker_order_id: str = field(repr=False)
+    outcome: Literal[
+        "OPEN",
+        "FILLED",
+        "CANCELLED",
+        "REJECTED",
+        "EXPIRED",
+        "UNRESOLVED",
+    ]
+    observed_at: datetime
+    http_status: int
+    raw_response_digest: str
+    order_payload_hash: str
+    complete: bool
+
+
+@dataclass(frozen=True)
+class BrokerOrderNotFound:
+    account: SelectedBrokerAccount
+    environment: Literal["sandbox", "production"]
+    broker_order_id: str = field(repr=False)
+    observed_at: datetime
+    http_status: int
+    raw_response_digest: str
+    complete: bool
+
+
+def _canonical_json(value):
+    return json.dumps(
+        value, sort_keys=True, separators=(",", ":"), ensure_ascii=True
+    )
+
+
+def _domain_json_sha256(domain, value):
+    return hashlib.sha256(
+        domain + _canonical_json(value).encode("utf-8")
+    ).hexdigest()
 
 
 class Clock:
@@ -185,10 +238,22 @@ class FakeReader:
         self.selected_hook = None
         self.query_behaviors = {}
         self.query_calls = []
+        self.authorization_counter = 0
+        self.ledger = None
+        self.runtime_safety = None
+        self.parsed_receipts = {}
 
-    def assert_gateway_binding(self, runtime_safety):
+    def assert_gateway_binding(self, ledger, runtime_safety):
         if self.environment != runtime_safety.environment:
             raise RuntimeSafetyError("reader environment mismatch")
+        if self.ledger is None:
+            self.ledger = ledger
+            self.runtime_safety = runtime_safety
+        elif (
+            self.ledger is not ledger
+            or self.runtime_safety is not runtime_safety
+        ):
+            raise RuntimeSafetyError("reader durable binding mismatch")
 
     def selected_account(self):
         if self.selected_hook is not None:
@@ -198,15 +263,165 @@ class FakeReader:
         return self.account
 
     def read_capacity(self, account):
-        return BrokerCapacitySnapshot(
-            account=self.account,
-            environment=self.environment,
-            broker_buying_power=Decimal("2000"),
-            observed_at=self.clock.now,
-            portfolio_snapshot_digest=self.capacity_digest,
-            positions_complete=self.capacity_complete,
-            open_orders_complete=self.capacity_complete,
-            source_response_digests=("1" * 64, "2" * 64),
+        if account != self.account:
+            raise RuntimeSafetyError("reader account mismatch")
+        if not self.capacity_complete:
+            receipt = self._record_response(
+                read_kind="ACCOUNT_LIST",
+                route="/v1/accounts/list.json",
+                raw=b'{"AccountListResponse":{"incomplete":true}}',
+                parsed=self._binding(),
+                final_response=True,
+            )
+            return self.ledger.record_broker_read_manifest(
+                BrokerReadManifestEvidence(
+                    evidence_kind="CAPACITY",
+                    account_id=self.account.account_id,
+                    account_id_key=self.account.account_id_key,
+                    institution_type=self.account.institution_type,
+                    environment=self.environment,
+                    origin=self._origin,
+                    target_broker_order_id=None,
+                    observed_at=self.clock.now,
+                    completeness="INCOMPLETE",
+                    canonical_result_json=_canonical_json({}),
+                ),
+                (
+                    BrokerReadManifestMember(
+                        role="binding.start",
+                        receipt_sha256=receipt.receipt_sha256,
+                    ),
+                ),
+            )
+
+        binding = self._binding()
+        encoded_account = quote(self.account.account_id_key, safe="")
+        as_of = str(int(self.clock.now.timestamp() * 1_000))
+        sources = [
+            (
+                "binding.start",
+                "ACCOUNT_LIST",
+                "/v1/accounts/list.json",
+                (),
+                b'{"AccountListResponse":{"binding":"start"}}',
+                binding,
+            )
+        ]
+        for scan in ("a", "b"):
+            sources.extend(
+                (
+                    (
+                        f"scan_{scan}.balance",
+                        "BALANCE",
+                        f"/v1/accounts/{encoded_account}/balance.json",
+                        (
+                            ("instType", self.account.institution_type),
+                            ("realTimeNAV", "true"),
+                        ),
+                        (
+                            '{"BalanceResponse":{"Computed":'
+                            '{"marginBuyingPower":2000}}}'
+                        ).encode("ascii"),
+                        {
+                            "account_id": self.account.account_id,
+                            "institution_type": self.account.institution_type,
+                            "margin_buying_power": "2000",
+                            "as_of_date": as_of,
+                        },
+                    ),
+                    (
+                        f"scan_{scan}.portfolio.0001",
+                        "PORTFOLIO_PAGE",
+                        f"/v1/accounts/{encoded_account}/portfolio.json",
+                        (
+                            ("count", "50"),
+                            ("lotsRequired", "false"),
+                            ("marketSession", "REGULAR"),
+                            ("pageNumber", "1"),
+                            ("sortBy", "SYMBOL"),
+                            ("sortOrder", "ASC"),
+                            ("totalsRequired", "false"),
+                            ("view", "COMPLETE"),
+                        ),
+                        b'{"PortfolioResponse":{"page":1}}',
+                        {
+                            "page_number": 1,
+                            "total_pages": 1,
+                            "metadata_field": "totalNoOfPages",
+                            "next_page": None,
+                            "positions": [],
+                        },
+                    ),
+                )
+            )
+            for lane in ("OPEN", "CANCEL_REQUESTED", "INDIVIDUAL_FILLS"):
+                sources.append(
+                    (
+                        f"scan_{scan}.orders.{lane}.0000",
+                        "OPEN_ORDERS_PAGE",
+                        f"/v1/accounts/{encoded_account}/orders.json",
+                        (("count", "100"), ("status", lane)),
+                        b'{"OrdersResponse":{"Order":[]}}',
+                        {
+                            "status_lane": lane,
+                            "orders": [],
+                            "marker": None,
+                        },
+                    )
+                )
+        sources.append(
+            (
+                "binding.end",
+                "ACCOUNT_LIST",
+                "/v1/accounts/list.json",
+                (),
+                b'{"AccountListResponse":{"binding":"end"}}',
+                binding,
+            )
+        )
+        members = []
+        for role, kind, route, query, raw, parsed in sources:
+            receipt = self._record_response(
+                read_kind=kind,
+                route=route,
+                query=query,
+                raw=raw,
+                parsed=parsed,
+                final_response=role == "binding.end",
+            )
+            members.append(
+                BrokerReadManifestMember(
+                    role=role, receipt_sha256=receipt.receipt_sha256
+                )
+            )
+        economic_state = {
+            "schema": "etrade-capacity.v1",
+            "account_status": "ACTIVE",
+            "account_mode": "MARGIN",
+            "account_type": "INDIVIDUAL",
+            "broker_buying_power": "2000",
+            "positions": [],
+            "open_orders": [],
+        }
+        result = dict(economic_state)
+        result["broker_buying_power_as_of"] = as_of
+        result["state_sha256"] = _domain_json_sha256(
+            b"etrade-capacity-state.v1\0", economic_state
+        )
+        return self.ledger.record_broker_read_manifest(
+            BrokerReadManifestEvidence(
+                evidence_kind="CAPACITY",
+                account_id=self.account.account_id,
+                account_id_key=self.account.account_id_key,
+                institution_type=self.account.institution_type,
+                environment=self.environment,
+                origin=self._origin,
+                target_broker_order_id=None,
+                observed_at=self.clock.now,
+                completeness="COMPLETE",
+                canonical_result_json=_canonical_json(result),
+            ),
+            tuple(members),
         )
 
     def query_order(self, account, broker_order_id):
@@ -217,16 +432,307 @@ class FakeReader:
         if callable(behavior):
             return behavior()
         if behavior is None:
-            return BrokerOrderNotFound(
-                account=self.account,
-                environment=self.environment,
+            return self._order_manifest(
                 broker_order_id=broker_order_id,
-                observed_at=self.clock.now,
-                http_status=404,
-                raw_response_digest="3" * 64,
-                complete=True,
+                outcome="UNRESOLVED",
+                payload_hashes=(),
+                not_found=True,
             )
-        return behavior
+        if type(behavior) is BrokerOrderNotFound:
+            return self._order_manifest(
+                broker_order_id=behavior.broker_order_id,
+                outcome="UNRESOLVED",
+                payload_hashes=(),
+                not_found=True,
+            )
+        if type(behavior) is not BrokerOrderSnapshot:
+            return behavior
+        return self._order_manifest(
+            broker_order_id=behavior.broker_order_id,
+            outcome=behavior.outcome,
+            payload_hashes=(behavior.order_payload_hash,),
+            not_found=False,
+        )
+
+    @property
+    def _origin(self):
+        return (
+            "https://api.etrade.com"
+            if self.environment == "production"
+            else "https://apisb.etrade.com"
+        )
+
+    def _binding(self):
+        return {
+            "account_id": self.account.account_id,
+            "account_id_key": self.account.account_id_key,
+            "institution_type": self.account.institution_type,
+            "account_status": "ACTIVE",
+            "account_mode": "MARGIN",
+            "account_type": "INDIVIDUAL",
+        }
+
+    def _record_response(
+        self,
+        *,
+        read_kind,
+        route,
+        raw,
+        parsed,
+        query=(),
+        target_broker_order_id=None,
+        http_status=200,
+        final_response=False,
+    ):
+        self.authorization_counter += 1
+        completed_at = (
+            self.clock.now
+            if final_response
+            else self.clock.now
+            - timedelta(milliseconds=50)
+            + timedelta(milliseconds=self.authorization_counter)
+        )
+        if read_kind == "ACCOUNT_LIST":
+            raw = _canonical_json(
+                {
+                    "AccountListResponse": {
+                        "Accounts": {
+                            "Account": [
+                                {
+                                    "accountId": self.account.account_id,
+                                    "accountIdKey": self.account.account_id_key,
+                                    "institutionType": self.account.institution_type,
+                                    "accountStatus": "ACTIVE",
+                                    "accountMode": "MARGIN",
+                                    "accountType": "INDIVIDUAL",
+                                }
+                            ]
+                        }
+                    }
+                }
+            ).encode("ascii")
+        elif read_kind == "BALANCE":
+            raw = _canonical_json(
+                {
+                    "BalanceResponse": {
+                        "accountId": self.account.account_id,
+                        "institutionType": self.account.institution_type,
+                        "asOfDate": parsed["as_of_date"],
+                        "Computed": {
+                            "marginBuyingPower": parsed[
+                                "margin_buying_power"
+                            ]
+                        },
+                    }
+                }
+            ).encode("ascii")
+        elif read_kind == "PORTFOLIO_PAGE":
+            raw = _canonical_json(
+                {
+                    "PortfolioResponse": {
+                        "AccountPortfolio": [
+                            {
+                                "accountId": self.account.account_id,
+                                "totalNoOfPages": "1",
+                                "Position": [],
+                            }
+                        ]
+                    }
+                }
+            ).encode("ascii")
+        elif read_kind == "OPEN_ORDERS_PAGE":
+            raw = b""
+            http_status = 204
+        evidence = BrokerReadResponseEvidence(
+            read_kind=read_kind,
+            account_id=self.account.account_id,
+            account_id_key=self.account.account_id_key,
+            institution_type=self.account.institution_type,
+            environment=self.environment,
+            origin=self._origin,
+            route=route,
+            query_json=_canonical_json(
+                [list(pair) for pair in sorted(query)]
+            ),
+            authorization_sha256=hashlib.sha256(
+                (
+                    "gateway-reader-authorization:"
+                    f"{self.authorization_counter}"
+                ).encode("ascii")
+            ).hexdigest(),
+            target_broker_order_id=target_broker_order_id,
+            request_started_at=completed_at - timedelta(microseconds=500),
+            response_completed_at=completed_at,
+            http_status=http_status,
+            raw_response_bytes=raw,
+            parser_schema=_PARSER_SCHEMA,
+            parser_code_sha256=_PARSER_CODE_SHA256,
+            parser_config_sha256=_PARSER_CONFIG_SHA256,
+            canonical_parsed_json="null",
+            completeness="INELIGIBLE",
+        )
+        canonical_parsed_json, completeness = (
+            _reparse_broker_read_response(evidence)
+        )
+        evidence = replace(
+            evidence,
+            canonical_parsed_json=canonical_parsed_json,
+            completeness=completeness,
+        )
+        receipt = self.ledger.record_broker_read_response(evidence)
+        self.parsed_receipts[receipt.receipt_sha256] = (
+            canonical_parsed_json
+        )
+        return receipt
+
+    def _order_manifest(
+        self,
+        *,
+        broker_order_id,
+        outcome,
+        payload_hashes,
+        not_found,
+    ):
+        binding = self._binding()
+        encoded_account = quote(self.account.account_id_key, safe="")
+        encoded_order = quote(broker_order_id, safe="")
+        binding_start = self._record_response(
+            read_kind="ACCOUNT_LIST",
+            route="/v1/accounts/list.json",
+            raw=b'{"AccountListResponse":{"binding":"query-start"}}',
+            parsed=binding,
+        )
+        raw = (
+            b""
+            if not_found
+            else _canonical_json(
+                {
+                    "OrdersResponse": {
+                        "Order": [
+                            {
+                                "orderId": broker_order_id,
+                                "orderType": "SPREADS",
+                                "OrderDetail": [
+                                    {
+                                        "accountId": self.account.account_id,
+                                        "orderNumber": broker_order_id,
+                                        "status": (
+                                            "EXECUTED"
+                                            if outcome == "FILLED"
+                                            else outcome
+                                        ),
+                                        "priceType": "NET_CREDIT",
+                                        "limitPrice": (
+                                            "1.50"
+                                            if order_payload_hash(1.50)
+                                            in payload_hashes
+                                            else "1.25"
+                                        ),
+                                        "orderTerm": "GOOD_FOR_DAY",
+                                        "marketSession": "REGULAR",
+                                        "allOrNone": False,
+                                        "stopPrice": "0",
+                                        "Instrument": [
+                                            self._known_leg(
+                                                "SELL_OPEN",
+                                                "620",
+                                                filled=outcome == "FILLED",
+                                            ),
+                                            self._known_leg(
+                                                "BUY_OPEN",
+                                                "615",
+                                                filled=outcome == "FILLED",
+                                            ),
+                                        ],
+                                    }
+                                ],
+                            }
+                        ]
+                    }
+                }
+            ).encode("ascii")
+        )
+        detail = self._record_response(
+            read_kind="ORDER_DETAIL",
+            route=(
+                f"/v1/accounts/{encoded_account}/orders/"
+                f"{encoded_order}.json"
+            ),
+            raw=raw,
+            parsed={},
+            target_broker_order_id=broker_order_id,
+            http_status=404 if not_found else 200,
+        )
+        parsed = json.loads(
+            self._receipt_parsed_json(detail.receipt_sha256)
+        )
+        binding_end = self._record_response(
+            read_kind="ACCOUNT_LIST",
+            route="/v1/accounts/list.json",
+            raw=b'{"AccountListResponse":{"binding":"query-end"}}',
+            parsed=binding,
+            final_response=True,
+        )
+        result = {
+            "schema": "etrade-order-query.v1",
+            "broker_order_id": broker_order_id,
+            "raw_status": parsed["raw_status"],
+            "outcome": parsed["outcome"],
+            "order_payload_hashes": parsed["order_payload_hashes"],
+            "http_status": 404 if not_found else 200,
+            "raw_response_digest": hashlib.sha256(raw).hexdigest(),
+            "not_found": parsed["not_found"],
+            "replacement_links": parsed["replacement_links"],
+        }
+        return self.ledger.record_broker_read_manifest(
+            BrokerReadManifestEvidence(
+                evidence_kind="ORDER_QUERY",
+                account_id=self.account.account_id,
+                account_id_key=self.account.account_id_key,
+                institution_type=self.account.institution_type,
+                environment=self.environment,
+                origin=self._origin,
+                target_broker_order_id=broker_order_id,
+                observed_at=self.clock.now,
+                completeness="COMPLETE",
+                canonical_result_json=_canonical_json(result),
+            ),
+            (
+                BrokerReadManifestMember(
+                    role="binding.start",
+                    receipt_sha256=binding_start.receipt_sha256,
+                ),
+                BrokerReadManifestMember(
+                    role="order.detail",
+                    receipt_sha256=detail.receipt_sha256,
+                ),
+                BrokerReadManifestMember(
+                    role="binding.end",
+                    receipt_sha256=binding_end.receipt_sha256,
+                ),
+            ),
+        )
+
+    def _known_leg(self, action, strike, *, filled):
+        return {
+            "Product": {
+                "symbol": "SPY",
+                "securityType": "OPTN",
+                "callPut": "PUT",
+                "expiryYear": "2027",
+                "expiryMonth": "1",
+                "expiryDay": "15",
+                "strikePrice": strike,
+            },
+            "orderAction": action,
+            "quantityType": "QUANTITY",
+            "orderedQuantity": "1",
+            "filledQuantity": "1" if filled else "0",
+            "cancelQuantity": "0",
+        }
+
+    def _receipt_parsed_json(self, receipt_sha256):
+        return self.parsed_receipts[receipt_sha256]
 
 
 class EtradeOrderGatewayTests(unittest.TestCase):
@@ -257,6 +763,10 @@ class EtradeOrderGatewayTests(unittest.TestCase):
             side_effect=self.harness.exchange,
         )
         self.patcher.start()
+        self.reader_type_patcher = patch.object(
+            gateway_module, "ETradeBrokerReader", FakeReader
+        )
+        self.reader_type_patcher.start()
         self.reader = FakeReader(self.clock, self.account)
         self.transport = self.make_transport(
             self.ledger, self.boundary
@@ -272,6 +782,7 @@ class EtradeOrderGatewayTests(unittest.TestCase):
         self.gateway.start()
 
     def tearDown(self):
+        self.reader_type_patcher.stop()
         self.patcher.stop()
         self.temporary.cleanup()
 
@@ -349,6 +860,41 @@ class EtradeOrderGatewayTests(unittest.TestCase):
             ],
             ["SUBMIT_PREVIEW", "SUBMIT_PLACE"],
         )
+        reservation = self.ledger.get_margin_reservation(first.intent_id)
+        self.assertIsNotNone(reservation.capacity_decision_sha256)
+        self.assertEqual(len(reservation.capacity_decision_sha256), 64)
+
+    def test_fake_reader_requires_explicit_test_patch_and_dependencies_are_immutable(
+        self,
+    ):
+        with patch.object(
+            gateway_module,
+            "ETradeBrokerReader",
+            ConcreteETradeBrokerReader,
+        ):
+            with self.assertRaises(GatewayValidationError):
+                EtradeOrderGateway(
+                    runtime_safety=self.boundary,
+                    ledger=self.ledger,
+                    transport=self.transport,
+                    reader=FakeReader(self.clock, self.account),
+                    opening_risk_budget=Decimal("2000"),
+                    clock=self.clock,
+                )
+
+        for name, value in (
+            ("reader", self.reader),
+            ("transport", self.transport),
+            ("ledger", self.ledger),
+            ("runtime_safety", self.boundary),
+            ("_reader", self.reader),
+            ("_transport", self.transport),
+            ("_ledger", self.ledger),
+            ("_runtime_safety", self.boundary),
+        ):
+            with self.subTest(name=name):
+                with self.assertRaises((AttributeError, TypeError)):
+                    setattr(self.gateway, name, value)
 
     def test_no_id_timeout_is_durable_and_cannot_be_auto_reconciled(self):
         self.harness.add(preview_result(), _ExchangeResult("TIMEOUT"))
@@ -867,6 +1413,7 @@ class EtradeOrderGatewayTests(unittest.TestCase):
         self.harness.add(preview_result(), place_result())
         limited.submit_opening(self.command())
 
+        self.clock.advance(1)
         with self.assertRaises(OrderIntentReservationError):
             limited.submit_opening(
                 self.command(key="order-2", decision="decision-2")

--- a/etrade_python_client/tests/test_order_intent_ledger.py
+++ b/etrade_python_client/tests/test_order_intent_ledger.py
@@ -8,13 +8,26 @@ import tempfile
 import threading
 import unittest
 from concurrent.futures import ThreadPoolExecutor
+from dataclasses import replace
 from datetime import datetime, timedelta, timezone
 from decimal import Decimal, localcontext
 from pathlib import Path
+from typing import Any
+from urllib.parse import quote
+
+from live_trading.etrade_broker_reader import (
+    _PARSER_CODE_SHA256,
+    _PARSER_CONFIG_SHA256,
+    _PARSER_SCHEMA,
+    _reparse_broker_read_response,
+)
 
 from live_trading.order_intent_ledger import (
     SCHEMA_VERSION,
     BrokerEvidence,
+    BrokerReadManifestEvidence,
+    BrokerReadManifestMember,
+    BrokerReadResponseEvidence,
     AccountCapacityEvidence,
     OutboundAuthorization,
     TransportRequestEvidence,
@@ -170,7 +183,22 @@ def closing_payload():
     return payload
 
 
-def make_intent(*, account="acct-1", environment="production", key="key-1", decision="decision-1", kind="OPENING", strike=620):
+def canonical_json(value: Any) -> str:
+    return json.dumps(
+        value,
+        sort_keys=True,
+        separators=(",", ":"),
+        ensure_ascii=True,
+    )
+
+
+def domain_json_hash(domain: bytes, value: Any) -> str:
+    return hashlib.sha256(
+        domain + canonical_json(value).encode("utf-8")
+    ).hexdigest()
+
+
+def make_intent(*, account="1000000001", environment="production", key="key-1", decision="decision-1", kind="OPENING", strike=620):
     order_payload = raw_payload(strike)
     if kind == "CLOSING":
         order_payload["legs"][0]["orderAction"] = "SELL_CLOSE"
@@ -181,20 +209,7 @@ def make_intent(*, account="acct-1", environment="production", key="key-1", deci
     )
 
 
-def risk(record, clock, *, collateral="500", max_loss="400", quote_time=None):
-    return RiskEvidence(
-        decision_id=record.envelope.decision_id,
-        max_loss_amount=Decimal(max_loss), collateral_amount=Decimal(collateral),
-        quote_observed_at=quote_time or clock.now,
-        quote_digest="a" * 64, portfolio_observed_at=quote_time or clock.now, portfolio_snapshot_digest="b" * 64,
-    )
-
-
-def capacity(clock, *, account="acct-1", environment="production", observed_at=None, buying_power="1000", risk_budget="1000", digest="b" * 64):
-    return AccountCapacityEvidence(account_id=account, environment=environment, broker_buying_power=Decimal(buying_power), risk_budget=Decimal(risk_budget), observed_at=observed_at or clock.now, portfolio_snapshot_digest=digest)
-
-
-def evidence(record, clock, *, operation="ORDER_QUERY", outcome="OPEN", broker_order_id="broker-1", client_order_id=None, observed_at=None):
+def evidence(record, clock, *, operation="SUBMIT_ACK", outcome="OPEN", broker_order_id="2000000001", client_order_id=None, observed_at=None):
     return BrokerEvidence(
         account_id=record.envelope.account_id, environment=record.envelope.environment,
         client_order_id=client_order_id or record.client_order_id, broker_order_id=broker_order_id,
@@ -207,7 +222,7 @@ def transport_request(
     authorization,
     *,
     operation="SUBMIT_PREVIEW",
-    account_id="acct-1",
+    account_id="1000000001",
     account_id_key="account-key",
     institution_type="BROKERAGE",
     target_broker_order_id=None,
@@ -257,14 +272,650 @@ class OrderIntentLedgerTests(unittest.TestCase):
         self.path = Path(self.tmp.name) / "runtime" / "orders.sqlite3"
         self.clock = Clock()
         self.ledger = OrderIntentLedger(self.path, clock=self.clock, run_id="run-a")
+        self.read_authorization_counter = 0
+        self.capacity_manifest_cache = {}
+        self.latest_capacity_decisions = {}
 
     def tearDown(self):
         self.tmp.cleanup()
 
-    def opening(self, *, key="key-1", account="acct-1"):
+    @staticmethod
+    def account_key(account):
+        suffix = hashlib.sha256(account.encode("ascii")).hexdigest()[:16]
+        return f"account-key-{suffix}"
+
+    def record_read(
+        self,
+        ledger,
+        *,
+        account,
+        environment,
+        observed_at,
+        read_kind,
+        route,
+        parsed=None,
+        raw,
+        query=(),
+        target_broker_order_id=None,
+        final_response=False,
+        return_parsed=False,
+    ):
+        self.read_authorization_counter += 1
+        authorization_sha256 = hashlib.sha256(
+            (
+                "order-ledger-test-authorization:"
+                f"{self.read_authorization_counter}"
+            ).encode("ascii")
+        ).hexdigest()
+        response_completed_at = (
+            observed_at
+            if final_response
+            else observed_at
+            - timedelta(seconds=30)
+            + timedelta(milliseconds=self.read_authorization_counter)
+        )
+        origin = (
+            "https://api.etrade.com"
+            if environment == "production"
+            else "https://apisb.etrade.com"
+        )
+        fixture = BrokerReadResponseEvidence(
+                read_kind=read_kind,
+                account_id=account,
+                account_id_key=self.account_key(account),
+                institution_type="BROKERAGE",
+                environment=environment,
+                origin=origin,
+                route=route,
+                query_json=canonical_json(
+                    [list(pair) for pair in sorted(query)]
+                ),
+                authorization_sha256=authorization_sha256,
+                target_broker_order_id=target_broker_order_id,
+                request_started_at=response_completed_at
+                - timedelta(microseconds=500),
+                response_completed_at=response_completed_at,
+                http_status=200,
+                raw_response_bytes=raw,
+                parser_schema=_PARSER_SCHEMA,
+                parser_code_sha256=_PARSER_CODE_SHA256,
+                parser_config_sha256=_PARSER_CONFIG_SHA256,
+                canonical_parsed_json=canonical_json(None),
+                completeness="INELIGIBLE",
+            )
+        canonical_parsed_json, completeness = (
+            _reparse_broker_read_response(fixture)
+        )
+        self.assertEqual(completeness, "COMPLETE")
+        if parsed is not None:
+            self.assertEqual(
+                canonical_parsed_json,
+                canonical_json(parsed),
+            )
+        receipt = ledger.record_broker_read_response(
+            replace(
+                fixture,
+                canonical_parsed_json=canonical_parsed_json,
+                completeness=completeness,
+            )
+        )
+        if return_parsed:
+            return receipt, json.loads(canonical_parsed_json)
+        return receipt
+
+    def set_capacity(
+        self,
+        *,
+        ledger=None,
+        account="1000000001",
+        environment="production",
+        observed_at=None,
+        buying_power="1000",
+        risk_budget="1000",
+        state_marker="default",
+    ):
+        ledger = ledger or self.ledger
+        observed_at = observed_at or self.clock.now
+        cache_key = (
+            str(ledger.path),
+            account,
+            environment,
+            observed_at,
+            str(buying_power),
+            str(risk_budget),
+            state_marker,
+        )
+        cached = self.capacity_manifest_cache.get(cache_key)
+        if cached is None:
+            account_key = self.account_key(account)
+            origin = (
+                "https://api.etrade.com"
+                if environment == "production"
+                else "https://apisb.etrade.com"
+            )
+            binding = {
+                "account_id": account,
+                "account_id_key": account_key,
+                "institution_type": "BROKERAGE",
+                "account_status": "ACTIVE",
+                "account_mode": "MARGIN",
+                "account_type": "INDIVIDUAL",
+            }
+            balance_as_of = str(
+                int(
+                    (
+                        observed_at - timedelta(seconds=30)
+                    ).timestamp()
+                    * 1_000
+                )
+            )
+            if state_marker == "default":
+                positions = []
+            else:
+                position_id = str(
+                    int(
+                        hashlib.sha256(
+                            state_marker.encode("ascii")
+                        ).hexdigest()[:15],
+                        16,
+                    )
+                    + 1
+                )
+                positions = [
+                    {
+                        "position_id": position_id,
+                        "account_id": account,
+                        "product": {
+                            "symbol": "SPY",
+                            "security_type": "EQ",
+                            "call_put": None,
+                            "expiry_year": None,
+                            "expiry_month": None,
+                            "expiry_day": None,
+                            "strike_price": None,
+                            "product_id": None,
+                        },
+                        "quantity": "1",
+                        "position_type": "LONG",
+                        "position_indicator": None,
+                        "osi_key": None,
+                    }
+                ]
+            sources = [
+                (
+                    "binding.start",
+                    "ACCOUNT_LIST",
+                    "/v1/accounts/list.json",
+                    (),
+                    binding,
+                )
+            ]
+            for scan in ("a", "b"):
+                sources.extend(
+                    (
+                        (
+                            f"scan_{scan}.balance",
+                            "BALANCE",
+                            f"/v1/accounts/{quote(account_key, safe='')}/balance.json",
+                            (
+                                ("instType", "BROKERAGE"),
+                                ("realTimeNAV", "true"),
+                            ),
+                            {
+                                "account_id": account,
+                                "institution_type": "BROKERAGE",
+                                "margin_buying_power": str(buying_power),
+                                "as_of_date": balance_as_of,
+                            },
+                        ),
+                        (
+                            f"scan_{scan}.portfolio.0001",
+                            "PORTFOLIO_PAGE",
+                            f"/v1/accounts/{quote(account_key, safe='')}/portfolio.json",
+                            (
+                                ("count", "50"),
+                                ("lotsRequired", "false"),
+                                ("marketSession", "REGULAR"),
+                                ("pageNumber", "1"),
+                                ("sortBy", "SYMBOL"),
+                                ("sortOrder", "ASC"),
+                                ("totalsRequired", "false"),
+                                ("view", "COMPLETE"),
+                            ),
+                            {
+                                "page_number": 1,
+                                "total_pages": 1,
+                                "metadata_field": "totalNoOfPages",
+                                "next_page": None,
+                                "positions": positions,
+                            },
+                        ),
+                    )
+                )
+                for lane in (
+                    "OPEN",
+                    "CANCEL_REQUESTED",
+                    "INDIVIDUAL_FILLS",
+                ):
+                    sources.append(
+                        (
+                            f"scan_{scan}.orders.{lane}.0000",
+                            "OPEN_ORDERS_PAGE",
+                            f"/v1/accounts/{quote(account_key, safe='')}/orders.json",
+                            (("count", "100"), ("status", lane)),
+                            {
+                                "status_lane": lane,
+                                "orders": [],
+                                "marker": None,
+                            },
+                        )
+                    )
+            sources.append(
+                (
+                    "binding.end",
+                    "ACCOUNT_LIST",
+                    "/v1/accounts/list.json",
+                    (),
+                    binding,
+                )
+            )
+            members = []
+            for role, read_kind, route, query, parsed in sources:
+                if read_kind == "ACCOUNT_LIST":
+                    raw_document = {
+                        "AccountListResponse": {
+                            "Accounts": {
+                                "Account": [
+                                    {
+                                        "accountId": account,
+                                        "accountIdKey": account_key,
+                                        "institutionType": "BROKERAGE",
+                                        "accountStatus": "ACTIVE",
+                                        "accountMode": "MARGIN",
+                                        "accountType": "INDIVIDUAL",
+                                    }
+                                ]
+                            }
+                        }
+                    }
+                elif read_kind == "BALANCE":
+                    raw_document = {
+                        "BalanceResponse": {
+                            "accountId": account,
+                            "institutionType": "BROKERAGE",
+                            "asOfDate": balance_as_of,
+                            "Computed": {
+                                "marginBuyingPower": str(buying_power)
+                            },
+                        }
+                    }
+                elif read_kind == "PORTFOLIO_PAGE":
+                    raw_document = {
+                        "PortfolioResponse": {
+                            "AccountPortfolio": [
+                                {
+                                    "accountId": account,
+                                    "totalNoOfPages": 1,
+                                    "Position": [
+                                        {
+                                            "positionId": position[
+                                                "position_id"
+                                            ],
+                                            "accountId": account,
+                                            "Product": {
+                                                "symbol": "SPY",
+                                                "securityType": "EQ",
+                                            },
+                                            "quantity": "1",
+                                            "positionType": "LONG",
+                                        }
+                                        for position in positions
+                                    ],
+                                }
+                            ]
+                        }
+                    }
+                else:
+                    self.assertEqual(read_kind, "OPEN_ORDERS_PAGE")
+                    raw_document = {"OrdersResponse": {"Order": []}}
+                raw = canonical_json(raw_document).encode("ascii")
+                receipt = self.record_read(
+                    ledger,
+                    account=account,
+                    environment=environment,
+                    observed_at=observed_at,
+                    read_kind=read_kind,
+                    route=route,
+                    query=query,
+                    parsed=parsed,
+                    raw=raw,
+                    final_response=role == "binding.end",
+                )
+                members.append(
+                    BrokerReadManifestMember(
+                        role=role,
+                        receipt_sha256=receipt.receipt_sha256,
+                    )
+                )
+            economic_state = {
+                "schema": "etrade-capacity.v1",
+                "account_status": "ACTIVE",
+                "account_mode": "MARGIN",
+                "account_type": "INDIVIDUAL",
+                "broker_buying_power": str(buying_power),
+                "positions": positions,
+                "open_orders": [],
+            }
+            result = dict(economic_state)
+            result["broker_buying_power_as_of"] = balance_as_of
+            result["state_sha256"] = domain_json_hash(
+                b"etrade-capacity-state.v1\0", economic_state
+            )
+            reference = ledger.record_broker_read_manifest(
+                BrokerReadManifestEvidence(
+                    evidence_kind="CAPACITY",
+                    account_id=account,
+                    account_id_key=account_key,
+                    institution_type="BROKERAGE",
+                    environment=environment,
+                    origin=origin,
+                    target_broker_order_id=None,
+                    observed_at=observed_at,
+                    completeness="COMPLETE",
+                    canonical_result_json=canonical_json(result),
+                ),
+                tuple(members),
+            )
+            self.capacity_manifest_cache[cache_key] = reference
+        else:
+            reference = cached
+        decision = ledger.set_reservation_cap_from_read(
+            reference, risk_budget=Decimal(str(risk_budget))
+        )
+        self.latest_capacity_decisions[
+            (str(ledger.path), account, environment)
+        ] = decision
+        return decision
+
+    def capacity_decision_for(
+        self, record, *, ledger=None
+    ):
+        ledger = ledger or self.ledger
+        key = (
+            str(ledger.path),
+            record.envelope.account_id,
+            record.envelope.environment,
+        )
+        return self.latest_capacity_decisions[key]
+
+    def risk(
+        self,
+        record,
+        *,
+        ledger=None,
+        collateral="500",
+        max_loss="400",
+        quote_time=None,
+        decision=None,
+        portfolio_observed_at=None,
+        portfolio_snapshot_digest=None,
+        capacity_decision_sha256=None,
+    ):
+        decision = decision or self.capacity_decision_for(
+            record, ledger=ledger
+        )
+        return RiskEvidence(
+            decision_id=record.envelope.decision_id,
+            max_loss_amount=Decimal(max_loss),
+            collateral_amount=Decimal(collateral),
+            quote_observed_at=quote_time or self.clock.now,
+            quote_digest="a" * 64,
+            portfolio_observed_at=(
+                portfolio_observed_at or decision.observed_at
+            ),
+            portfolio_snapshot_digest=(
+                portfolio_snapshot_digest
+                or decision.portfolio_snapshot_digest
+            ),
+            capacity_decision_sha256=(
+                capacity_decision_sha256 or decision.decision_sha256
+            ),
+        )
+
+    def capacity_evidence(self, decision):
+        return AccountCapacityEvidence(
+            account_id=self._capacity_account(decision),
+            environment=self._capacity_environment(decision),
+            broker_buying_power=decision.broker_buying_power,
+            risk_budget=decision.risk_budget,
+            observed_at=decision.observed_at,
+            portfolio_snapshot_digest=decision.portfolio_snapshot_digest,
+            broker_read_evidence_sha256=decision.evidence_sha256,
+        )
+
+    def _capacity_account(self, decision):
+        with sqlite3.connect(self.path) as conn:
+            return conn.execute(
+                """
+                SELECT account_id FROM capacity_decisions
+                WHERE capacity_decision_sha256 = ?
+                """,
+                (decision.decision_sha256,),
+            ).fetchone()[0]
+
+    def _capacity_environment(self, decision):
+        with sqlite3.connect(self.path) as conn:
+            return conn.execute(
+                """
+                SELECT environment FROM capacity_decisions
+                WHERE capacity_decision_sha256 = ?
+                """,
+                (decision.decision_sha256,),
+            ).fetchone()[0]
+
+    def query_evidence(
+        self,
+        record,
+        *,
+        ledger=None,
+        operation="ORDER_QUERY",
+        outcome="OPEN",
+        broker_order_id="2000000001",
+        observed_at=None,
+    ):
+        ledger = ledger or self.ledger
+        observed_at = observed_at or self.clock.now
+        account = record.envelope.account_id
+        environment = record.envelope.environment
+        account_key = self.account_key(account)
+        origin = (
+            "https://api.etrade.com"
+            if environment == "production"
+            else "https://apisb.etrade.com"
+        )
+        binding = {
+            "account_id": account,
+            "account_id_key": account_key,
+            "institution_type": "BROKERAGE",
+            "account_status": "ACTIVE",
+            "account_mode": "MARGIN",
+            "account_type": "INDIVIDUAL",
+        }
+        payload_hashes = [
+            ledger.expected_order_payload_hash(record.intent_id)
+        ]
+        binding_raw = canonical_json(
+            {
+                "AccountListResponse": {
+                    "Accounts": {
+                        "Account": [
+                            {
+                                "accountId": account,
+                                "accountIdKey": account_key,
+                                "institutionType": "BROKERAGE",
+                                "accountStatus": "ACTIVE",
+                                "accountMode": "MARGIN",
+                                "accountType": "INDIVIDUAL",
+                            }
+                        ]
+                    }
+                }
+            }
+        ).encode("ascii")
+        wire_payload = json.loads(record.envelope.wire_payload)
+        raw_status = "EXECUTED" if outcome == "FILLED" else outcome
+        raw = canonical_json(
+            {
+                "OrdersResponse": {
+                    "Order": [
+                        {
+                            "orderId": broker_order_id,
+                            "orderType": "SPREADS",
+                            "OrderDetail": [
+                                {
+                                    "accountId": account,
+                                    "orderNumber": broker_order_id,
+                                    "status": raw_status,
+                                    "priceType": wire_payload[
+                                        "priceType"
+                                    ],
+                                    "limitPrice": wire_payload[
+                                        "limitPrice"
+                                    ],
+                                    "orderTerm": "GOOD_FOR_DAY",
+                                    "marketSession": "REGULAR",
+                                    "allOrNone": False,
+                                    "stopPrice": 0,
+                                    "Instrument": [
+                                        {
+                                            "Product": {
+                                                "symbol": leg["symbol"],
+                                                "securityType": "OPTN",
+                                                "callPut": leg["callPut"],
+                                                "expiryYear": leg[
+                                                    "expiryYear"
+                                                ],
+                                                "expiryMonth": leg[
+                                                    "expiryMonth"
+                                                ],
+                                                "expiryDay": leg[
+                                                    "expiryDay"
+                                                ],
+                                                "strikePrice": leg[
+                                                    "strikePrice"
+                                                ],
+                                            },
+                                            "quantityType": "QUANTITY",
+                                            "orderedQuantity": leg[
+                                                "quantity"
+                                            ],
+                                            "filledQuantity": (
+                                                leg["quantity"]
+                                                if outcome == "FILLED"
+                                                else 0
+                                            ),
+                                            "orderAction": leg[
+                                                "orderAction"
+                                            ],
+                                        }
+                                        for leg in wire_payload["legs"]
+                                    ],
+                                }
+                            ],
+                        }
+                    ]
+                }
+            }
+        ).encode("ascii")
+        start = self.record_read(
+            ledger,
+            account=account,
+            environment=environment,
+            observed_at=observed_at,
+            read_kind="ACCOUNT_LIST",
+            route="/v1/accounts/list.json",
+            parsed=binding,
+            raw=binding_raw,
+        )
+        detail, detail_parsed = self.record_read(
+            ledger,
+            account=account,
+            environment=environment,
+            observed_at=observed_at,
+            read_kind="ORDER_DETAIL",
+            route=(
+                f"/v1/accounts/{quote(account_key, safe='')}/orders/"
+                f"{quote(broker_order_id, safe='')}.json"
+            ),
+            raw=raw,
+            target_broker_order_id=broker_order_id,
+            return_parsed=True,
+        )
+        self.assertIn(
+            payload_hashes[0],
+            detail_parsed["order_payload_hashes"],
+        )
+        end = self.record_read(
+            ledger,
+            account=account,
+            environment=environment,
+            observed_at=observed_at,
+            read_kind="ACCOUNT_LIST",
+            route="/v1/accounts/list.json",
+            parsed=binding,
+            raw=binding_raw,
+            final_response=True,
+        )
+        result = {
+            "schema": "etrade-order-query.v1",
+            "broker_order_id": broker_order_id,
+            "raw_status": detail_parsed["raw_status"],
+            "outcome": detail_parsed["outcome"],
+            "order_payload_hashes": detail_parsed[
+                "order_payload_hashes"
+            ],
+            "http_status": 200,
+            "raw_response_digest": hashlib.sha256(raw).hexdigest(),
+            "not_found": detail_parsed["not_found"],
+            "replacement_links": detail_parsed[
+                "replacement_links"
+            ],
+        }
+        reference = ledger.record_broker_read_manifest(
+            BrokerReadManifestEvidence(
+                evidence_kind="ORDER_QUERY",
+                account_id=account,
+                account_id_key=account_key,
+                institution_type="BROKERAGE",
+                environment=environment,
+                origin=origin,
+                target_broker_order_id=broker_order_id,
+                observed_at=observed_at,
+                completeness="COMPLETE",
+                canonical_result_json=canonical_json(result),
+            ),
+            (
+                BrokerReadManifestMember(
+                    "binding.start", start.receipt_sha256
+                ),
+                BrokerReadManifestMember(
+                    "order.detail", detail.receipt_sha256
+                ),
+                BrokerReadManifestMember(
+                    "binding.end", end.receipt_sha256
+                ),
+            ),
+        )
+        derived = ledger.broker_evidence_from_read(
+            record.intent_id, reference, operation=operation
+        )
+        self.assertIsNotNone(derived)
+        return derived
+
+    def opening(self, *, key="key-1", account="1000000001"):
         record = self.ledger.create_intent(make_intent(key=key, account=account)).intent
-        self.ledger.set_reservation_cap(capacity(self.clock, account=account))
-        self.ledger.reserve_margin(record.intent_id, risk(record, self.clock))
+        self.set_capacity(account=account)
+        self.ledger.reserve_margin(record.intent_id, self.risk(record))
         return record
 
     def begin_submission(self, record, owner, lease):
@@ -429,13 +1080,13 @@ class OrderIntentLedgerTests(unittest.TestCase):
         debit["legs"][0]["orderAction"] = "BUY_OPEN"
         debit["legs"][1]["orderAction"] = "SELL_OPEN"
         record = self.ledger.create_intent(OrderIntent.build(
-            account_id="acct-1", environment="production", strategy_id="credit-spread", decision_id="debit",
+            account_id="1000000001", environment="production", strategy_id="credit-spread", decision_id="debit",
             idempotency_scope="decision", idempotency_key="debit", intent_kind="OPENING", order_payload=debit,
         )).intent
-        self.ledger.set_reservation_cap(capacity(self.clock))
+        self.set_capacity()
         with self.assertRaises(OrderIntentReservationError):
-            self.ledger.reserve_margin(record.intent_id, risk(record, self.clock, collateral="124.99", max_loss="124.99"))
-        reserved = self.ledger.reserve_margin(record.intent_id, risk(record, self.clock, collateral="125", max_loss="125"))
+            self.ledger.reserve_margin(record.intent_id, self.risk(record, collateral="124.99", max_loss="124.99"))
+        reserved = self.ledger.reserve_margin(record.intent_id, self.risk(record, collateral="125", max_loss="125"))
         self.assertEqual(reserved.amount, Decimal("125"))
 
     def test_opening_vertical_price_type_must_match_put_and_call_risk_orientation(self):
@@ -469,28 +1120,29 @@ class OrderIntentLedgerTests(unittest.TestCase):
 
     def test_risk_evidence_is_required_positive_fresh_and_bound_to_decision(self):
         record = self.ledger.create_intent(make_intent()).intent
-        self.ledger.set_reservation_cap(capacity(self.clock))
+        self.set_capacity()
         with self.assertRaises(OrderIntentValidationError):
-            self.ledger.reserve_margin(record.intent_id, risk(record, self.clock, collateral="0", max_loss="0"))
+            self.ledger.reserve_margin(record.intent_id, self.risk(record, collateral="0", max_loss="0"))
         with self.assertRaises(OrderIntentReservationError):
-            self.ledger.reserve_margin(record.intent_id, risk(record, self.clock, collateral="1", max_loss="1"))
+            self.ledger.reserve_margin(record.intent_id, self.risk(record, collateral="1", max_loss="1"))
         with self.assertRaises(OrderIntentValidationError):
-            self.ledger.reserve_margin(record.intent_id, risk(record, self.clock, quote_time=self.clock.now - timedelta(minutes=6)))
-        bad = risk(record, self.clock)
+            self.ledger.reserve_margin(record.intent_id, self.risk(record, quote_time=self.clock.now - timedelta(minutes=6)))
+        bad = self.risk(record)
         object.__setattr__(bad, "decision_id", "other-decision")
         with self.assertRaises(OrderIntentIntegrityError):
             self.ledger.reserve_margin(record.intent_id, bad)
-        reservation = self.ledger.reserve_margin(record.intent_id, risk(record, self.clock))
+        reservation = self.ledger.reserve_margin(record.intent_id, self.risk(record))
         self.assertEqual(reservation.max_loss_amount, Decimal("400"))
         self.assertEqual(reservation.quote_digest, "a" * 64)
-        changed = risk(record, self.clock)
+        changed = self.risk(record)
         object.__setattr__(changed, "quote_digest", "e" * 64)
         with self.assertRaises(OrderIntentTransitionError):
             self.ledger.reserve_margin(record.intent_id, changed)
 
     def test_evidence_rejects_numeric_identity_datetime_and_validate_subclasses(self):
         record = self.ledger.create_intent(make_intent()).intent
-        normal_capacity = capacity(self.clock)
+        capacity_decision = self.set_capacity()
+        normal_capacity = self.capacity_evidence(capacity_decision)
         with self.assertRaises(OrderIntentValidationError):
             self.ledger.set_reservation_cap(
                 BypassCapacityEvidence(**normal_capacity.__dict__)
@@ -498,17 +1150,18 @@ class OrderIntentLedgerTests(unittest.TestCase):
         with self.assertRaises(OrderIntentValidationError):
             self.ledger.set_reservation_cap(
                 AccountCapacityEvidence(
-                    account_id="acct-1",
+                    account_id="1000000001",
                     environment="production",
                     broker_buying_power=AlwaysSmallDecimal("1"),
                     risk_budget=AlwaysSmallDecimal("1"),
                     observed_at=self.clock.now,
-                    portfolio_snapshot_digest="b" * 64,
+                    portfolio_snapshot_digest=capacity_decision.portfolio_snapshot_digest,
+                    broker_read_evidence_sha256=capacity_decision.evidence_sha256,
                 )
             )
         self.ledger.set_reservation_cap(normal_capacity)
 
-        normal_risk = risk(record, self.clock)
+        normal_risk = self.risk(record)
         with self.assertRaises(OrderIntentValidationError):
             self.ledger.reserve_margin(
                 record.intent_id, BypassRiskEvidence(**normal_risk.__dict__)
@@ -522,8 +1175,9 @@ class OrderIntentLedgerTests(unittest.TestCase):
                     collateral_amount=AlwaysSmallDecimal("1"),
                     quote_observed_at=self.clock.now,
                     quote_digest="a" * 64,
-                    portfolio_observed_at=self.clock.now,
-                    portfolio_snapshot_digest="b" * 64,
+                    portfolio_observed_at=capacity_decision.observed_at,
+                    portfolio_snapshot_digest=capacity_decision.portfolio_snapshot_digest,
+                    capacity_decision_sha256=capacity_decision.decision_sha256,
                 ),
             )
         with localcontext() as decimal_context:
@@ -531,7 +1185,7 @@ class OrderIntentLedgerTests(unittest.TestCase):
             with self.assertRaises(OrderIntentReservationError):
                 self.ledger.reserve_margin(
                     record.intent_id,
-                    risk(record, self.clock, collateral="1", max_loss="1"),
+                    self.risk(record, collateral="1", max_loss="1"),
                 )
 
         self.ledger.reserve_margin(record.intent_id, normal_risk)
@@ -580,14 +1234,14 @@ class OrderIntentLedgerTests(unittest.TestCase):
             self.ledger.claim_submission(record.intent_id, "worker", lease_seconds=30)
 
     def test_atomic_concurrent_reservation_cap_and_same_account_claim_blocker(self):
-        self.ledger.set_reservation_cap(capacity(self.clock))
+        self.set_capacity()
         left = self.ledger.create_intent(make_intent(key="left")).intent
         right = self.ledger.create_intent(make_intent(key="right")).intent
         barrier = threading.Barrier(2)
         def reserve(record):
             barrier.wait()
             try:
-                self.ledger.reserve_margin(record.intent_id, risk(record, self.clock, collateral="600", max_loss="400"))
+                self.ledger.reserve_margin(record.intent_id, self.risk(record, collateral="600", max_loss="400"))
                 return True
             except OrderIntentReservationError:
                 return False
@@ -598,7 +1252,7 @@ class OrderIntentLedgerTests(unittest.TestCase):
         other = right if winner is left else left
         self.ledger.reserve_margin(
             other.intent_id,
-            risk(other, self.clock, collateral="400", max_loss="400"),
+            self.risk(other, collateral="400", max_loss="400"),
         )
         lease = self.ledger.claim_submission(winner.intent_id, "worker-a", lease_seconds=30)
         self.begin_submission(winner, "worker-a", lease)
@@ -607,39 +1261,47 @@ class OrderIntentLedgerTests(unittest.TestCase):
 
     def test_capacity_snapshots_are_ordered_can_reach_zero_and_block_new_claims(self):
         record = self.ledger.create_intent(make_intent()).intent
-        self.ledger.set_reservation_cap(capacity(self.clock))
-        self.ledger.reserve_margin(record.intent_id, risk(record, self.clock))
+        self.set_capacity()
+        self.ledger.reserve_margin(record.intent_id, self.risk(record))
         with self.assertRaises(OrderIntentIntegrityError):
-            self.ledger.set_reservation_cap(capacity(self.clock, buying_power="0", risk_budget="0"))
+            self.set_capacity(buying_power="0", risk_budget="0")
         self.clock.advance(1)
-        self.assertEqual(self.ledger.set_reservation_cap(capacity(self.clock, buying_power="0", risk_budget="0")), Decimal("0"))
+        self.assertEqual(
+            self.set_capacity(
+                buying_power="0", risk_budget="0"
+            ).cap_amount,
+            Decimal("0"),
+        )
         with self.assertRaises(OrderIntentReservationError):
             self.ledger.claim_submission(record.intent_id, "worker", lease_seconds=30)
         blocked = self.ledger.create_intent(make_intent(key="zero-cap", decision="zero-cap")).intent
         with self.assertRaises(OrderIntentReservationError):
-            self.ledger.reserve_margin(blocked.intent_id, risk(blocked, self.clock))
+            self.ledger.reserve_margin(blocked.intent_id, self.risk(blocked))
 
     def test_identical_equal_time_capacity_is_idempotent_but_conflict_fails(self):
-        snapshot = capacity(self.clock)
-
         self.assertEqual(
-            self.ledger.set_reservation_cap(snapshot),
+            self.set_capacity().cap_amount,
             Decimal("1000"),
         )
         self.assertEqual(
-            self.ledger.set_reservation_cap(snapshot),
+            self.set_capacity().cap_amount,
             Decimal("1000"),
         )
         with self.assertRaises(OrderIntentIntegrityError):
-            self.ledger.set_reservation_cap(
-                capacity(self.clock, digest="d" * 64)
-            )
+            self.set_capacity(state_marker="different")
 
     def test_reservation_requires_the_capacity_snapshot_used_for_its_portfolio_risk(self):
         record = self.ledger.create_intent(make_intent()).intent
-        self.ledger.set_reservation_cap(capacity(self.clock, digest="d" * 64))
+        decision = self.set_capacity(state_marker="different")
         with self.assertRaises(OrderIntentIntegrityError):
-            self.ledger.reserve_margin(record.intent_id, risk(record, self.clock))
+            self.ledger.reserve_margin(
+                record.intent_id,
+                self.risk(
+                    record,
+                    portfolio_snapshot_digest="b" * 64,
+                    capacity_decision_sha256=decision.decision_sha256,
+                ),
+            )
 
     def test_expired_claim_without_place_attempt_returns_to_intent_with_new_fence(self):
         record = self.opening()
@@ -668,7 +1330,7 @@ class OrderIntentLedgerTests(unittest.TestCase):
         self.clock.advance(6)
 
         self.assertEqual(
-            self.ledger.reconciliation_blockers("acct-1", "production"), ()
+            self.ledger.reconciliation_blockers("1000000001", "production"), ()
         )
         self.assertEqual(self.ledger.get_intent(record.intent_id).state, "INTENT")
         replacement = self.ledger.claim_submission(
@@ -803,7 +1465,7 @@ class OrderIntentLedgerTests(unittest.TestCase):
         self.clock.advance(6)
 
         self.assertEqual(
-            self.ledger.reconciliation_blockers("acct-1", "production"), ()
+            self.ledger.reconciliation_blockers("1000000001", "production"), ()
         )
         replacement = self.ledger.acquire_amendment_lease(
             submitted.intent_id,
@@ -848,7 +1510,7 @@ class OrderIntentLedgerTests(unittest.TestCase):
         self.clock.advance(6)
 
         self.assertEqual(
-            self.ledger.reconciliation_blockers("acct-1", "production"), ()
+            self.ledger.reconciliation_blockers("1000000001", "production"), ()
         )
         replacement = self.ledger.acquire_amendment_lease(
             submitted.intent_id,
@@ -1059,28 +1721,51 @@ class OrderIntentLedgerTests(unittest.TestCase):
         self.begin_submission(record, "worker", lease)
         self.ledger.record_post_unknown(record.intent_id, "worker", lease.fencing_token, "POST_TIMEOUT")
         restarted = OrderIntentLedger(self.path, clock=self.clock, run_id="run-b")
-        self.assertEqual([item.intent_id for item in restarted.reconciliation_blockers("acct-1", "production")], [record.intent_id])
-        filled = restarted.reconcile_terminal(record.intent_id, "FILLED", evidence(record, self.clock, outcome="FILLED"))
+        self.assertEqual([item.intent_id for item in restarted.reconciliation_blockers("1000000001", "production")], [record.intent_id])
+        filled_evidence = self.query_evidence(
+            record,
+            ledger=restarted,
+            outcome="FILLED",
+            broker_order_id="2000000001",
+        )
+        filled = restarted.reconcile_terminal(
+            record.intent_id, "FILLED", filled_evidence
+        )
         self.assertEqual(filled.state, "FILLED")
         self.assertEqual(restarted.get_margin_reservation(record.intent_id).state, "FILLED_PENDING_ABSORPTION")
         next_opening = restarted.create_intent(make_intent(key="next-opening", decision="next-decision")).intent
-        restarted.reserve_margin(next_opening.intent_id, risk(next_opening, self.clock))
+        restarted.reserve_margin(
+            next_opening.intent_id,
+            self.risk(next_opening, ledger=restarted),
+        )
         with self.assertRaises(OrderIntentReservationError):
             restarted.claim_submission(next_opening.intent_id, "new-worker", lease_seconds=30)
         self.clock.advance(1)
-        with self.assertRaises(OrderIntentReconciliationRequired):
-            restarted.absorb_filled_reservation(record.intent_id, capacity(self.clock))
+        refreshed_capacity = self.set_capacity(ledger=restarted)
         with self.assertRaises(OrderIntentReconciliationRequired):
             restarted.absorb_filled_reservation(
-                record.intent_id, capacity(self.clock, digest="d" * 64)
+                record.intent_id,
+                self.capacity_evidence(refreshed_capacity),
+            )
+        self.clock.advance(1)
+        changed_capacity = self.set_capacity(
+            ledger=restarted, state_marker="different"
+        )
+        with self.assertRaises(OrderIntentReconciliationRequired):
+            restarted.absorb_filled_reservation(
+                record.intent_id,
+                self.capacity_evidence(changed_capacity),
             )
         self.assertEqual(
             restarted.get_margin_reservation(record.intent_id).state,
             "FILLED_PENDING_ABSORPTION",
         )
         event = next(item for item in restarted.events(record.intent_id) if item.reason_code == "BROKER_FILLED")
-        self.assertEqual(event.raw_response_digest, "c" * 64)
-        self.assertEqual((event.account_id, event.environment, event.client_order_id), ("acct-1", "production", record.client_order_id))
+        self.assertEqual(
+            event.raw_response_digest,
+            filled_evidence.raw_response_digest,
+        )
+        self.assertEqual((event.account_id, event.environment, event.client_order_id), ("1000000001", "production", record.client_order_id))
         self.assertEqual((event.evidence_operation, event.http_status, event.broker_status), ("ORDER_QUERY", 200, "FILLED"))
 
     def test_amendment_is_persisted_before_post_fenced_and_expiry_is_reconciliation_only(self):
@@ -1094,8 +1779,16 @@ class OrderIntentLedgerTests(unittest.TestCase):
         with self.assertRaises(OrderIntentReconciliationRequired):
             self.ledger.acquire_amendment_lease(submitted.intent_id, "other", lease_seconds=5, idempotency_key="amend-1", amendment_payload=raw_payload())
         self.clock.advance(6)
-        self.assertEqual(self.ledger.reconciliation_blockers("acct-1", "production")[0].intent_id, submitted.intent_id)
-        self.ledger.reconcile_terminal(submitted.intent_id, "CANCELLED", evidence(submitted, self.clock, operation="AMEND_QUERY", outcome="CANCELLED", client_order_id=amendment.client_order_id))
+        self.assertEqual(self.ledger.reconciliation_blockers("1000000001", "production")[0].intent_id, submitted.intent_id)
+        amendment_evidence = self.query_evidence(
+            submitted,
+            operation="AMEND_QUERY",
+            outcome="CANCELLED",
+            broker_order_id=submitted.broker_order_id,
+        )
+        self.ledger.reconcile_terminal(
+            submitted.intent_id, "CANCELLED", amendment_evidence
+        )
         with sqlite3.connect(self.path) as conn:
             completion = conn.execute("SELECT completion_state FROM amendment_history WHERE intent_id = ? AND idempotency_key = ?", (submitted.intent_id, "amend-1")).fetchone()
         self.assertEqual(completion, ("TERMINAL",))
@@ -1123,7 +1816,7 @@ class OrderIntentLedgerTests(unittest.TestCase):
             self.ledger.acquire_amendment_lease(record.intent_id, "nudger", lease_seconds=30, idempotency_key="amend-1", amendment_payload=raw_payload())
         with sqlite3.connect(self.path) as conn:
             history = conn.execute("SELECT target_broker_order_id, client_order_id, payload_hash FROM amendment_history WHERE intent_id = ? AND idempotency_key = ?", (record.intent_id, "amend-1")).fetchone()
-        self.assertEqual(history[:2], ("broker-1", amendment.client_order_id))
+        self.assertEqual(history[:2], ("2000000001", amendment.client_order_id))
         self.assertEqual(len(history[2]), 64)
 
     def test_original_intent_rejects_known_client_id_collision_with_completed_amendment(self):
@@ -1131,11 +1824,11 @@ class OrderIntentLedgerTests(unittest.TestCase):
         submit = self.ledger.claim_submission(source.intent_id, "worker", lease_seconds=30)
         self.begin_submission(source, "worker", submit)
         self.ledger.record_post_acknowledgement(source.intent_id, "worker", submit.fencing_token, evidence(source, self.clock, operation="SUBMIT_ACK"))
-        amendment = self.ledger.acquire_amendment_lease(source.intent_id, "nudger", lease_seconds=30, idempotency_key="amend-13221", amendment_payload=raw_payload())
+        amendment = self.ledger.acquire_amendment_lease(source.intent_id, "nudger", lease_seconds=30, idempotency_key="amend-68395", amendment_payload=raw_payload())
         self.begin_amendment(source, "nudger", amendment)
         self.ledger.record_amendment_acknowledgement(source.intent_id, "nudger", amendment.fencing_token, evidence(source, self.clock, operation="AMEND_ACK", client_order_id=amendment.client_order_id, broker_order_id="broker-amended"))
         with self.assertRaises(OrderIntentIntegrityError):
-            self.ledger.create_intent(make_intent(key="target-210261"))
+            self.ledger.create_intent(make_intent(key="target-338459"))
 
     def test_amendment_is_reprice_only_and_in_doubt_lease_cannot_be_released(self):
         record = self.opening()
@@ -1204,7 +1897,7 @@ class OrderIntentLedgerTests(unittest.TestCase):
         other = self.ledger.create_intent(make_intent(key="other-opening", decision="other-opening")).intent
         self.ledger.reserve_margin(
             other.intent_id,
-            risk(other, self.clock, collateral="400", max_loss="400"),
+            self.risk(other, collateral="400", max_loss="400"),
         )
         with self.assertRaises(OrderIntentReconciliationRequired):
             self.ledger.claim_submission(other.intent_id, "other", lease_seconds=30)
@@ -1216,7 +1909,7 @@ class OrderIntentLedgerTests(unittest.TestCase):
         record = self.opening()
         submit = self.ledger.claim_submission(record.intent_id, "worker", lease_seconds=600)
         self.clock.advance(1)
-        self.ledger.set_reservation_cap(capacity(self.clock, buying_power="0", risk_budget="0"))
+        self.set_capacity(buying_power="0", risk_budget="0")
         with self.assertRaises(OrderIntentReservationError):
             self.begin_submission(record, "worker", submit)
         self.assertEqual(self.ledger.get_intent(record.intent_id).state, "CLAIMED")
@@ -1225,26 +1918,46 @@ class OrderIntentLedgerTests(unittest.TestCase):
         for terminal in ("CANCELLED", "EXPIRED"):
             with self.subTest(terminal=terminal):
                 self.clock.advance(1)
-                account = f"acct-{terminal.lower()}"
+                account = {
+                    "CANCELLED": "1000000011",
+                    "EXPIRED": "1000000012",
+                }[terminal]
+                broker_order_id = {
+                    "CANCELLED": "2000000011",
+                    "EXPIRED": "2000000012",
+                }[terminal]
                 record = self.opening(key=f"{terminal}-opening", account=account)
                 submit = self.ledger.claim_submission(record.intent_id, "worker", lease_seconds=30)
                 self.begin_submission(record, "worker", submit)
-                self.ledger.record_post_acknowledgement(record.intent_id, "worker", submit.fencing_token, evidence(record, self.clock, operation="SUBMIT_ACK", broker_order_id=f"{terminal}-broker"))
-                self.ledger.reconcile_terminal(record.intent_id, terminal, evidence(record, self.clock, operation="ORDER_QUERY", outcome=terminal, broker_order_id=f"{terminal}-broker"))
+                self.ledger.record_post_acknowledgement(record.intent_id, "worker", submit.fencing_token, evidence(record, self.clock, operation="SUBMIT_ACK", broker_order_id=broker_order_id))
+                terminal_evidence = self.query_evidence(
+                    record,
+                    outcome=terminal,
+                    broker_order_id=broker_order_id,
+                )
+                self.ledger.reconcile_terminal(
+                    record.intent_id, terminal, terminal_evidence
+                )
                 self.assertEqual(self.ledger.get_margin_reservation(record.intent_id).state, "FILLED_PENDING_ABSORPTION")
                 blocked = self.ledger.create_intent(make_intent(account=account, key=f"{terminal}-blocked", decision=f"{terminal}-blocked")).intent
-                self.ledger.reserve_margin(blocked.intent_id, risk(blocked, self.clock))
+                self.ledger.reserve_margin(blocked.intent_id, self.risk(blocked))
                 with self.assertRaises(OrderIntentReservationError):
                     self.ledger.claim_submission(blocked.intent_id, "blocked", lease_seconds=30)
                 self.clock.advance(1)
-                with self.assertRaises(OrderIntentReconciliationRequired):
-                    self.ledger.absorb_filled_reservation(
-                        record.intent_id, capacity(self.clock, account=account)
-                    )
+                refreshed_capacity = self.set_capacity(account=account)
                 with self.assertRaises(OrderIntentReconciliationRequired):
                     self.ledger.absorb_filled_reservation(
                         record.intent_id,
-                        capacity(self.clock, account=account, digest="d" * 64),
+                        self.capacity_evidence(refreshed_capacity),
+                    )
+                self.clock.advance(1)
+                changed_capacity = self.set_capacity(
+                    account=account, state_marker="different"
+                )
+                with self.assertRaises(OrderIntentReconciliationRequired):
+                    self.ledger.absorb_filled_reservation(
+                        record.intent_id,
+                        self.capacity_evidence(changed_capacity),
                     )
                 with self.assertRaises(OrderIntentReservationError):
                     self.ledger.claim_submission(blocked.intent_id, "still-blocked", lease_seconds=30)
@@ -1296,6 +2009,26 @@ class OrderIntentLedgerTests(unittest.TestCase):
             payload_hash=legacy.payload_hash,
         )
         claimed_client_id = stable_client_order_id(claimed_legacy)
+        query_wire = wire_order_payload(raw_payload())
+        query_canonical = canonical_order_payload(
+            json.loads(query_wire)
+        )
+        query_legacy = OrderIntent(
+            account_id="1000000099",
+            environment="production",
+            strategy_id="legacy-open",
+            decision_id="legacy-query-decision",
+            idempotency_scope="legacy",
+            idempotency_key="legacy-query",
+            intent_kind="OPENING",
+            wire_payload=query_wire,
+            canonical_payload=query_canonical,
+            payload_hash=hashlib.sha256(
+                b"etrade-order-payload.v2\0"
+                + query_canonical.encode("utf-8")
+            ).hexdigest(),
+        )
+        query_client_id = stable_client_order_id(query_legacy)
         now = int(self.clock.now.timestamp() * 1_000_000)
         with sqlite3.connect(self.path) as conn:
             conn.execute(
@@ -1326,6 +2059,38 @@ class OrderIntentLedgerTests(unittest.TestCase):
                     legacy.canonical_payload,
                     legacy.payload_hash,
                     legacy_client_id,
+                    now,
+                    now,
+                ),
+            )
+            conn.execute(
+                """
+                INSERT INTO order_intents (
+                    intent_id, account_id, environment, strategy_id, decision_id,
+                    idempotency_scope, idempotency_key, intent_kind, wire_payload,
+                    canonical_payload, payload_hash, client_order_id, state,
+                    broker_order_id, submission_fence, amendment_fence,
+                    submission_lease_owner, submission_lease_expires_at,
+                    pending_operation, pending_owner, pending_fence,
+                    last_reconciled_run, created_at, updated_at
+                ) VALUES (
+                    'legacy-query-intent', ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?,
+                    'SUBMITTED', '2000000099', 1, 0, NULL, NULL,
+                    NULL, NULL, NULL, 'legacy-run', ?, ?
+                )
+                """,
+                (
+                    query_legacy.account_id,
+                    query_legacy.environment,
+                    query_legacy.strategy_id,
+                    query_legacy.decision_id,
+                    query_legacy.idempotency_scope,
+                    query_legacy.idempotency_key,
+                    query_legacy.intent_kind,
+                    query_legacy.wire_payload,
+                    query_legacy.canonical_payload,
+                    query_legacy.payload_hash,
+                    query_client_id,
                     now,
                     now,
                 ),
@@ -1464,19 +2229,14 @@ class OrderIntentLedgerTests(unittest.TestCase):
         migrated.release_amendment_lease(
             legacy_record.intent_id, "legacy-amender", 1
         )
+        query_record = migrated.get_intent("legacy-query-intent")
+        legacy_query = self.query_evidence(
+            query_record,
+            ledger=migrated,
+            broker_order_id="2000000099",
+        )
         reconciled = migrated.mark_reconciled(
-            legacy_record.intent_id,
-            BrokerEvidence(
-                account_id=legacy.account_id,
-                environment=legacy.environment,
-                client_order_id=legacy_client_id,
-                broker_order_id="legacy-broker-order",
-                operation="ORDER_QUERY",
-                outcome="OPEN",
-                observed_at=self.clock.now,
-                http_status=200,
-                raw_response_digest="f" * 64,
-            ),
+            query_record.intent_id, legacy_query
         )
         self.assertEqual(reconciled.state, "SUBMITTED")
         self.assertEqual(migrated.path, self.path)
@@ -1541,8 +2301,10 @@ class OrderIntentLedgerTests(unittest.TestCase):
         record = migrated.create_intent(
             make_intent(key="migration-live", decision="migration-live")
         ).intent
-        migrated.set_reservation_cap(capacity(self.clock))
-        migrated.reserve_margin(record.intent_id, risk(record, self.clock))
+        self.set_capacity(ledger=migrated)
+        migrated.reserve_margin(
+            record.intent_id, self.risk(record, ledger=migrated)
+        )
         lease = migrated.claim_submission(
             record.intent_id, "worker", lease_seconds=5
         )


### PR DESCRIPTION
## Summary
- add an exact account-bound, origin-pinned, no-retry E*TRADE GET reader
- persist bounded raw responses and independently replay strict parsers in schema 11
- require chronological, content-addressed manifests for two-pass capacity and direct known-order reconciliation
- keep errors, pagination drift, replacement links, partial fills, and ambiguous outcomes fail-closed
- connect the reader to the isolated order gateway without wiring any live caller

## Verification
- 112 focused ledger/reader/transport/gateway tests passed
- 277 maintained repository tests passed in clean Python 3.10
- py_compile and git diff --check passed
- independent adversarial reproductions for broker messages, chronological lineage, replacement links, and partial terminal fills passed

## Safety
No live or sandbox E*TRADE request was made. No deployment or service restart was performed. Position absorption, closing, cancellation, live composition, and operational migration remain release blockers.