### PR TITLE
R7e: absorb terminal E*TRADE risk from exact fill evidence

### DIFF
--- a/etrade_python_client/RELIABILITY.md
+++ b/etrade_python_client/RELIABILITY.md
@@ -514,10 +514,14 @@ finding.
     state, and persist the raw response before any normalized result can leave
     the reader.
   - Independently replay the installed strict parser over each retained
-    response, then accept capacity only from a content-addressed schema-11
-    manifest containing two complete economically identical account scans.
+    response, then accept capacity only from a content-addressed manifest
+    containing two complete economically identical account scans.
     Reconciliation uses only a direct query for the already durable broker
     order ID.
+  - Schema 12 releases terminal opening reservations only for an exact
+    zero-fill terminal or a complete balanced fill proven by newer position
+    lots carrying the same broker order and leg identities. Absorbed full-fill
+    margin remains counted in account utilization.
   - Remain intentionally disconnected from the live agent until the remaining
     position, closing, cancellation, composition, and operational migration
     gates below are complete.
@@ -529,12 +533,12 @@ finding.
 ### Remaining risk
 
 This is containment in the current source, not production readiness. The
-compatibility order client still owns current live calls. The isolated R7a–R7d
-stack now provides a schema-11 intent ledger, hardened mutation transport,
-origin-bound durable reader, and opening/reprice coordinator, but no live code
-instantiates it.
+compatibility order client still owns current live calls. The isolated R7a–R7e
+stack now provides a schema-12 intent ledger, hardened mutation transport,
+origin-bound durable reader, opening/reprice coordinator, and exact zero/full
+terminal-risk absorption, but no live code instantiates it.
 
-Position-bound fill absorption, closing capacity, durable per-intent
+Partial/replacement/assignment recovery, closing capacity, durable per-intent
 cancellation, a single production composition root, and a static ban on every
 direct legacy mutation path remain required.
 
@@ -558,19 +562,20 @@ deployed dashboard has not been reloaded or visually inspected with R6.
   files, guarded response/request logging, order calls without a boundary,
   placement-time arm expiry, dashboard credential rejection, and loopback/CORS
   behavior.
-- The current R7 ledger/reader/transport/coordinator focused suite includes
-  112 deterministic tests for immutable identity, exact authorization/XML,
+- The current R7 ledger/reader/transport/coordinator focused suite includes 153
+  deterministic tests for immutable identity, exact authorization/XML,
   transport deadlines, send fencing, parsed receipts, crash/timeout recovery,
   capacity arithmetic, gateway-owned risk ceilings, environment/account
   binding, strict raw-response replay, pagination/marker completeness,
-  two-scan stability, exact order-term reconciliation, amendment replay,
-  terminal-risk retention, and additive schema 8→9→10→11 migration.
+  lot-aware two-scan stability, exact order/fill reconciliation, amendment
+  replay, terminal absorption, retained filled risk, and additive schema
+  8→9→10→11→12 migration.
   Independent adversarial review found and closed fail-open handling for
   replacement-linked and partially filled terminal orders; both now remain
   unresolved. The review explicitly retains a no-go on live wiring until the
-  remaining position, closing, cancellation, and composition protocols are
-  delivered.
-- The maintained `tests/` suite passes 277 tests in the clean Python 3.10
+  remaining partial/complex terminal, closing, cancellation, and composition
+  protocols are delivered.
+- The maintained `tests/` suite passes 318 tests in the clean Python 3.10
   environment. An unscoped repository-root pytest invocation still
   mis-collects two legacy `scratch/test_delta_*` research scripts and triggers
   import-time market-data behavior; the reproducible-build/CI gate must

--- a/etrade_python_client/docs/order_intent_ledger.md
+++ b/etrade_python_client/docs/order_intent_ledger.md
@@ -1,7 +1,7 @@
 # Durable Order Intent Ledger
 
 **Delivery status:** R7a ledger + R7b transport + R7c coordinator + R7d
-durable reader, isolated
+durable reader + R7e terminal-risk absorption, isolated
 
 **Production status:** not connected to live E*TRADE mutation paths
 
@@ -23,9 +23,12 @@ legacy order paths.
 - No new closing orders until a later slice supplies typed position and open-order
   capacity evidence. Previously persisted closing orders remain readable and
   reconcilable after migration, but cannot be newly claimed or amended.
+- Exact zero-fill cancellation/rejection/expiration and exact full-fill
+  position absorption are supported. Partial fills, replacement chains,
+  transformed lots, assignment/exercise, and ambiguous position evidence
+  remain blocked.
 - No equity orders, naked opening options, arbitrary multi-leg spreads, bulk
-  cancellation, or terminal reservation release. Unsupported operations fail
-  closed.
+  cancellation, or closing orders. Unsupported operations fail closed.
 
 ## State and crash boundary
 
@@ -72,10 +75,12 @@ remains blocked rather than guessed or retried.
   evidence. The caller's asserted maximum loss cannot be below the exposure
   derived from strike width, price, contract multiplier, and quantity.
 - An opening terminal state retains its reservation as
-  `FILLED_PENDING_ABSORPTION`. The schema-11 R7a–R7d stack never releases it:
-  neither a newer timestamp nor a different account digest proves that a
-  specific partial or terminal fill is reflected in positions. A later
-  position-absorption slice must add order-bound position evidence.
+  `FILLED_PENDING_ABSORPTION`. Schema 12 releases it only after a fresh,
+  exact order re-query proves either zero filled quantity with complete cancel
+  arithmetic, or a complete balanced fill whose order-bound position lots are
+  present in a newer stable portfolio snapshot. Full-fill margin remains in
+  account risk utilization after release, so restart cannot recycle it into a
+  new opening order.
 - Evidence dataclasses and their security-critical string, timestamp, integer,
   byte, and `Decimal` fields must use exact built-in types. Subclass overrides
   cannot replace validation or comparison behavior.
@@ -88,7 +93,7 @@ remains blocked rather than guessed or retried.
   Strategy commands cannot raise it. Reconciliation requires the reader's
   normalized order payload to match the durable original, pending amendment, or
   latest completed amendment hash.
-- Capacity can be set only from a content-addressed schema-11 manifest. A
+- Capacity can be set only from a content-addressed broker-read manifest. A
   complete manifest brackets two independent scans with exact account-list
   reads; fully traverses balance, every portfolio page, and all reviewed active
   order status lanes; and requires both economic scans to match. Moving balance
@@ -112,13 +117,21 @@ remains blocked rather than guessed or retried.
 
 ## Schema policy
 
-Schema 11 adds raw broker-read receipts, ordered semantic manifests, durable
-capacity decisions, and provenance foreign keys on caps, reservations, and
-events. Additive schema 8→9→10→11 migration is one explicit SQLite transaction
-and verifies required columns, foreign keys, append-only triggers, journal
-mode, foreign-key integrity, and `quick_check` before version promotion.
-Unknown or malformed schemas fail closed. A production operator must still
-take an atomic private backup and complete a rollback drill before migration.
+Schema 12 adds immutable terminal-reservation absorption receipts, their
+baseline/order/post-capacity evidence chain, and append-only transition guards.
+It retains schema 11 raw broker-read receipts, ordered semantic manifests,
+durable capacity decisions, and provenance foreign keys. Additive schema
+8→9→10→11→12 migration is one explicit SQLite transaction and verifies
+required columns, foreign keys, append-only triggers, journal mode, foreign-key
+integrity, and `quick_check` before version promotion. Unknown or malformed
+schemas fail closed. A production operator must still take an atomic private
+backup and complete a rollback drill before migration.
+
+Schema 8/9 opening intents that predate durable reservations are migrated with
+a conservative reservation equal to their immutable maximum exposure. Live
+states remain active and terminal states remain pending absorption. Those
+records have no fabricated capacity decision: full-fill absorption therefore
+stays blocked, while a fresh exact zero-fill terminal can still release risk.
 
 ## Remaining production release gates
 
@@ -126,9 +139,9 @@ The isolated R7 stack must not be used as evidence that live execution is
 production-ready. The following remain required before any order-capable
 process is enabled:
 
-1. Position-level fill evidence must safely absorb terminal opening
-   reservations, including partial fills, replacements, assignment/exercise,
-   and zero-fill proof for cancelled/rejected/expired orders.
+1. Partial fills, replacements, transformed lots, and assignment/exercise
+   remain unsupported and blocked; supervised recovery procedures are still
+   required for those states.
 2. Closing-position capacity and one-shot per-intent cancellation need durable,
    crash-tested protocols. Bulk cancellation remains disabled.
 3. The live composition root must construct the exact ledger, reader,
@@ -142,9 +155,10 @@ process is enabled:
    observation of the exact served/live artifacts.
 
 The focused ledger/reader/transport/coordinator suites exercise raw-parser
-binding, pagination and marker drift, two-scan stability, schema rollback,
-exact payload reconciliation, mutation fencing, and crash/timeout behavior.
-They contain 112 deterministic tests; the maintained repository `tests/` suite
-contains 277 passing tests in the clean Python 3.10 environment. This is source
-verification only; position, cancellation/closing, live composition, and
-operational migration gates above remain open.
+binding, pagination and marker drift, lot-aware two-scan stability, schema
+rollback, exact payload/fill reconciliation, terminal absorption, retained
+filled risk, mutation fencing, and crash/timeout behavior. They contain 153
+deterministic tests; the maintained repository `tests/` suite contains 318
+passing tests in the clean Python 3.10 environment. This is source verification
+only; partial/complex terminal states, cancellation/closing, live composition,
+and operational migration gates above remain open.

--- a/etrade_python_client/docs/production_readiness_upgrade_plan.md
+++ b/etrade_python_client/docs/production_readiness_upgrade_plan.md
@@ -61,10 +61,11 @@ current source:
   quarantined.
 
 These changes do **not** satisfy Phase 0 or make the repository production
-ready. The existing order paths are guarded but not yet centralized. R7a–R7d
+ready. The existing order paths are guarded but not yet centralized. R7a–R7e
 preserve the arm/account check and add isolated durable intent identity,
 capacity reservations, mutation fencing, direct known-order reconciliation,
-and raw read provenance, but no live caller is composed through that stack.
+raw read provenance, and exact zero/full terminal-risk absorption, but no live
+caller is composed through that stack.
 The current local dashboard settings are intentionally rejected until stronger
 credentials are provisioned. GitHub reports the repository as public on
 2026-07-26, and OAuth keys retained in its public history must be treated as
@@ -388,11 +389,13 @@ intent, idempotency key, preview, broker IDs, price budget, every transition,
 actor, timestamps, retries, and reconciliation generation. Repricing has one
 owner and absolute slippage/debit/credit/time limits.
 
-Implementation status: schema 11 currently supports isolated opening and
+Implementation status: schema 12 currently supports isolated opening and
 price-only reprice flows with `INTENT`, `CLAIMED`, `FAILED`,
 `SUBMISSION_UNKNOWN`, `SUBMITTED`, and terminal states. Terminal-fill
-absorption, new closing intents, cancellation, and live composition remain
-fail-closed release gates.
+absorption is limited to exact zero fills or complete balanced fills with newer
+order-bound position lots; partial/replacement/assignment states stay blocked.
+New closing intents, cancellation, and live composition remain fail-closed
+release gates.
 
 ### Boundary 6: deterministic backtesting
 
@@ -515,11 +518,12 @@ Exit gate:
 
 ### Phase 2 — broker and snapshot foundations (weeks 2–3)
 
-Status: partially delivered. R7b–R7d provide the isolated bounded mutation
+Status: partially delivered. R7b–R7e provide the isolated bounded mutation
 transport, strict origin-bound reader, durable raw/parser receipts, explicit
-pagination, and two-scan capacity manifests. Shared OAuth recovery, general
-snapshot read models, health/readiness, graceful shutdown, metrics, and live
-composition remain open.
+pagination, lot-aware two-scan capacity manifests, and exact terminal order
+evidence. Shared OAuth recovery, general snapshot read models,
+health/readiness, graceful shutdown, metrics, and live composition remain
+open.
 
 Deliver:
 
@@ -541,11 +545,13 @@ Exit gate:
 
 ### Phase 3 — durable live control plane (weeks 3–5)
 
-Status: partially delivered. R7a–R7d provide the schema-11 ledger, stable
+Status: partially delivered. R7a–R7e provide the schema-12 ledger, stable
 opening intent identity, outbox-style send claims, reconciliation, capacity
-reservations, and a single isolated reprice owner. Fill absorption,
-closing/cancellation, the broader pure risk policy, process decomposition,
-dashboard command routing, and hardened live deployment remain open.
+reservations, a single isolated reprice owner, and exact zero/full terminal-risk
+absorption with retained filled-margin accounting. Partial/complex terminal
+states, closing/cancellation, the broader pure risk policy, process
+decomposition, dashboard command routing, and hardened live deployment remain
+open.
 
 Deliver:
 
@@ -668,20 +674,21 @@ boundaries are extracted. Remove old paths only after golden tests and
 shadow-parity prove equivalent intended behavior.
 
 The current stacked delivery names the source-level startup containment slice
-R6. R7a–R7d now implement an isolated schema-11 execution core: strict
+R6. R7a–R7e now implement an isolated schema-12 execution core: strict
 vertical-spread validation, stable intent/client identity, durable capacity
 reservations, monotonic submission/amendment fences, exact immutable outbound
 authorization, a no-retry mutation transport, an opening/reprice coordinator,
-and an origin-bound durable E*TRADE reader. The reader records bounded raw
-responses, the ledger independently replays their strict parser, and capacity
-or reconciliation can use only a semantically complete content-addressed
-manifest. No live caller instantiates this stack.
+an origin-bound durable E*TRADE reader, and order/lot-bound zero/full terminal
+absorption. The reader records bounded raw responses, the ledger independently
+replays their strict parser, and capacity or reconciliation can use only a
+semantically complete content-addressed manifest. Full fills retain their
+reserved margin in utilization after absorption. No live caller instantiates
+this stack.
 
-The next R7 safety boundary is position-bound terminal-fill absorption,
-followed by closing-position capacity and one-shot per-intent cancellation.
-Only after those protocols pass restart/crash tests may the live composition
-root own the gateway and static enforcement prohibit every direct legacy
-mutation call. See `docs/order_intent_ledger.md`.
+The next R7 safety boundaries are closing-position capacity and one-shot
+per-intent cancellation. Only after those protocols pass restart/crash tests
+may the live composition root own the gateway and static enforcement prohibit
+every direct legacy mutation call. See `docs/order_intent_ledger.md`.
 
 ## Test and verification matrix
 
@@ -733,11 +740,12 @@ exercised a live/sandbox mutation. Current-source credential removal also does
 not establish secret hygiene while the repository remains public and the old
 keys remain in Git history. External revoke/rotate, coordinated history purge,
 strong local credential reprovisioning, the remaining R7
-position/closing/cancellation protocols, durable-gateway composition, and
-deployment verification remain required. The isolated R7a–R7d stack has
-focused deterministic coverage and independent causal/security review, but it
-has no production call site and is not live-execution evidence. The remaining
-actions belong to the staged acceptance gates above.
+partial/closing/cancellation protocols, durable-gateway composition, and
+deployment verification remain required. The isolated R7a–R7e stack has
+focused deterministic coverage and independent causal/security review,
+including exact zero/full terminal absorption, but it has no production call
+site and is not live-execution evidence. The remaining actions belong to the
+staged acceptance gates above.
 
 The working tree was already heavily modified and contains important untracked
 runtime sources. This review intentionally adds only this plan and does not

--- a/etrade_python_client/docs/project_overview.md
+++ b/etrade_python_client/docs/project_overview.md
@@ -153,6 +153,7 @@ flowchart LR
     TRANSPORT["R7b Mutation Transport<br/>(Implemented, Isolated)"]
     GATE["R7c Order Gateway<br/>(Implemented, Isolated)"]
     READER["R7d Durable E*TRADE Reader<br/>(Implemented, Isolated)"]
+    ABSORB["R7e Terminal-Risk Absorption<br/>(Implemented, Isolated)"]
     BROKER["E*TRADE"]
 
     CLI --> SAFE
@@ -165,6 +166,8 @@ flowchart LR
     DIRECT -.->|"future migration"| GATE
     GATE -->|"intent, reservation, reconciliation"| LEDGER
     GATE -->|"capacity and known-order reads"| READER
+    GATE -->|"zero/full terminal proof"| ABSORB
+    ABSORB -->|"immutable receipt + retained filled risk"| LEDGER
     GATE --> TRANSPORT
     READER -->|"append-only raw receipts + manifests"| LEDGER
     TRANSPORT -->|"send claims + mutation receipts"| LEDGER
@@ -182,10 +185,13 @@ restart reconciliation, and exact economic-term comparison. No live code
 instantiates this stack. R7d adds the concrete origin-bound reader: every
 usable GET is durably recorded as bounded raw bytes, independently reparsed by
 the ledger, and grouped into a semantically complete manifest before it can
-authorize capacity or reconciliation. Position absorption,
-cancellation/closing protocols, the single live composition root, and removal
-of legacy mutation paths remain mandatory before live wiring. The deployed
-service has not been restarted or inspected with R6 or R7.
+authorize capacity or reconciliation. R7e releases zero-fill terminal risk or
+absorbs a complete balanced fill only from a fresh exact order read plus newer
+order-bound position lots; absorbed full-fill margin remains counted against
+account risk. Partial/replacement/assignment states, cancellation/closing
+protocols, the single live composition root, and removal of legacy mutation
+paths remain mandatory before live wiring. The deployed service has not been
+restarted or inspected with R6 or R7.
 
 ---
 
@@ -231,8 +237,8 @@ shadow/research-only and cannot affect E*TRADE order eligibility.
 *   **Account Identity Revalidation** ([`accounts_bo.py`](file:///Users/btian/EtradePythonClient/etrade_python_client/accounts/accounts_bo.py), [`order_bo.py`](file:///Users/btian/EtradePythonClient/etrade_python_client/order/order_bo.py)): Selects production accounts by exact account ID, account key, and institution type instead of a mutable list index. The live process revalidates the armed identity after startup and account refresh, and the compatibility order client repeats it immediately before every order API call. The isolated R7 reader, gateway, and transport preserve the same boundary; future live composition must make that gateway the sole mutation owner.
 *   **Durable Order Intent Ledger** ([`order_intent_ledger.py`](file:///Users/btian/EtradePythonClient/etrade_python_client/live_trading/order_intent_ledger.py), [`order_intent_ledger.md`](file:///Users/btian/EtradePythonClient/etrade_python_client/docs/order_intent_ledger.md)): R7a provides strict vertical-spread validation, account capacity reservations, stable identifiers, monotonic submission/amendment fences, immutable outbound authorizations, exact send/response receipts, and reconciliation-only handling after an ambiguous mutation.
 *   **Hardened Mutation Transport** ([`etrade_broker_transport.py`](file:///Users/btian/EtradePythonClient/etrade_python_client/live_trading/etrade_broker_transport.py)): R7b is the only reviewed adapter permitted to derive E*TRADE mutation XML from a durable authorization. It disables ambient proxies, cookies, hooks, redirects, and retries; revalidates the armed account; claims the exact send before I/O; bounds the exchange in an isolated process; and records the parsed result before returning.
-*   **Order Gateway** ([`etrade_order_gateway.py`](file:///Users/btian/EtradePythonClient/etrade_python_client/live_trading/etrade_order_gateway.py)): R7c coordinates opening submissions and price-only amendments through the exact transport. Startup stays read-only until every known broker order is reconciled, unknown responses without a broker ID remain permanent blockers, returned order terms must hash to the durable authorization, and an immutable gateway policy—not a strategy command—sets the account risk ceiling. This component remains intentionally unreachable from the live agent until position absorption, closing/cancellation, live composition/static enforcement, and operational validation are delivered.
-*   **Durable E*TRADE Reader** ([`etrade_broker_reader.py`](file:///Users/btian/EtradePythonClient/etrade_python_client/live_trading/etrade_broker_reader.py)): R7d performs only exact origin-pinned, no-retry GETs in bounded disposable processes. It rebinds the configured account before and after a read, traverses explicit portfolio pages and reviewed active-order marker lanes, requires two economically identical capacity scans, and persists raw response bytes plus parser and request provenance before returning a content-addressed manifest. Known-order reconciliation uses only a direct lookup of the durable broker order ID; missing, incomplete, ambiguous, or mismatched evidence remains blocked.
+*   **Order Gateway** ([`etrade_order_gateway.py`](file:///Users/btian/EtradePythonClient/etrade_python_client/live_trading/etrade_order_gateway.py)): R7c coordinates opening submissions and price-only amendments through the exact transport. R7e extends read-only startup reconciliation with deterministic terminal-reservation absorption: zero-fill terminals need no capacity read, while full fills require a newer lot-aware capacity decision bound to the same order. Startup stays blocked on partial, replacement-linked, stale, or ambiguous evidence. This component remains intentionally unreachable from the live agent until closing/cancellation, live composition/static enforcement, and operational validation are delivered.
+*   **Durable E*TRADE Reader** ([`etrade_broker_reader.py`](file:///Users/btian/EtradePythonClient/etrade_python_client/live_trading/etrade_broker_reader.py)): R7d performs only exact origin-pinned, no-retry GETs in bounded disposable processes. R7e adds exact per-leg fill quantities/timestamps and requests `lotsRequired=true`; position lots retain order and leg identity, signed quantities, and canonical provenance across both stability scans. Known-order reconciliation still uses only a direct lookup of the durable broker order ID; missing, incomplete, ambiguous, or mismatched evidence remains blocked.
 *   **Dashboard Containment** ([`etrade_cover_call_new.py`](file:///Users/btian/EtradePythonClient/etrade_python_client/live_trading/etrade_cover_call_new.py)): Serves the order-capable dashboard on loopback only, does not start ngrok automatically, and does not grant wildcard CORS. Startup rejects default or weak dashboard credentials, while local settings and touched logs use owner-only file handling.
 *   **Credential Source Cleanup** ([`etrade_check_option.py`](file:///Users/btian/EtradePythonClient/etrade_python_client/live_trading/etrade_check_option.py), [`etrade_option_chains.py`](file:///Users/btian/EtradePythonClient/etrade_python_client/live_trading/etrade_option_chains.py)): Removes hardcoded OAuth credentials from the current source and requires local configuration or environment variables. Because the repository is currently public and those values remain in Git history, the affected keys must be treated as compromised until they are revoked and rotated externally; a coordinated history purge remains separate follow-up work.
 

--- a/etrade_python_client/live_trading/etrade_broker_reader.py
+++ b/etrade_python_client/live_trading/etrade_broker_reader.py
@@ -52,6 +52,7 @@ _MAX_JSON_NODES = 50_000
 _MAX_JSON_DEPTH = 48
 _MAX_PORTFOLIO_PAGES = 100
 _MAX_POSITIONS = 5_000
+_MAX_POSITION_LOTS = 20_000
 _MAX_ORDER_PAGES = 100
 _MAX_ORDERS = 10_000
 _MAX_BROKER_INT64 = 9_223_372_036_854_775_807
@@ -60,7 +61,7 @@ _ACTIVE_ORDER_STATUSES = (
     "CANCEL_REQUESTED",
     "INDIVIDUAL_FILLS",
 )
-_PARSER_SCHEMA = "etrade-broker-reader.v1"
+_PARSER_SCHEMA = "etrade-broker-reader.v2"
 _PARSER_CODE_SHA256 = hashlib.sha256(Path(__file__).read_bytes()).hexdigest()
 _PARSER_CONFIG_SHA256 = hashlib.sha256(
     json.dumps(
@@ -71,6 +72,7 @@ _PARSER_CONFIG_SHA256 = hashlib.sha256(
             "max_order_pages": _MAX_ORDER_PAGES,
             "max_orders": _MAX_ORDERS,
             "max_portfolio_pages": _MAX_PORTFOLIO_PAGES,
+            "max_position_lots": _MAX_POSITION_LOTS,
             "max_positions": _MAX_POSITIONS,
             "max_raw_response_bytes": _MAX_RAW_RESPONSE_BYTES,
         },
@@ -296,10 +298,11 @@ class ETradeBrokerReader:
                 )
             parsed = order_read.parsed
             result = {
-                "schema": "etrade-order-query.v1",
+                "schema": "etrade-order-query.v2",
                 "broker_order_id": target,
                 "raw_status": parsed["raw_status"],
                 "outcome": parsed["outcome"],
+                "fill_summary": parsed["fill_summary"],
                 "order_payload_hashes": parsed["order_payload_hashes"],
                 "http_status": order_read.http_status,
                 "raw_response_digest": order_read.raw_response_digest,
@@ -447,7 +450,7 @@ class ETradeBrokerReader:
         )
         orders, order_members, orders_completed = self._read_active_orders()
         result = {
-            "schema": "etrade-capacity.v1",
+            "schema": "etrade-capacity.v2",
             "account_status": binding.account_status,
             "account_mode": binding.account_mode,
             "account_type": binding.account_type,
@@ -461,7 +464,7 @@ class ETradeBrokerReader:
         economic_state = dict(result)
         economic_state.pop("broker_buying_power_as_of")
         state_sha256 = _domain_json_hash(
-            b"etrade-capacity-state.v1\0", economic_state
+            b"etrade-capacity-state.v2\0", economic_state
         )
         members = (
             BrokerReadManifestMember(
@@ -577,6 +580,7 @@ class ETradeBrokerReader:
         positions: list[dict[str, Any]] = []
         members: list[BrokerReadManifestMember] = []
         seen_position_ids: set[str] = set()
+        seen_position_lot_ids: set[str] = set()
         expected_total_pages: int | None = None
         expected_metadata_field: str | None = None
         page_number = 1
@@ -591,7 +595,7 @@ class ETradeBrokerReader:
                 route=f"/v1/accounts/{encoded_account}/portfolio.json",
                 query=(
                     ("count", "50"),
-                    ("lotsRequired", "false"),
+                    ("lotsRequired", "true"),
                     ("marketSession", "REGULAR"),
                     ("pageNumber", str(page_number)),
                     ("sortBy", "SYMBOL"),
@@ -602,7 +606,9 @@ class ETradeBrokerReader:
                 target_broker_order_id=None,
                 allowed_statuses={200, 204},
                 parser=lambda status, raw, page=page_number: (
-                    self._parse_portfolio_page(status, raw, page)
+                    self._parse_portfolio_page(
+                        status, raw, page, lots_required=True
+                    )
                 ),
             )
             parsed = read.parsed
@@ -632,6 +638,17 @@ class ETradeBrokerReader:
                         "portfolio contains a duplicate position id"
                     )
                 seen_position_ids.add(position_id)
+                for lot in position["lots"]:
+                    lot_id = lot["position_lot_id"]
+                    if lot_id in seen_position_lot_ids:
+                        raise ETradeBrokerReaderIntegrityError(
+                            "portfolio contains a duplicate position lot id"
+                        )
+                    seen_position_lot_ids.add(lot_id)
+                    if len(seen_position_lot_ids) > _MAX_POSITION_LOTS:
+                        raise ETradeBrokerReaderIntegrityError(
+                            "portfolio exceeded its fixed position-lot bound"
+                        )
                 positions.append(position)
                 if len(positions) > _MAX_POSITIONS:
                     raise ETradeBrokerReaderIntegrityError(
@@ -653,7 +670,12 @@ class ETradeBrokerReader:
         return positions, tuple(members), completed_at
 
     def _parse_portfolio_page(
-        self, status: int, raw: bytes, page_number: int
+        self,
+        status: int,
+        raw: bytes,
+        page_number: int,
+        *,
+        lots_required: bool,
     ) -> tuple[
         dict[str, Any], Literal["COMPLETE", "HAS_NEXT"]
     ]:
@@ -718,7 +740,9 @@ class ETradeBrokerReader:
                 "AccountPortfolio.Position must be an array"
             )
         positions = [
-            self._normalize_position(position)
+            self._normalize_position(
+                position, lots_required=lots_required
+            )
             for position in raw_positions
         ]
         raw_next_page = account_portfolio.get("nextPageNo")
@@ -747,7 +771,9 @@ class ETradeBrokerReader:
             "positions": positions,
         }, completeness
 
-    def _normalize_position(self, value: Any) -> dict[str, Any]:
+    def _normalize_position(
+        self, value: Any, *, lots_required: bool
+    ) -> dict[str, Any]:
         position = _object(value, "Position")
         position_id = _broker_int64_text(
             position.get("positionId"), "position id"
@@ -776,7 +802,7 @@ class ETradeBrokerReader:
         osi_key = _optional_ascii_text(
             position.get("osiKey"), "position osi key"
         )
-        return {
+        normalized = {
             "position_id": position_id,
             "account_id": account_id,
             "product": product,
@@ -785,6 +811,34 @@ class ETradeBrokerReader:
             "position_indicator": position_indicator,
             "osi_key": osi_key,
         }
+        if not lots_required:
+            return normalized
+        lot_fields = [
+            field
+            for field in ("PositionLot", "positionLot")
+            if field in position
+        ]
+        if len(lot_fields) > 1:
+            raise ETradeBrokerReaderIntegrityError(
+                "position uses conflicting PositionLot fields"
+            )
+        raw_lots = position.get(lot_fields[0], []) if lot_fields else []
+        if type(raw_lots) is not list:
+            raise ETradeBrokerReaderIntegrityError(
+                "PositionLot must be an array"
+            )
+        lots = [
+            _normalize_position_lot(lot, position_id)
+            for lot in raw_lots
+        ]
+        lot_ids = [lot["position_lot_id"] for lot in lots]
+        if len(lot_ids) != len(set(lot_ids)):
+            raise ETradeBrokerReaderIntegrityError(
+                "position contains duplicate position lot ids"
+            )
+        lots.sort(key=_canonical_json)
+        normalized["lots"] = lots
+        return normalized
 
     def _read_active_orders(
         self,
@@ -1047,6 +1101,12 @@ class ETradeBrokerReader:
                 "not_found": True,
                 "raw_status": "NOT_FOUND",
                 "outcome": "UNRESOLVED",
+                "fill_summary": {
+                    "classification": "UNRESOLVED",
+                    "placed_time_epoch_ms": None,
+                    "executed_time_epoch_ms": None,
+                    "legs": [],
+                },
                 "order_payload_hashes": [],
                 "replacement_links": {},
                 "normalized_order": None,
@@ -1082,13 +1142,23 @@ class ETradeBrokerReader:
             raise ETradeBrokerReaderIntegrityError(
                 "known R7 order must contain exactly one OrderDetail"
             )
-        normalized, outcome, hashes, replacement_links = (
+        normalized, fill_summary, hashes, replacement_links = (
             self._normalize_known_vertical(order, details[0])
         )
+        classification = fill_summary["classification"]
+        if classification == "OPEN":
+            outcome = "OPEN"
+        elif classification == "FULL_FILL":
+            outcome = "FILLED"
+        elif classification == "ZERO_FILL_TERMINAL":
+            outcome = normalized["status"]
+        else:
+            outcome = "UNRESOLVED"
         return {
             "not_found": False,
             "raw_status": normalized["status"],
             "outcome": outcome,
+            "fill_summary": fill_summary,
             "order_payload_hashes": hashes,
             "replacement_links": replacement_links,
             "normalized_order": normalized,
@@ -1098,14 +1168,7 @@ class ETradeBrokerReader:
         self, order: dict[str, Any], raw_detail: Any
     ) -> tuple[
         dict[str, Any],
-        Literal[
-            "OPEN",
-            "FILLED",
-            "CANCELLED",
-            "REJECTED",
-            "EXPIRED",
-            "UNRESOLVED",
-        ],
+        dict[str, Any],
         list[str],
         dict[str, str | None],
     ]:
@@ -1134,6 +1197,20 @@ class ETradeBrokerReader:
                 "known order number conflicts with outer order id"
             )
         status = _ascii_text(detail.get("status"), "known order status")
+        placed_time = _optional_epoch_milliseconds_text(
+            detail.get("placedTime"), "known order placed time"
+        )
+        executed_time = _optional_epoch_milliseconds_text(
+            detail.get("executedTime"), "known order executed time"
+        )
+        if (
+            placed_time is not None
+            and executed_time is not None
+            and int(executed_time) < int(placed_time)
+        ):
+            raise ETradeBrokerReaderIntegrityError(
+                "known order executed time precedes placed time"
+            )
         price_type = _ascii_text(
             detail.get("priceType"), "known order price type"
         )
@@ -1180,16 +1257,19 @@ class ETradeBrokerReader:
                 "known vertical must contain exactly two option legs"
             )
         legs = [
-            _normalize_known_leg(instrument)
-            for instrument in raw_instruments
+            _normalize_known_leg(instrument, leg_number=index)
+            for index, instrument in enumerate(raw_instruments, start=1)
         ]
+        if {leg["legNumber"] for leg in legs} != {1, 2}:
+            raise ETradeBrokerReaderIntegrityError(
+                "known vertical leg numbers must be exactly 1 and 2"
+            )
         reference = (
             legs[0]["symbol"],
             legs[0]["callPut"],
             legs[0]["expiryYear"],
             legs[0]["expiryMonth"],
             legs[0]["expiryDay"],
-            legs[0]["quantity"],
         )
         if any(
             (
@@ -1198,14 +1278,14 @@ class ETradeBrokerReader:
                 leg["expiryYear"],
                 leg["expiryMonth"],
                 leg["expiryDay"],
-                leg["quantity"],
             )
             != reference
             for leg in legs
         ):
             raise ETradeBrokerReaderIntegrityError(
-                "known vertical leg identity/quantity is inconsistent"
+                "known vertical leg identity is inconsistent"
             )
+        balanced = len({leg["quantity"] for leg in legs}) == 1
         if (
             {leg["orderAction"] for leg in legs}
             != {"BUY_OPEN", "SELL_OPEN"}
@@ -1222,38 +1302,59 @@ class ETradeBrokerReader:
             "orderTerm": "GOOD_FOR_DAY",
             "spreadType": "VERTICAL",
         }
-        payload_hashes = sorted(
-            {
-                canonical_order_payload_hash(
-                    {
-                        **payload_base,
-                        "legs": [
-                            {
-                                "symbol": leg["symbol"],
-                                "callPut": leg["callPut"],
-                                "expiryYear": int(leg["expiryYear"]),
-                                "expiryMonth": int(leg["expiryMonth"]),
-                                "expiryDay": int(leg["expiryDay"]),
-                                "strikePrice": Decimal(
-                                    leg["strikePrice"]
-                                ),
-                                "orderAction": leg["orderAction"],
-                                "quantity": int(leg["quantity"]),
-                            }
-                            for leg in permutation
-                        ],
-                    }
-                )
-                for permutation in (legs, list(reversed(legs)))
-            }
+        payload_hashes = (
+            sorted(
+                {
+                    canonical_order_payload_hash(
+                        {
+                            **payload_base,
+                            "legs": [
+                                {
+                                    "symbol": leg["symbol"],
+                                    "callPut": leg["callPut"],
+                                    "expiryYear": int(
+                                        leg["expiryYear"]
+                                    ),
+                                    "expiryMonth": int(
+                                        leg["expiryMonth"]
+                                    ),
+                                    "expiryDay": int(leg["expiryDay"]),
+                                    "strikePrice": Decimal(
+                                        leg["strikePrice"]
+                                    ),
+                                    "orderAction": leg["orderAction"],
+                                    "quantity": int(leg["quantity"]),
+                                }
+                                for leg in permutation
+                            ],
+                        }
+                    )
+                    for permutation in (
+                        legs,
+                        list(reversed(legs)),
+                    )
+                }
+            )
+            if balanced
+            else []
         )
         fills_complete = all(
             Decimal(leg["filledQuantity"])
             == Decimal(leg["quantity"])
+            and Decimal(leg["cancelQuantity"]) == 0
             for leg in legs
         )
-        any_fill = any(
-            Decimal(leg["filledQuantity"]) > 0 for leg in legs
+        all_zero_fill = all(
+            Decimal(leg["filledQuantity"]) == 0 for leg in legs
+        )
+        all_zero_cancel = all(
+            Decimal(leg["cancelQuantity"]) == 0 for leg in legs
+        )
+        cancel_arithmetic_complete = all(
+            Decimal(leg["filledQuantity"])
+            + Decimal(leg["cancelQuantity"])
+            == Decimal(leg["quantity"])
+            for leg in legs
         )
         replacement_links = {
             "replaces_order_id": _first_optional_broker_id(
@@ -1271,18 +1372,39 @@ class ETradeBrokerReader:
             value is not None for value in replacement_links.values()
         )
         if has_replacement_link:
-            outcome = "UNRESOLVED"
-        elif status == "OPEN" and not any_fill:
-            outcome = "OPEN"
-        elif status == "EXECUTED" and fills_complete:
-            outcome = "FILLED"
+            classification = "UNRESOLVED"
+        elif (
+            status == "OPEN"
+            and balanced
+            and all_zero_fill
+            and all_zero_cancel
+            and executed_time is None
+        ):
+            classification = "OPEN"
+        elif (
+            status == "EXECUTED"
+            and balanced
+            and fills_complete
+            and executed_time is not None
+        ):
+            classification = "FULL_FILL"
         elif (
             status in {"CANCELLED", "REJECTED", "EXPIRED"}
-            and not any_fill
+            and balanced
+            and all_zero_fill
+            and cancel_arithmetic_complete
+            and executed_time is None
         ):
-            outcome = status
+            classification = "ZERO_FILL_TERMINAL"
         else:
-            outcome = "UNRESOLVED"
+            classification = "UNRESOLVED"
+        fill_legs = _canonical_fill_summary_legs(legs)
+        fill_summary = {
+            "classification": classification,
+            "placed_time_epoch_ms": placed_time,
+            "executed_time_epoch_ms": executed_time,
+            "legs": fill_legs,
+        }
         return {
             "account_id": account_id,
             "status": status,
@@ -1299,7 +1421,9 @@ class ETradeBrokerReader:
                 )
             ),
             "legs": legs,
-        }, outcome, payload_hashes, replacement_links
+            "placed_time_epoch_ms": placed_time,
+            "executed_time_epoch_ms": executed_time,
+        }, fill_summary, payload_hashes, replacement_links
 
     def _get(
         self,
@@ -1524,10 +1648,20 @@ def _reparse_broker_read_response(
                 query.get("pageNumber"),
                 "durable portfolio page number",
             )
+            raw_lots_required = query.get("lotsRequired")
+            if raw_lots_required == "true":
+                lots_required = True
+            elif raw_lots_required == "false":
+                lots_required = False
+            else:
+                raise ETradeBrokerReaderIntegrityError(
+                    "durable portfolio lotsRequired query is unsupported"
+                )
             parsed, completeness = parser._parse_portfolio_page(
                 evidence.http_status,
                 evidence.raw_response_bytes,
                 page_number,
+                lots_required=lots_required,
             )
         elif evidence.read_kind == "OPEN_ORDERS_PAGE":
             lane = _ascii_text(
@@ -1943,10 +2077,44 @@ def _broker_int64_text(value: Any, label: str) -> str:
     return text
 
 
+def _signed_broker_int64_text(value: Any, label: str) -> str:
+    text = _integer_text(value, label)
+    number = int(text)
+    if (
+        number < -_MAX_BROKER_INT64 - 1
+        or number > _MAX_BROKER_INT64
+    ):
+        raise ETradeBrokerReaderIntegrityError(
+            f"{label} exceeds signed broker int64"
+        )
+    return text
+
+
+def _optional_nonnegative_broker_int64_text(
+    value: Any, label: str
+) -> str | None:
+    if value is None:
+        return None
+    text = _integer_text(value, label, nonnegative=True)
+    if int(text) > _MAX_BROKER_INT64:
+        raise ETradeBrokerReaderIntegrityError(
+            f"{label} exceeds signed broker int64"
+        )
+    return text
+
+
 def _optional_broker_id(value: Any, label: str) -> str | None:
     if value is None:
         return None
     return _broker_int64_text(value, label)
+
+
+def _optional_epoch_milliseconds_text(
+    value: Any, label: str
+) -> str | None:
+    if value is None:
+        return None
+    return _epoch_milliseconds_text(value, label)
 
 
 def _first_optional_broker_id(
@@ -2090,6 +2258,54 @@ def _normalize_product(value: Any, label: str) -> dict[str, Any]:
     }
 
 
+def _normalize_position_lot(
+    value: Any, parent_position_id: str
+) -> dict[str, Any]:
+    lot = _object(value, "PositionLot")
+    position_id = _broker_int64_text(
+        lot.get("positionId"), "position lot parent position id"
+    )
+    if position_id != parent_position_id:
+        raise ETradeBrokerReaderIntegrityError(
+            "position lot parent id does not match its position"
+        )
+    raw_leg_no = lot.get("legNo")
+    if raw_leg_no is None:
+        leg_no = None
+    else:
+        leg_no = _integer_text(
+            raw_leg_no,
+            "position lot leg number",
+            nonnegative=True,
+        )
+        if int(leg_no) > 2_147_483_647:
+            raise ETradeBrokerReaderIntegrityError(
+                "position lot leg number exceeds signed int32"
+            )
+    return {
+        "position_id": position_id,
+        "position_lot_id": _broker_int64_text(
+            lot.get("positionLotId"), "position lot id"
+        ),
+        "order_no": _optional_nonnegative_broker_int64_text(
+            lot.get("orderNo"), "position lot order number"
+        ),
+        "leg_no": leg_no,
+        "original_quantity": _decimal_text(
+            lot.get("originalQty"), "position lot original quantity"
+        ),
+        "remaining_quantity": _decimal_text(
+            lot.get("remainingQty"), "position lot remaining quantity"
+        ),
+        "available_quantity": _decimal_text(
+            lot.get("availableQty"), "position lot available quantity"
+        ),
+        "acquired_date_epoch_ms": _signed_broker_int64_text(
+            lot.get("acquiredDate"), "position lot acquired date"
+        ),
+    }
+
+
 def _normalize_generic_instrument(value: Any) -> dict[str, Any]:
     instrument = _object(value, "Instrument")
     ordered = instrument.get(
@@ -2102,16 +2318,28 @@ def _normalize_generic_instrument(value: Any) -> dict[str, Any]:
     ordered_text = _decimal_text(
         ordered, "instrument ordered quantity", nonnegative=True
     )
+    if "filledQuantity" not in instrument:
+        raise ETradeBrokerReaderIntegrityError(
+            "active-order instrument lacks filled quantity"
+        )
+    if "cancelQuantity" not in instrument:
+        raise ETradeBrokerReaderIntegrityError(
+            "active-order instrument lacks cancel quantity"
+        )
     filled_text = _decimal_text(
-        instrument.get("filledQuantity", "0"),
+        instrument["filledQuantity"],
         "instrument filled quantity",
         nonnegative=True,
     )
     cancel_text = _decimal_text(
-        instrument.get("cancelQuantity", "0"),
+        instrument["cancelQuantity"],
         "instrument cancel quantity",
         nonnegative=True,
     )
+    if Decimal(filled_text) + Decimal(cancel_text) > Decimal(ordered_text):
+        raise ETradeBrokerReaderIntegrityError(
+            "instrument fill/cancel quantities exceed ordered quantity"
+        )
     return {
         "product": _normalize_product(
             instrument.get("Product"), "instrument product"
@@ -2128,7 +2356,13 @@ def _normalize_generic_instrument(value: Any) -> dict[str, Any]:
     }
 
 
-def _normalize_known_leg(value: Any) -> dict[str, Any]:
+def _normalize_known_leg(
+    value: Any, *, leg_number: int
+) -> dict[str, Any]:
+    if type(leg_number) is not int or leg_number not in {1, 2}:
+        raise ETradeBrokerReaderIntegrityError(
+            "known vertical leg number must be 1 or 2"
+        )
     instrument = _object(value, "known Instrument")
     product = _normalize_product(
         instrument.get("Product"), "known option product"
@@ -2162,14 +2396,27 @@ def _normalize_known_leg(value: Any) -> dict[str, Any]:
         "known ordered quantity",
         positive=True,
     )
+    if "filledQuantity" not in instrument:
+        raise ETradeBrokerReaderIntegrityError(
+            "known vertical leg lacks filled quantity"
+        )
+    if "cancelQuantity" not in instrument:
+        raise ETradeBrokerReaderIntegrityError(
+            "known vertical leg lacks cancel quantity"
+        )
     filled = _integral_decimal_text(
-        instrument.get("filledQuantity", "0"),
+        instrument["filledQuantity"],
         "known filled quantity",
         nonnegative=True,
     )
-    if int(filled) > int(quantity):
+    cancelled = _integral_decimal_text(
+        instrument["cancelQuantity"],
+        "known cancel quantity",
+        nonnegative=True,
+    )
+    if int(filled) + int(cancelled) > int(quantity):
         raise ETradeBrokerReaderIntegrityError(
-            "known filled quantity exceeds ordered quantity"
+            "known filled/cancel quantities exceed ordered quantity"
         )
     action = _ascii_text(
         instrument.get("orderAction"), "known order action"
@@ -2179,6 +2426,7 @@ def _normalize_known_leg(value: Any) -> dict[str, Any]:
             "known vertical leg is not opening exposure"
         )
     return {
+        "legNumber": leg_number,
         "symbol": product["symbol"],
         "securityType": product["security_type"],
         "callPut": product["call_put"],
@@ -2186,8 +2434,45 @@ def _normalize_known_leg(value: Any) -> dict[str, Any]:
         "expiryMonth": product["expiry_month"],
         "expiryDay": product["expiry_day"],
         "strikePrice": product["strike_price"],
+        "productId": product["product_id"],
         "orderAction": action,
         "quantityType": "QUANTITY",
         "quantity": quantity,
         "filledQuantity": filled,
+        "cancelQuantity": cancelled,
     }
+
+
+def _canonical_fill_summary_legs(
+    legs: list[dict[str, Any]],
+) -> list[dict[str, Any]]:
+    if (
+        type(legs) is not list
+        or len(legs) != 2
+        or {leg.get("legNumber") for leg in legs} != {1, 2}
+    ):
+        raise ETradeBrokerReaderIntegrityError(
+            "fill summary requires unique leg numbers 1 and 2"
+        )
+    result = [
+        {
+            "leg_number": leg["legNumber"],
+            "product": {
+                "symbol": leg["symbol"],
+                "security_type": leg["securityType"],
+                "call_put": leg["callPut"],
+                "expiry_year": leg["expiryYear"],
+                "expiry_month": leg["expiryMonth"],
+                "expiry_day": leg["expiryDay"],
+                "strike_price": leg["strikePrice"],
+                "product_id": leg["productId"],
+            },
+            "order_action": leg["orderAction"],
+            "ordered_quantity": leg["quantity"],
+            "filled_quantity": leg["filledQuantity"],
+            "cancel_quantity": leg["cancelQuantity"],
+        }
+        for leg in legs
+    ]
+    result.sort(key=_canonical_json)
+    return result

--- a/etrade_python_client/live_trading/etrade_order_gateway.py
+++ b/etrade_python_client/live_trading/etrade_order_gateway.py
@@ -31,6 +31,7 @@ from live_trading.order_intent_ledger import (
     BrokerEvidence,
     CapacityDecisionReceipt,
     IntentRecord,
+    MarginReservation,
     OrderIntent,
     OrderIntentBrokerTermsMismatch,
     OrderIntentIntegrityError,
@@ -38,7 +39,9 @@ from live_trading.order_intent_ledger import (
     OrderIntentLedgerError,
     OrderIntentReconciliationRequired,
     OrderIntentTransitionError,
+    ReservationAbsorptionReceipt,
     RiskEvidence,
+    TerminalAbsorptionRequirement,
     TransportResponseReceipt,
     canonical_order_payload_hash,
 )
@@ -103,6 +106,13 @@ class _ReconciliationContext:
     operation: Literal["ORDER_QUERY", "AMEND_QUERY"]
     client_order_id: str = field(repr=False)
     broker_order_id: str = field(repr=False)
+
+
+@dataclass(frozen=True)
+class _TerminalAbsorptionCandidate:
+    record: IntentRecord
+    terminal_read: BrokerReadEvidenceRef
+    requirement: TerminalAbsorptionRequirement
 
 
 class EtradeOrderGateway:
@@ -208,17 +218,46 @@ class EtradeOrderGateway:
         )
         for blocker in blockers:
             self._reconcile_once(blocker, account)
+        pending_absorptions = self.ledger.pending_terminal_reservations(
+            account.account_id, self.runtime_safety.environment
+        )
+        absorption_candidates = []
+        for pending in pending_absorptions:
+            candidate = self._prepare_terminal_absorption(
+                pending, account
+            )
+            if candidate is not None:
+                absorption_candidates.append(candidate)
+        post_capacity = None
+        if any(
+            candidate.requirement.classification == "FULL_FILL"
+            for candidate in absorption_candidates
+        ):
+            try:
+                post_capacity = self._read_capacity(account)
+            except GatewayReconciliationRequired:
+                post_capacity = None
+        for candidate in absorption_candidates:
+            self._apply_terminal_absorption(
+                candidate,
+                account,
+                post_capacity=(
+                    post_capacity
+                    if candidate.requirement.classification == "FULL_FILL"
+                    else None
+                ),
+            )
         remaining = self.ledger.reconciliation_blockers(
             account.account_id, self.runtime_safety.environment
         )
-        unabsorbed = self.ledger.unabsorbed_filled_reservation_count(
+        unabsorbed = self.ledger.pending_terminal_reservations(
             account.account_id, self.runtime_safety.environment
         )
         if remaining or unabsorbed:
             raise GatewayReconciliationRequired(
                 "gateway remains read-only: "
                 f"{len(remaining)} broker operation(s), "
-                f"{unabsorbed} unabsorbed fill reservation(s)"
+                f"{len(unabsorbed)} pending terminal reservation(s)"
             )
         self._checked_account()
         self._started = True
@@ -629,6 +668,170 @@ class EtradeOrderGateway:
                 "broker evidence could not be applied atomically"
             ) from exc
 
+    def _prepare_terminal_absorption(
+        self,
+        record: IntentRecord,
+        account: SelectedBrokerAccount,
+    ) -> _TerminalAbsorptionCandidate | None:
+        """Collect one exact terminal read before any shared capacity scan."""
+
+        if (
+            record.envelope.account_id != account.account_id
+            or record.envelope.environment
+            != self.runtime_safety.environment
+            or record.broker_order_id is None
+        ):
+            raise GatewayValidationError(
+                "pending terminal reservation has invalid durable identity"
+            )
+        checked = self._checked_account()
+        _require_same_account(account, checked)
+        try:
+            terminal_read = self.reader.query_order(
+                checked, record.broker_order_id
+            )
+        except ETradeBrokerReaderUnavailable:
+            return None
+        except ETradeBrokerReaderIntegrityError as exc:
+            raise GatewayValidationError(
+                "terminal absorption order read violated the durable contract"
+            ) from exc
+        except ETradeBrokerReaderError:
+            return None
+        if (
+            type(terminal_read) is not BrokerReadEvidenceRef
+            or terminal_read.evidence_kind != "ORDER_QUERY"
+        ):
+            raise GatewayValidationError(
+                "terminal absorption requires exact durable order evidence"
+            )
+        try:
+            requirement = self.ledger.terminal_absorption_requirement(
+                record.intent_id, terminal_read
+            )
+        except OrderIntentReconciliationRequired:
+            return None
+        except OrderIntentLedgerError as exc:
+            raise GatewayValidationError(
+                "terminal absorption requirement failed durable validation"
+            ) from exc
+        if (
+            type(requirement) is not TerminalAbsorptionRequirement
+            or requirement.intent_id != record.intent_id
+            or requirement.broker_order_id != record.broker_order_id
+            or requirement.terminal_state != record.state
+            or requirement.terminal_order_evidence_sha256
+            != terminal_read.evidence_sha256
+        ):
+            raise GatewayValidationError(
+                "terminal absorption requirement is not bound to the intent"
+            )
+        try:
+            reservation = self.ledger.get_margin_reservation(
+                record.intent_id
+            )
+        except OrderIntentLedgerError as exc:
+            raise GatewayValidationError(
+                "terminal absorption reservation failed durable validation"
+            ) from exc
+        if (
+            type(reservation) is not MarginReservation
+            or reservation.intent_id != record.intent_id
+            or reservation.account_id != account.account_id
+            or reservation.environment
+            != self.runtime_safety.environment
+            or reservation.state != "FILLED_PENDING_ABSORPTION"
+            or reservation.capacity_decision_sha256
+            != requirement.baseline_capacity_decision_sha256
+        ):
+            raise GatewayValidationError(
+                "terminal absorption requirement is disconnected from risk"
+            )
+        if requirement.post_capacity_required != (
+            requirement.classification == "FULL_FILL"
+        ):
+            raise GatewayValidationError(
+                "terminal absorption requirement has inconsistent capacity needs"
+            )
+        if requirement.classification not in {"ZERO_FILL", "FULL_FILL"}:
+            raise GatewayValidationError(
+                "terminal absorption classification is unsupported"
+            )
+        self._checked_account()
+        return _TerminalAbsorptionCandidate(
+            record=record,
+            terminal_read=terminal_read,
+            requirement=requirement,
+        )
+
+    def _apply_terminal_absorption(
+        self,
+        candidate: _TerminalAbsorptionCandidate,
+        account: SelectedBrokerAccount,
+        *,
+        post_capacity: CapacityDecisionReceipt | None,
+    ) -> bool:
+        """Apply one candidate using a capacity snapshot newer than the batch."""
+
+        if type(candidate) is not _TerminalAbsorptionCandidate:
+            raise GatewayValidationError(
+                "terminal absorption candidate has an invalid type"
+            )
+        record = candidate.record
+        terminal_read = candidate.terminal_read
+        requirement = candidate.requirement
+        if requirement.classification == "FULL_FILL":
+            if post_capacity is None:
+                return False
+            if type(post_capacity) is not CapacityDecisionReceipt:
+                raise GatewayValidationError(
+                    "full-fill absorption requires exact capacity evidence"
+                )
+        elif (
+            requirement.classification == "ZERO_FILL"
+            and post_capacity is not None
+        ):
+            raise GatewayValidationError(
+                "zero-fill absorption cannot use capacity evidence"
+            )
+        checked = self._checked_account()
+        _require_same_account(account, checked)
+        try:
+            receipt = self.ledger.absorb_terminal_reservation(
+                record.intent_id,
+                terminal_read,
+                post_capacity_decision=post_capacity,
+            )
+        except OrderIntentReconciliationRequired:
+            return False
+        except OrderIntentLedgerError as exc:
+            raise GatewayValidationError(
+                "terminal reservation could not be absorbed atomically"
+            ) from exc
+        if (
+            type(receipt) is not ReservationAbsorptionReceipt
+            or receipt.intent_id != record.intent_id
+            or receipt.broker_order_id != record.broker_order_id
+            or receipt.terminal_state != record.state
+            or receipt.classification != requirement.classification
+            or receipt.terminal_order_evidence_sha256
+            != terminal_read.evidence_sha256
+            or (
+                post_capacity is None
+                and receipt.post_capacity_decision_sha256 is not None
+            )
+            or (
+                post_capacity is not None
+                and receipt.post_capacity_decision_sha256
+                != post_capacity.decision_sha256
+            )
+        ):
+            raise GatewayValidationError(
+                "terminal absorption receipt is not bound to the intent"
+            )
+        self._checked_account()
+        return True
+
     def _reconciliation_context(
         self, record: IntentRecord
     ) -> _ReconciliationContext | None:
@@ -697,7 +900,7 @@ class EtradeOrderGateway:
             account.account_id, self.runtime_safety.environment
         ):
             raise GatewayReconciliationRequired(
-                "unabsorbed filled risk blocks mutation"
+                "unabsorbed terminal risk blocks mutation"
             )
 
     def _require_started(self) -> None:

--- a/etrade_python_client/live_trading/order_intent_ledger.py
+++ b/etrade_python_client/live_trading/order_intent_ledger.py
@@ -25,8 +25,8 @@ from typing import Any, Callable, Iterator, Literal, Mapping
 from urllib.parse import quote
 
 
-SCHEMA_VERSION = 11
-_MIGRATABLE_SCHEMA_VERSIONS = frozenset({8, 9, 10})
+SCHEMA_VERSION = 12
+_MIGRATABLE_SCHEMA_VERSIONS = frozenset({8, 9, 10, 11})
 _BUSY_TIMEOUT_MS = 5_000
 _EVIDENCE_MAX_AGE_SECONDS = 300
 _DECIMAL_PRECISION = 50
@@ -69,6 +69,10 @@ _READ_PARSED_HASH_DOMAIN = b"etrade-read-parsed.v1\0"
 _READ_RECEIPT_HASH_DOMAIN = b"etrade-read-receipt.v1\0"
 _READ_MANIFEST_HASH_DOMAIN = b"etrade-read-manifest.v1\0"
 _CAPACITY_DECISION_HASH_DOMAIN = b"etrade-capacity-decision.v1\0"
+_RESERVATION_ABSORPTION_HASH_DOMAIN = (
+    b"etrade-reservation-absorption.v1\0"
+)
+_LOT_PROOF_HASH_DOMAIN = b"etrade-reservation-lot-proof.v1\0"
 _INTENT_KINDS = frozenset({"OPENING", "CLOSING"})
 _ENVIRONMENTS = frozenset({"sandbox", "production"})
 _TERMINAL_STATES = frozenset({"FILLED", "CANCELLED", "REJECTED", "EXPIRED", "FAILED"})
@@ -136,6 +140,590 @@ _LEG_FIELDS = frozenset(
         "quantity",
     }
 )
+
+_REQUIRED_TRIGGER_DEFINITIONS = {
+    "prevent_order_event_update": """
+        CREATE TRIGGER prevent_order_event_update
+        BEFORE UPDATE ON order_events
+        BEGIN
+            SELECT RAISE(ABORT, 'order events are append-only');
+        END
+    """,
+    "prevent_order_event_delete": """
+        CREATE TRIGGER prevent_order_event_delete
+        BEFORE DELETE ON order_events
+        BEGIN
+            SELECT RAISE(ABORT, 'order events are append-only');
+        END
+    """,
+    "prevent_amendment_history_update": """
+        CREATE TRIGGER prevent_amendment_history_update
+        BEFORE UPDATE ON amendment_history
+        BEGIN
+            SELECT RAISE(ABORT, 'amendment history is immutable');
+        END
+    """,
+    "prevent_amendment_history_delete": """
+        CREATE TRIGGER prevent_amendment_history_delete
+        BEFORE DELETE ON amendment_history
+        BEGIN
+            SELECT RAISE(ABORT, 'amendment history is immutable');
+        END
+    """,
+    "prevent_outbound_authorization_update": """
+        CREATE TRIGGER prevent_outbound_authorization_update
+        BEFORE UPDATE ON outbound_authorizations
+        BEGIN
+            SELECT RAISE(ABORT, 'outbound authorizations are immutable');
+        END
+    """,
+    "prevent_outbound_authorization_delete": """
+        CREATE TRIGGER prevent_outbound_authorization_delete
+        BEFORE DELETE ON outbound_authorizations
+        BEGIN
+            SELECT RAISE(ABORT, 'outbound authorizations are immutable');
+        END
+    """,
+    "prevent_transport_send_attempt_update": """
+        CREATE TRIGGER prevent_transport_send_attempt_update
+        BEFORE UPDATE ON transport_send_attempts
+        BEGIN
+            SELECT RAISE(ABORT, 'transport send attempts are immutable');
+        END
+    """,
+    "prevent_transport_send_attempt_delete": """
+        CREATE TRIGGER prevent_transport_send_attempt_delete
+        BEFORE DELETE ON transport_send_attempts
+        BEGIN
+            SELECT RAISE(ABORT, 'transport send attempts are immutable');
+        END
+    """,
+    "prevent_broker_preview_receipt_update": """
+        CREATE TRIGGER prevent_broker_preview_receipt_update
+        BEFORE UPDATE ON broker_preview_receipts
+        BEGIN
+            SELECT RAISE(ABORT, 'broker preview receipts are immutable');
+        END
+    """,
+    "prevent_broker_preview_receipt_delete": """
+        CREATE TRIGGER prevent_broker_preview_receipt_delete
+        BEFORE DELETE ON broker_preview_receipts
+        BEGIN
+            SELECT RAISE(ABORT, 'broker preview receipts are immutable');
+        END
+    """,
+    "prevent_transport_response_receipt_update": """
+        CREATE TRIGGER prevent_transport_response_receipt_update
+        BEFORE UPDATE ON transport_response_receipts
+        BEGIN
+            SELECT RAISE(ABORT, 'transport response receipts are immutable');
+        END
+    """,
+    "prevent_transport_response_receipt_delete": """
+        CREATE TRIGGER prevent_transport_response_receipt_delete
+        BEFORE DELETE ON transport_response_receipts
+        BEGIN
+            SELECT RAISE(ABORT, 'transport response receipts are immutable');
+        END
+    """,
+    "prevent_broker_order_history_update": """
+        CREATE TRIGGER prevent_broker_order_history_update
+        BEFORE UPDATE ON broker_order_history
+        BEGIN
+            SELECT RAISE(ABORT, 'broker order history is immutable');
+        END
+    """,
+    "prevent_broker_order_history_delete": """
+        CREATE TRIGGER prevent_broker_order_history_delete
+        BEFORE DELETE ON broker_order_history
+        BEGIN
+            SELECT RAISE(ABORT, 'broker order history is immutable');
+        END
+    """,
+    "prevent_intent_identity_mutation": """
+        CREATE TRIGGER prevent_intent_identity_mutation
+        BEFORE UPDATE ON order_intents
+        WHEN OLD.account_id != NEW.account_id
+          OR OLD.environment != NEW.environment
+          OR OLD.strategy_id != NEW.strategy_id
+          OR OLD.decision_id != NEW.decision_id
+          OR OLD.idempotency_scope != NEW.idempotency_scope
+          OR OLD.idempotency_key != NEW.idempotency_key
+          OR OLD.intent_kind != NEW.intent_kind
+          OR OLD.wire_payload != NEW.wire_payload
+          OR OLD.canonical_payload != NEW.canonical_payload
+          OR OLD.payload_hash != NEW.payload_hash
+          OR OLD.client_order_id != NEW.client_order_id
+        BEGIN
+            SELECT RAISE(ABORT, 'order intent identity is immutable');
+        END
+    """,
+    "prevent_terminal_rewrite": """
+        CREATE TRIGGER prevent_terminal_rewrite
+        BEFORE UPDATE ON order_intents
+        WHEN OLD.state IN ('FILLED', 'CANCELLED', 'REJECTED', 'EXPIRED', 'FAILED')
+          AND NEW.state != OLD.state
+        BEGIN
+            SELECT RAISE(ABORT, 'terminal order intent cannot transition');
+        END
+    """,
+    "prevent_broker_read_receipt_update": """
+        CREATE TRIGGER prevent_broker_read_receipt_update
+        BEFORE UPDATE ON broker_read_receipts
+        BEGIN
+            SELECT RAISE(ABORT, 'broker read receipts are append-only');
+        END
+    """,
+    "prevent_broker_read_receipt_delete": """
+        CREATE TRIGGER prevent_broker_read_receipt_delete
+        BEFORE DELETE ON broker_read_receipts
+        BEGIN
+            SELECT RAISE(ABORT, 'broker read receipts are append-only');
+        END
+    """,
+    "prevent_broker_read_manifest_update": """
+        CREATE TRIGGER prevent_broker_read_manifest_update
+        BEFORE UPDATE ON broker_read_manifests
+        BEGIN
+            SELECT RAISE(ABORT, 'broker read manifests are append-only');
+        END
+    """,
+    "prevent_broker_read_manifest_delete": """
+        CREATE TRIGGER prevent_broker_read_manifest_delete
+        BEFORE DELETE ON broker_read_manifests
+        BEGIN
+            SELECT RAISE(ABORT, 'broker read manifests are append-only');
+        END
+    """,
+    "prevent_broker_read_member_update": """
+        CREATE TRIGGER prevent_broker_read_member_update
+        BEFORE UPDATE ON broker_read_manifest_members
+        BEGIN
+            SELECT RAISE(ABORT, 'broker read manifest members are append-only');
+        END
+    """,
+    "prevent_broker_read_member_delete": """
+        CREATE TRIGGER prevent_broker_read_member_delete
+        BEFORE DELETE ON broker_read_manifest_members
+        BEGIN
+            SELECT RAISE(ABORT, 'broker read manifest members are append-only');
+        END
+    """,
+    "prevent_capacity_decision_update": """
+        CREATE TRIGGER prevent_capacity_decision_update
+        BEFORE UPDATE ON capacity_decisions
+        BEGIN
+            SELECT RAISE(ABORT, 'capacity decisions are append-only');
+        END
+    """,
+    "prevent_capacity_decision_delete": """
+        CREATE TRIGGER prevent_capacity_decision_delete
+        BEFORE DELETE ON capacity_decisions
+        BEGIN
+            SELECT RAISE(ABORT, 'capacity decisions are append-only');
+        END
+    """,
+    "prevent_reservation_absorption_update": """
+        CREATE TRIGGER prevent_reservation_absorption_update
+        BEFORE UPDATE ON reservation_absorptions
+        BEGIN
+            SELECT RAISE(ABORT, 'reservation absorptions are append-only');
+        END
+    """,
+    "prevent_reservation_absorption_delete": """
+        CREATE TRIGGER prevent_reservation_absorption_delete
+        BEFORE DELETE ON reservation_absorptions
+        BEGIN
+            SELECT RAISE(ABORT, 'reservation absorptions are append-only');
+        END
+    """,
+    "prevent_margin_reservation_delete": """
+        CREATE TRIGGER prevent_margin_reservation_delete
+        BEFORE DELETE ON margin_reservations
+        BEGIN
+            SELECT RAISE(ABORT, 'margin reservations are durable');
+        END
+    """,
+    "prevent_margin_reservation_identity_update": """
+        CREATE TRIGGER prevent_margin_reservation_identity_update
+        BEFORE UPDATE ON margin_reservations
+        WHEN OLD.intent_id IS NOT NEW.intent_id
+           OR OLD.account_id IS NOT NEW.account_id
+           OR OLD.environment IS NOT NEW.environment
+           OR OLD.amount IS NOT NEW.amount
+           OR OLD.risk_decision_id IS NOT NEW.risk_decision_id
+           OR OLD.max_loss_amount IS NOT NEW.max_loss_amount
+           OR OLD.quote_observed_at IS NOT NEW.quote_observed_at
+           OR OLD.quote_digest IS NOT NEW.quote_digest
+           OR OLD.portfolio_observed_at IS NOT NEW.portfolio_observed_at
+           OR OLD.portfolio_snapshot_digest IS NOT NEW.portfolio_snapshot_digest
+           OR OLD.capacity_decision_sha256 IS NOT NEW.capacity_decision_sha256
+           OR OLD.created_at IS NOT NEW.created_at
+        BEGIN
+            SELECT RAISE(ABORT, 'margin reservation identity is immutable');
+        END
+    """,
+    "prevent_margin_reservation_invalid_transition": """
+        CREATE TRIGGER prevent_margin_reservation_invalid_transition
+        BEFORE UPDATE ON margin_reservations
+        WHEN NOT (
+            OLD.state = NEW.state
+            OR (
+                OLD.state = 'ACTIVE'
+                AND NEW.state IN ('FILLED_PENDING_ABSORPTION','RELEASED')
+            )
+            OR (
+                OLD.state = 'FILLED_PENDING_ABSORPTION'
+                AND NEW.state = 'RELEASED'
+            )
+        )
+        BEGIN
+            SELECT RAISE(ABORT, 'invalid margin reservation transition');
+        END
+    """,
+    "prevent_margin_reservation_release_rewrite": """
+        CREATE TRIGGER prevent_margin_reservation_release_rewrite
+        BEFORE UPDATE ON margin_reservations
+        WHEN OLD.state = NEW.state
+         AND (
+            OLD.released_reason_code IS NOT NEW.released_reason_code
+            OR OLD.released_at IS NOT NEW.released_at
+         )
+        BEGIN
+            SELECT RAISE(ABORT, 'margin reservation release metadata is immutable');
+        END
+    """,
+    "validate_margin_reservation_insert": """
+        CREATE TRIGGER validate_margin_reservation_insert
+        BEFORE INSERT ON margin_reservations
+        WHEN NOT (
+            EXISTS (
+                SELECT 1
+                FROM order_intents AS intent
+                JOIN reservation_caps AS cap
+                  ON cap.account_id = intent.account_id
+                 AND cap.environment = intent.environment
+                JOIN capacity_decisions AS decision
+                  ON decision.capacity_decision_sha256 =
+                        NEW.capacity_decision_sha256
+                WHERE intent.intent_id = NEW.intent_id
+                  AND intent.intent_kind = 'OPENING'
+                  AND intent.state = 'INTENT'
+                  AND intent.broker_order_id IS NULL
+                  AND NEW.account_id = intent.account_id
+                  AND NEW.environment = intent.environment
+                  AND NEW.risk_decision_id = intent.decision_id
+                  AND NEW.state = 'ACTIVE'
+                  AND NEW.released_reason_code IS NULL
+                  AND NEW.released_at IS NULL
+                  AND NEW.created_at >= intent.created_at
+                  AND cap.capacity_decision_sha256 =
+                        NEW.capacity_decision_sha256
+                  AND cap.cap_amount = decision.cap_amount
+                  AND cap.broker_buying_power =
+                        decision.broker_buying_power
+                  AND cap.risk_budget = decision.risk_budget
+                  AND cap.observed_at = decision.observed_at
+                  AND cap.portfolio_snapshot_digest =
+                        decision.capacity_snapshot_sha256
+                  AND decision.account_id = NEW.account_id
+                  AND decision.environment = NEW.environment
+                  AND NEW.portfolio_observed_at =
+                        decision.observed_at
+                  AND NEW.portfolio_snapshot_digest =
+                        decision.capacity_snapshot_sha256
+                  AND etrade_decimal_gte(
+                        NEW.amount,
+                        etrade_opening_exposure_floor(
+                            intent.wire_payload
+                        )
+                  ) = 1
+                  AND etrade_decimal_gte(
+                        NEW.max_loss_amount,
+                        etrade_opening_exposure_floor(
+                            intent.wire_payload
+                        )
+                  ) = 1
+                  AND etrade_decimal_gte(
+                        decision.cap_amount,
+                        NEW.amount
+                  ) = 1
+            )
+            OR EXISTS (
+                SELECT 1
+                FROM order_intents AS intent
+                JOIN ledger_metadata AS metadata
+                  ON metadata.singleton = 1
+                WHERE metadata.schema_version IN (8, 9)
+                  AND intent.intent_id = NEW.intent_id
+                  AND intent.intent_kind = 'OPENING'
+                  AND intent.state != 'FAILED'
+                  AND NEW.account_id = intent.account_id
+                  AND NEW.environment = intent.environment
+                  AND NEW.risk_decision_id =
+                        'legacy-opening-migration'
+                  AND NEW.amount =
+                        etrade_opening_exposure_floor(
+                            intent.wire_payload
+                        )
+                  AND NEW.max_loss_amount = NEW.amount
+                  AND NEW.quote_observed_at = intent.created_at
+                  AND NEW.portfolio_observed_at =
+                        intent.created_at
+                  AND NEW.created_at = intent.created_at
+                  AND NEW.quote_digest =
+                        etrade_legacy_reservation_digest(
+                            'quote', metadata.schema_version,
+                            intent.intent_id, intent.payload_hash
+                        )
+                  AND NEW.portfolio_snapshot_digest =
+                        etrade_legacy_reservation_digest(
+                            'portfolio', metadata.schema_version,
+                            intent.intent_id, intent.payload_hash
+                        )
+                  AND NEW.capacity_decision_sha256 IS NULL
+                  AND NEW.released_reason_code IS NULL
+                  AND NEW.released_at IS NULL
+                  AND (
+                        (
+                            intent.state IN (
+                                'FILLED','CANCELLED',
+                                'REJECTED','EXPIRED'
+                            )
+                            AND NEW.state =
+                                'FILLED_PENDING_ABSORPTION'
+                        )
+                        OR
+                        (
+                            intent.state IN (
+                                'INTENT','CLAIMED',
+                                'SUBMISSION_UNKNOWN','SUBMITTED'
+                            )
+                            AND NEW.state = 'ACTIVE'
+                        )
+                  )
+            )
+        )
+        BEGIN
+            SELECT RAISE(ABORT, 'margin reservation insert lacks exact risk provenance');
+        END
+    """,
+    "validate_reservation_created_event_insert": """
+        CREATE TRIGGER validate_reservation_created_event_insert
+        BEFORE INSERT ON order_events
+        WHEN NEW.event_type = 'RESERVATION_CREATED'
+         AND NOT (
+            EXISTS (
+                SELECT 1
+                FROM margin_reservations AS reservation
+                JOIN order_intents AS intent
+                  ON intent.intent_id = reservation.intent_id
+                WHERE reservation.intent_id = NEW.intent_id
+                  AND reservation.account_id = NEW.account_id
+                  AND reservation.environment = NEW.environment
+                  AND reservation.created_at = NEW.created_at
+                  AND reservation.capacity_decision_sha256
+                        IS NOT NULL
+                  AND intent.client_order_id =
+                        NEW.client_order_id
+                  AND intent.state = 'INTENT'
+                  AND NEW.from_state = 'INTENT'
+                  AND NEW.to_state = 'INTENT'
+                  AND NEW.actor = 'system'
+                  AND NEW.reason_code =
+                        'RESERVATION_CREATED'
+                  AND NEW.broker_status IS NULL
+                  AND NEW.broker_order_id IS NULL
+                  AND NEW.observed_at IS NULL
+                  AND NEW.evidence_operation IS NULL
+                  AND NEW.http_status IS NULL
+                  AND NEW.raw_response_digest IS NULL
+                  AND NEW.broker_read_evidence_sha256 IS NULL
+            )
+            OR EXISTS (
+                SELECT 1
+                FROM margin_reservations AS reservation
+                JOIN order_intents AS intent
+                  ON intent.intent_id = reservation.intent_id
+                JOIN ledger_metadata AS metadata
+                  ON metadata.singleton = 1
+                WHERE metadata.schema_version IN (8, 9)
+                  AND reservation.intent_id = NEW.intent_id
+                  AND reservation.account_id = NEW.account_id
+                  AND reservation.environment = NEW.environment
+                  AND reservation.created_at = NEW.created_at
+                  AND reservation.risk_decision_id =
+                        'legacy-opening-migration'
+                  AND reservation.capacity_decision_sha256
+                        IS NULL
+                  AND intent.client_order_id =
+                        NEW.client_order_id
+                  AND NEW.from_state = intent.state
+                  AND NEW.to_state = intent.state
+                  AND NEW.actor = 'schema-migration'
+                  AND NEW.reason_code =
+                        'RESERVATION_CREATED'
+                  AND NEW.broker_status IS NULL
+                  AND NEW.broker_order_id IS NULL
+                  AND NEW.observed_at IS NULL
+                  AND NEW.evidence_operation IS NULL
+                  AND NEW.http_status IS NULL
+                  AND NEW.raw_response_digest IS NULL
+                  AND NEW.broker_read_evidence_sha256 IS NULL
+            )
+        )
+        BEGIN
+            SELECT RAISE(ABORT, 'reservation creation event lacks exact risk provenance');
+        END
+    """,
+    "validate_margin_reservation_pre_post_release": """
+        CREATE TRIGGER validate_margin_reservation_pre_post_release
+        BEFORE UPDATE ON margin_reservations
+        WHEN OLD.state = 'ACTIVE'
+         AND NEW.state = 'RELEASED'
+         AND NOT EXISTS (
+            SELECT 1
+            FROM order_intents AS intent
+            WHERE intent.intent_id = OLD.intent_id
+              AND intent.intent_kind = 'OPENING'
+              AND intent.state = 'FAILED'
+              AND intent.broker_order_id IS NULL
+              AND intent.updated_at = NEW.released_at
+              AND NEW.released_reason_code =
+                    'PRE_POST_ABORTED'
+              AND EXISTS (
+                    SELECT 1
+                    FROM order_events AS claim
+                    WHERE claim.intent_id = intent.intent_id
+                      AND claim.event_type =
+                            'SUBMISSION_CLAIMED'
+                      AND claim.from_state = 'INTENT'
+                      AND claim.to_state = 'CLAIMED'
+                      AND claim.reason_code =
+                            'SUBMISSION_CLAIMED'
+                      AND claim.created_at <= NEW.released_at
+              )
+              AND NOT EXISTS (
+                    SELECT 1
+                    FROM order_events AS post
+                    WHERE post.intent_id = intent.intent_id
+                      AND post.event_type = 'POST_STARTED'
+              )
+              AND NOT EXISTS (
+                    SELECT 1
+                    FROM transport_send_attempts AS attempt
+                    WHERE attempt.intent_id = intent.intent_id
+                      AND attempt.transport_operation =
+                            'SUBMIT_PLACE'
+              )
+              AND NOT EXISTS (
+                    SELECT 1
+                    FROM transport_response_receipts AS response
+                    WHERE response.intent_id = intent.intent_id
+                      AND response.transport_operation =
+                            'SUBMIT_PLACE'
+              )
+         )
+        BEGIN
+            SELECT RAISE(ABORT, 'active reservation release lacks pre-post failure proof');
+        END
+    """,
+    "validate_reservation_absorption_insert": """
+        CREATE TRIGGER validate_reservation_absorption_insert
+        BEFORE INSERT ON reservation_absorptions
+        WHEN NOT EXISTS (
+            SELECT 1
+            FROM order_intents AS intent
+            JOIN margin_reservations AS reservation
+              ON reservation.intent_id = intent.intent_id
+            JOIN broker_read_manifests AS terminal_manifest
+              ON terminal_manifest.evidence_sha256 =
+                    NEW.terminal_order_evidence_sha256
+            WHERE intent.intent_id = NEW.intent_id
+              AND intent.intent_kind = 'OPENING'
+              AND intent.account_id = NEW.account_id
+              AND intent.environment = NEW.environment
+              AND intent.broker_order_id = NEW.broker_order_id
+              AND intent.state = NEW.terminal_state
+              AND reservation.account_id = NEW.account_id
+              AND reservation.environment = NEW.environment
+              AND reservation.state = 'FILLED_PENDING_ABSORPTION'
+              AND reservation.capacity_decision_sha256
+                    IS NEW.baseline_capacity_decision_sha256
+              AND terminal_manifest.evidence_kind = 'ORDER_QUERY'
+              AND terminal_manifest.completeness = 'COMPLETE'
+              AND terminal_manifest.account_id = NEW.account_id
+              AND terminal_manifest.environment = NEW.environment
+              AND terminal_manifest.target_broker_order_id =
+                    NEW.broker_order_id
+              AND (
+                    (
+                        NEW.classification = 'ZERO_FILL'
+                        AND intent.state IN (
+                            'CANCELLED','REJECTED','EXPIRED'
+                        )
+                        AND NEW.absorbed_margin_amount = '0'
+                        AND NEW.post_capacity_decision_sha256 IS NULL
+                        AND NEW.post_capacity_evidence_sha256 IS NULL
+                    )
+                    OR
+                    (
+                        NEW.classification = 'FULL_FILL'
+                        AND intent.state = 'FILLED'
+                        AND NEW.absorbed_margin_amount = reservation.amount
+                        AND EXISTS (
+                            SELECT 1
+                            FROM capacity_decisions AS post_decision
+                            JOIN broker_read_manifests AS post_manifest
+                              ON post_manifest.evidence_sha256 =
+                                    NEW.post_capacity_evidence_sha256
+                            WHERE post_decision.capacity_decision_sha256 =
+                                    NEW.post_capacity_decision_sha256
+                              AND post_decision.evidence_sha256 =
+                                    NEW.post_capacity_evidence_sha256
+                              AND post_decision.account_id = NEW.account_id
+                              AND post_decision.environment = NEW.environment
+                              AND post_manifest.evidence_kind = 'CAPACITY'
+                              AND post_manifest.completeness = 'COMPLETE'
+                              AND post_manifest.account_id = NEW.account_id
+                              AND post_manifest.environment = NEW.environment
+                              AND post_manifest.target_broker_order_id IS NULL
+                        )
+                    )
+              )
+        )
+        BEGIN
+            SELECT RAISE(ABORT, 'reservation absorption is not cross-bound to durable risk');
+        END
+    """,
+    "require_terminal_absorption_receipt": """
+        CREATE TRIGGER require_terminal_absorption_receipt
+        BEFORE UPDATE ON margin_reservations
+        WHEN OLD.state = 'FILLED_PENDING_ABSORPTION'
+         AND NEW.state = 'RELEASED'
+         AND NOT EXISTS (
+            SELECT 1
+            FROM reservation_absorptions
+            WHERE intent_id = OLD.intent_id
+              AND (
+                    (
+                        classification = 'ZERO_FILL'
+                        AND NEW.released_reason_code =
+                            'ZERO_FILL_CONFIRMED'
+                    )
+                    OR
+                    (
+                        classification = 'FULL_FILL'
+                        AND NEW.released_reason_code =
+                            'FULL_FILL_POSITION_ABSORBED'
+                    )
+              )
+        )
+        BEGIN
+            SELECT RAISE(ABORT, 'terminal reservation release lacks absorption receipt');
+        END
+    """,
+}
 
 
 class OrderIntentLedgerError(RuntimeError):
@@ -431,6 +1019,47 @@ class CapacityDecisionReceipt:
 
 
 @dataclass(frozen=True)
+class TerminalAbsorptionRequirement:
+    intent_id: str
+    classification: Literal["ZERO_FILL", "FULL_FILL"]
+    terminal_state: Literal[
+        "FILLED", "CANCELLED", "REJECTED", "EXPIRED"
+    ]
+    broker_order_id: str
+    terminal_order_evidence_sha256: str
+    baseline_capacity_decision_sha256: str | None
+    ordered_quantity: int
+    filled_quantity: int
+    post_capacity_required: bool
+
+
+@dataclass(frozen=True)
+class ReservationAbsorptionReceipt:
+    absorption_sha256: str
+    intent_id: str
+    account_id: str
+    environment: Literal["sandbox", "production"]
+    broker_order_id: str
+    terminal_state: Literal[
+        "FILLED", "CANCELLED", "REJECTED", "EXPIRED"
+    ]
+    classification: Literal["ZERO_FILL", "FULL_FILL"]
+    terminal_order_evidence_sha256: str
+    baseline_capacity_decision_sha256: str | None
+    post_capacity_decision_sha256: str | None
+    post_capacity_evidence_sha256: str | None
+    ordered_quantity: int
+    filled_quantity: int
+    placed_time_epoch_ms: str
+    executed_time_epoch_ms: str | None
+    canonical_lot_proof_json: str
+    lot_proof_sha256: str
+    absorbed_margin_amount: Decimal
+    observed_at: datetime
+    recorded_at: datetime
+
+
+@dataclass(frozen=True)
 class MarginReservation:
     intent_id: str
     account_id: str
@@ -687,6 +1316,61 @@ def _execute_sql_script(conn: sqlite3.Connection, script: str) -> None:
         raise OrderIntentLedgerError(
             "ledger schema script ended with an incomplete statement"
         )
+
+
+def _normalized_schema_sql(sql: str) -> str:
+    return " ".join(sql.strip().rstrip(";").lower().split())
+
+
+def _sqlite_opening_exposure_floor(wire_payload: Any) -> str | None:
+    """SQLite fail-closed adapter for the immutable opening-risk floor."""
+
+    try:
+        payload = json.loads(wire_payload)
+        if type(payload) is not dict:
+            return None
+        return _canonical_amount(_opening_exposure_floor(payload))
+    except Exception:
+        return None
+
+
+def _sqlite_decimal_gte(left: Any, right: Any) -> int:
+    """Compare canonical decimal text without SQLite's floating coercion."""
+
+    try:
+        return int(
+            _canonical_signed_decimal_text(left, "left decimal")
+            >= _canonical_signed_decimal_text(right, "right decimal")
+        )
+    except OrderIntentLedgerError:
+        return 0
+
+
+def _sqlite_legacy_reservation_digest(
+    kind: Any,
+    source_schema_version: Any,
+    intent_id: Any,
+    payload_hash: Any,
+) -> str | None:
+    if (
+        kind not in {"quote", "portfolio"}
+        or type(source_schema_version) is not int
+        or source_schema_version not in {8, 9}
+        or type(intent_id) is not str
+        or type(payload_hash) is not str
+    ):
+        return None
+    material = {
+        "source_schema_version": source_schema_version,
+        "intent_id": intent_id,
+        "payload_hash": payload_hash,
+    }
+    domain = (
+        b"etrade-legacy-reservation-quote.v1\0"
+        if kind == "quote"
+        else b"etrade-legacy-reservation-portfolio.v1\0"
+    )
+    return _domain_json_hash(domain, material)
 
 
 class OrderIntentLedger:
@@ -1564,8 +2248,7 @@ class OrderIntentLedger:
                 )
             cap = conn.execute(
                 """
-                SELECT cap_amount, observed_at, portfolio_snapshot_digest,
-                       capacity_decision_sha256
+                SELECT *
                 FROM reservation_caps
                 WHERE account_id = ? AND environment = ?
                 """,
@@ -1581,6 +2264,7 @@ class OrderIntentLedger:
                 raise OrderIntentIntegrityError(
                     "reservation must name the exact durable capacity decision"
                 )
+            self._verified_reservation_cap_row(conn, cap)
             if (
                 int(cap["observed_at"]) != _to_us(evidence.portfolio_observed_at)
                 or cap["portfolio_snapshot_digest"] != evidence.portfolio_snapshot_digest
@@ -1668,6 +2352,69 @@ class OrderIntentLedger:
                 (account_id, environment),
             ).fetchone()
         return int(row["total"])
+
+    def pending_terminal_reservations(
+        self, account_id: str, environment: str
+    ) -> tuple[IntentRecord, ...]:
+        """Return terminal opening intents whose risk is not yet absorbed."""
+
+        _validate_identity("account_id", account_id)
+        _validate_environment(environment)
+        with self._connection() as conn:
+            rows = conn.execute(
+                """
+                SELECT order_intents.*,
+                       margin_reservations.account_id
+                           AS reservation_account_id,
+                       margin_reservations.environment
+                           AS reservation_environment
+                FROM margin_reservations
+                JOIN order_intents USING (intent_id)
+                WHERE margin_reservations.state =
+                          'FILLED_PENDING_ABSORPTION'
+                  AND (
+                        (
+                            margin_reservations.account_id = ?
+                            AND margin_reservations.environment = ?
+                        )
+                        OR
+                        (
+                            order_intents.account_id = ?
+                            AND order_intents.environment = ?
+                        )
+                  )
+                ORDER BY order_intents.created_at, order_intents.intent_id
+                """,
+                (
+                    account_id,
+                    environment,
+                    account_id,
+                    environment,
+                ),
+            ).fetchall()
+            for row in rows:
+                if (
+                    row["account_id"] != account_id
+                    or row["environment"] != environment
+                    or row["reservation_account_id"] != account_id
+                    or row["reservation_environment"] != environment
+                    or row["intent_kind"] != "OPENING"
+                    or row["state"]
+                    not in {"FILLED", "CANCELLED", "REJECTED", "EXPIRED"}
+                    or row["broker_order_id"] is None
+                    or conn.execute(
+                        """
+                        SELECT 1 FROM reservation_absorptions
+                        WHERE intent_id = ?
+                        """,
+                        (row["intent_id"],),
+                    ).fetchone()
+                    is not None
+                ):
+                    raise OrderIntentIntegrityError(
+                        "pending terminal reservation has inconsistent durable state"
+                    )
+            return tuple(self._intent_from_row(row) for row in rows)
 
     def claim_submission(self, intent_id: str, owner: str, *, lease_seconds: float) -> SubmissionLease:
         _validate_identity("intent_id", intent_id)
@@ -2383,21 +3130,282 @@ class OrderIntentLedger:
             self._append_reconciliation_event(conn, intent_id, intent["state"], terminal_state, "BROKER_TERMINAL_RECONCILED", reason_code, evidence, now)
             return self._intent_from_row(self._require_intent(conn, intent_id))
 
+    def terminal_absorption_requirement(
+        self,
+        intent_id: str,
+        terminal_order_evidence: BrokerReadEvidenceRef,
+    ) -> TerminalAbsorptionRequirement:
+        """Classify an exact fresh terminal read without changing risk state."""
+
+        _validate_identity("intent_id", intent_id)
+        if (
+            type(terminal_order_evidence) is not BrokerReadEvidenceRef
+            or terminal_order_evidence.evidence_kind != "ORDER_QUERY"
+        ):
+            raise OrderIntentValidationError(
+                "terminal absorption requires exact ORDER_QUERY evidence"
+            )
+        now = self._now_us()
+        with self._connection() as conn:
+            requirement, _, _, _, _ = (
+                self._terminal_absorption_requirement_conn(
+                    conn,
+                    intent_id,
+                    terminal_order_evidence,
+                    now,
+                )
+            )
+        return requirement
+
+    def absorb_terminal_reservation(
+        self,
+        intent_id: str,
+        terminal_order_evidence: BrokerReadEvidenceRef,
+        *,
+        post_capacity_decision: CapacityDecisionReceipt | None = None,
+    ) -> ReservationAbsorptionReceipt:
+        """Release terminal reservation state only from exact durable proof."""
+
+        _validate_identity("intent_id", intent_id)
+        if (
+            type(terminal_order_evidence) is not BrokerReadEvidenceRef
+            or terminal_order_evidence.evidence_kind != "ORDER_QUERY"
+        ):
+            raise OrderIntentValidationError(
+                "terminal absorption requires exact ORDER_QUERY evidence"
+            )
+        if (
+            post_capacity_decision is not None
+            and type(post_capacity_decision) is not CapacityDecisionReceipt
+        ):
+            raise OrderIntentValidationError(
+                "post-capacity proof must use the exact decision receipt type"
+            )
+        now = self._now_us()
+        with self._transaction() as conn:
+            existing = conn.execute(
+                """
+                SELECT * FROM reservation_absorptions
+                WHERE intent_id = ?
+                """,
+                (intent_id,),
+            ).fetchone()
+            if existing is not None:
+                receipt = self._reservation_absorption_from_row(
+                    conn, existing
+                )
+                requested_decision = (
+                    None
+                    if post_capacity_decision is None
+                    else post_capacity_decision.decision_sha256
+                )
+                if (
+                    receipt.terminal_order_evidence_sha256
+                    != terminal_order_evidence.evidence_sha256
+                    or receipt.post_capacity_decision_sha256
+                    != requested_decision
+                ):
+                    raise OrderIntentIntegrityError(
+                        "terminal reservation already has a conflicting absorption proof"
+                    )
+                return receipt
+
+            (
+                requirement,
+                intent,
+                reservation,
+                terminal_manifest,
+                terminal_result,
+            ) = self._terminal_absorption_requirement_conn(
+                conn,
+                intent_id,
+                terminal_order_evidence,
+                now,
+            )
+            post_decision_sha256: str | None = None
+            post_evidence_sha256: str | None = None
+            canonical_lot_proof: list[dict[str, Any]] = []
+            absorbed_margin_amount = "0"
+            observed_at = int(terminal_manifest["observed_at"])
+            if requirement.classification == "ZERO_FILL":
+                if post_capacity_decision is not None:
+                    raise OrderIntentIntegrityError(
+                        "zero-fill absorption cannot be rebound to capacity evidence"
+                    )
+            else:
+                if post_capacity_decision is None:
+                    raise OrderIntentReconciliationRequired(
+                        "full-fill absorption requires a newer exact capacity decision"
+                    )
+                (
+                    post_manifest,
+                    post_result,
+                ) = self._verified_capacity_decision_receipt(
+                    conn, post_capacity_decision, now
+                )
+                self._require_latest_complete_manifest_head(
+                    conn, post_manifest, recorded_at_boundary=now
+                )
+                if (
+                    post_manifest["account_id"] != intent["account_id"]
+                    or post_manifest["environment"]
+                    != intent["environment"]
+                    or int(post_manifest["observed_at"])
+                    <= int(terminal_manifest["observed_at"])
+                ):
+                    raise OrderIntentReconciliationRequired(
+                        "post-fill capacity evidence must be newer and bound to the same account"
+                    )
+                if self._manifest_request_started_at(
+                    conn, post_capacity_decision.evidence_sha256
+                ) <= int(terminal_manifest["observed_at"]):
+                    raise OrderIntentReconciliationRequired(
+                        "post-fill capacity read began before terminal order evidence"
+                    )
+                canonical_lot_proof = _terminal_position_lot_proof(
+                    post_result,
+                    broker_order_id=requirement.broker_order_id,
+                    fill_summary=terminal_result["fill_summary"],
+                )
+                post_decision_sha256 = (
+                    post_capacity_decision.decision_sha256
+                )
+                post_evidence_sha256 = (
+                    post_capacity_decision.evidence_sha256
+                )
+                absorbed_margin_amount = reservation["amount"]
+                observed_at = int(post_manifest["observed_at"])
+
+            lot_proof_json = _canonical_read_json(
+                canonical_lot_proof
+            )
+            lot_proof_sha256 = _domain_bytes_hash(
+                _LOT_PROOF_HASH_DOMAIN,
+                lot_proof_json.encode("utf-8"),
+            )
+            fill_summary = terminal_result["fill_summary"]
+            absorption_material = {
+                "intent_id": intent_id,
+                "account_id": intent["account_id"],
+                "environment": intent["environment"],
+                "broker_order_id": requirement.broker_order_id,
+                "terminal_state": requirement.terminal_state,
+                "classification": requirement.classification,
+                "terminal_order_evidence_sha256":
+                    terminal_order_evidence.evidence_sha256,
+                "baseline_capacity_decision_sha256":
+                    reservation["capacity_decision_sha256"],
+                "post_capacity_decision_sha256":
+                    post_decision_sha256,
+                "post_capacity_evidence_sha256":
+                    post_evidence_sha256,
+                "ordered_quantity": requirement.ordered_quantity,
+                "filled_quantity": requirement.filled_quantity,
+                "placed_time_epoch_ms":
+                    fill_summary["placed_time_epoch_ms"],
+                "executed_time_epoch_ms":
+                    fill_summary["executed_time_epoch_ms"],
+                "canonical_lot_proof_json": lot_proof_json,
+                "lot_proof_sha256": lot_proof_sha256,
+                "absorbed_margin_amount": absorbed_margin_amount,
+                "observed_at": observed_at,
+                "recorded_at": now,
+            }
+            absorption_sha256 = _domain_json_hash(
+                _RESERVATION_ABSORPTION_HASH_DOMAIN,
+                absorption_material,
+            )
+            conn.execute(
+                """
+                INSERT INTO reservation_absorptions (
+                    absorption_sha256, intent_id, account_id,
+                    environment, broker_order_id, terminal_state,
+                    classification, terminal_order_evidence_sha256,
+                    baseline_capacity_decision_sha256,
+                    post_capacity_decision_sha256,
+                    post_capacity_evidence_sha256, ordered_quantity,
+                    filled_quantity, placed_time_epoch_ms,
+                    executed_time_epoch_ms, canonical_lot_proof_json,
+                    lot_proof_sha256, absorbed_margin_amount,
+                    observed_at, recorded_at
+                ) VALUES (
+                    ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?,
+                    ?, ?, ?
+                )
+                """,
+                (
+                    absorption_sha256,
+                    *absorption_material.values(),
+                ),
+            )
+            release_reason = (
+                "ZERO_FILL_CONFIRMED"
+                if requirement.classification == "ZERO_FILL"
+                else "FULL_FILL_POSITION_ABSORBED"
+            )
+            conn.execute(
+                """
+                UPDATE margin_reservations
+                SET state = 'RELEASED', released_reason_code = ?,
+                    released_at = ?
+                WHERE intent_id = ?
+                  AND state = 'FILLED_PENDING_ABSORPTION'
+                """,
+                (release_reason, now, intent_id),
+            )
+            if conn.execute("SELECT changes()").fetchone()[0] != 1:
+                raise OrderIntentIntegrityError(
+                    "terminal reservation release was not atomic"
+                )
+            self._append_event(
+                conn,
+                intent_id,
+                (
+                    "RESERVATION_RELEASED"
+                    if requirement.classification == "ZERO_FILL"
+                    else "FILLED_ABSORBED"
+                ),
+                intent["state"],
+                intent["state"],
+                "broker-evidence",
+                (
+                    "RESERVATION_RELEASED"
+                    if requirement.classification == "ZERO_FILL"
+                    else "FILLED_ABSORBED"
+                ),
+                now,
+                broker_status=intent["state"],
+                broker_order_id=requirement.broker_order_id,
+                observed_at=int(terminal_manifest["observed_at"]),
+                evidence_operation="ORDER_QUERY",
+                broker_read_evidence_sha256=(
+                    terminal_order_evidence.evidence_sha256
+                ),
+            )
+            row = conn.execute(
+                """
+                SELECT * FROM reservation_absorptions
+                WHERE intent_id = ?
+                """,
+                (intent_id,),
+            ).fetchone()
+            return self._reservation_absorption_from_row(conn, row)
+
     def absorb_filled_reservation(
         self, intent_id: str, evidence: AccountCapacityEvidence
     ) -> MarginReservation:
-        """Fail closed until R7b can prove a terminal order's position effect.
+        """Retained fail-closed compatibility shim for pre-R7e callers."""
 
-        A newer or merely different account digest cannot prove that the
-        snapshot incorporated this specific order, especially after a partial
-        fill. Keeping the reservation blocks new exposure without guessing.
-        """
         _validate_identity("intent_id", intent_id)
         if type(evidence) is not AccountCapacityEvidence:
-            raise OrderIntentValidationError("absorb_filled_reservation requires typed AccountCapacityEvidence")
-        AccountCapacityEvidence.validate(evidence, _from_us(self._now_us()))
+            raise OrderIntentValidationError(
+                "absorb_filled_reservation requires typed AccountCapacityEvidence"
+            )
+        AccountCapacityEvidence.validate(
+            evidence, _from_us(self._now_us())
+        )
         raise OrderIntentReconciliationRequired(
-            "terminal reservations require R7b position-level absorption evidence"
+            "use durable terminal order and schema-v2 capacity evidence"
         )
 
     def reconciliation_blockers(self, account_id: str, environment: str) -> tuple[IntentRecord, ...]:
@@ -2727,14 +3735,20 @@ class OrderIntentLedger:
 
     def _initialize_schema(self) -> None:
         with self._connection() as conn:
-            metadata_table = conn.execute(
+            metadata_before_lock = conn.execute(
                 "SELECT 1 FROM sqlite_master WHERE type = 'table' AND name = 'ledger_metadata'"
             ).fetchone()
-            if metadata_table is None:
+            if metadata_before_lock is None:
                 mode = conn.execute("PRAGMA journal_mode = DELETE").fetchone()[0]
                 if str(mode).lower() != "delete":
                     raise OrderIntentLedgerError("ledger requires SQLite DELETE journaling in its private directory")
             conn.execute("BEGIN EXCLUSIVE")
+            # Another process may have initialized the securely precreated file
+            # while this constructor waited for the exclusive lock. Re-read the
+            # catalog under that lock rather than acting on stale pre-lock state.
+            metadata_table = conn.execute(
+                "SELECT 1 FROM sqlite_master WHERE type = 'table' AND name = 'ledger_metadata'"
+            ).fetchone()
             if metadata_table is None:
                 conn.execute("CREATE TABLE ledger_metadata (singleton INTEGER PRIMARY KEY CHECK (singleton = 1), schema_version INTEGER NOT NULL)")
             conn.execute("INSERT OR IGNORE INTO ledger_metadata (singleton, schema_version) VALUES (1, ?)", (SCHEMA_VERSION,))
@@ -2809,6 +3823,75 @@ class OrderIntentLedger:
                     CHECK (CAST(amount AS REAL) > 0 AND CAST(max_loss_amount AS REAL) > 0),
                     CHECK (length(quote_digest) = 64 AND length(portfolio_snapshot_digest) = 64),
                     CHECK ((state IN ('ACTIVE', 'FILLED_PENDING_ABSORPTION')) = (released_reason_code IS NULL AND released_at IS NULL))
+                );
+                CREATE TABLE IF NOT EXISTS reservation_absorptions (
+                    absorption_sha256 TEXT PRIMARY KEY
+                        CHECK (length(absorption_sha256) = 64),
+                    intent_id TEXT NOT NULL UNIQUE
+                        REFERENCES order_intents(intent_id),
+                    account_id TEXT NOT NULL,
+                    environment TEXT NOT NULL
+                        CHECK (environment IN ('sandbox', 'production')),
+                    broker_order_id TEXT NOT NULL,
+                    terminal_state TEXT NOT NULL CHECK (
+                        terminal_state IN (
+                            'FILLED','CANCELLED','REJECTED','EXPIRED'
+                        )
+                    ),
+                    classification TEXT NOT NULL
+                        CHECK (classification IN ('ZERO_FILL','FULL_FILL')),
+                    terminal_order_evidence_sha256 TEXT NOT NULL
+                        REFERENCES broker_read_manifests(evidence_sha256),
+                    baseline_capacity_decision_sha256 TEXT
+                        REFERENCES capacity_decisions(
+                            capacity_decision_sha256
+                        ),
+                    post_capacity_decision_sha256 TEXT
+                        REFERENCES capacity_decisions(
+                            capacity_decision_sha256
+                        ),
+                    post_capacity_evidence_sha256 TEXT
+                        REFERENCES broker_read_manifests(evidence_sha256),
+                    ordered_quantity INTEGER NOT NULL
+                        CHECK (ordered_quantity > 0),
+                    filled_quantity INTEGER NOT NULL CHECK (
+                        filled_quantity >= 0
+                        AND filled_quantity <= ordered_quantity
+                    ),
+                    placed_time_epoch_ms TEXT NOT NULL,
+                    executed_time_epoch_ms TEXT,
+                    canonical_lot_proof_json TEXT NOT NULL,
+                    lot_proof_sha256 TEXT NOT NULL
+                        CHECK (length(lot_proof_sha256) = 64),
+                    absorbed_margin_amount TEXT NOT NULL,
+                    observed_at INTEGER NOT NULL,
+                    recorded_at INTEGER NOT NULL,
+                    CHECK (
+                        (
+                            classification = 'ZERO_FILL'
+                            AND terminal_state IN (
+                                'CANCELLED','REJECTED','EXPIRED'
+                            )
+                            AND filled_quantity = 0
+                            AND post_capacity_decision_sha256 IS NULL
+                            AND post_capacity_evidence_sha256 IS NULL
+                            AND executed_time_epoch_ms IS NULL
+                            AND canonical_lot_proof_json = '[]'
+                            AND absorbed_margin_amount = '0'
+                        )
+                        OR
+                        (
+                            classification = 'FULL_FILL'
+                            AND terminal_state = 'FILLED'
+                            AND filled_quantity = ordered_quantity
+                            AND baseline_capacity_decision_sha256 IS NOT NULL
+                            AND post_capacity_decision_sha256 IS NOT NULL
+                            AND post_capacity_evidence_sha256 IS NOT NULL
+                            AND executed_time_epoch_ms IS NOT NULL
+                            AND canonical_lot_proof_json != '[]'
+                            AND CAST(absorbed_margin_amount AS REAL) > 0
+                        )
+                    )
                 );
                 CREATE TABLE IF NOT EXISTS amendment_leases (
                     intent_id TEXT PRIMARY KEY REFERENCES order_intents(intent_id),
@@ -2940,6 +4023,10 @@ class OrderIntentLedger:
                 );
                 CREATE INDEX IF NOT EXISTS idx_intents_account_environment_state ON order_intents(account_id, environment, state);
                 CREATE INDEX IF NOT EXISTS idx_reservations_account_environment ON margin_reservations(account_id, environment, state);
+                CREATE INDEX IF NOT EXISTS idx_reservation_absorptions_account
+                ON reservation_absorptions(
+                    account_id, environment, classification
+                );
                 CREATE TABLE IF NOT EXISTS broker_order_history (
                     broker_order_id TEXT PRIMARY KEY,
                     intent_id TEXT NOT NULL REFERENCES order_intents(intent_id),
@@ -2959,14 +4046,6 @@ class OrderIntentLedger:
                 CREATE TRIGGER IF NOT EXISTS prevent_transport_response_receipt_delete BEFORE DELETE ON transport_response_receipts BEGIN SELECT RAISE(ABORT, 'transport response receipts are immutable'); END;
                 CREATE TRIGGER IF NOT EXISTS prevent_broker_order_history_update BEFORE UPDATE ON broker_order_history BEGIN SELECT RAISE(ABORT, 'broker order history is immutable'); END;
                 CREATE TRIGGER IF NOT EXISTS prevent_broker_order_history_delete BEFORE DELETE ON broker_order_history BEGIN SELECT RAISE(ABORT, 'broker order history is immutable'); END;
-                CREATE TRIGGER IF NOT EXISTS prevent_broker_read_receipt_update BEFORE UPDATE ON broker_read_receipts BEGIN SELECT RAISE(ABORT, 'broker read receipts are append-only'); END;
-                CREATE TRIGGER IF NOT EXISTS prevent_broker_read_receipt_delete BEFORE DELETE ON broker_read_receipts BEGIN SELECT RAISE(ABORT, 'broker read receipts are append-only'); END;
-                CREATE TRIGGER IF NOT EXISTS prevent_broker_read_manifest_update BEFORE UPDATE ON broker_read_manifests BEGIN SELECT RAISE(ABORT, 'broker read manifests are append-only'); END;
-                CREATE TRIGGER IF NOT EXISTS prevent_broker_read_manifest_delete BEFORE DELETE ON broker_read_manifests BEGIN SELECT RAISE(ABORT, 'broker read manifests are append-only'); END;
-                CREATE TRIGGER IF NOT EXISTS prevent_broker_read_member_update BEFORE UPDATE ON broker_read_manifest_members BEGIN SELECT RAISE(ABORT, 'broker read manifest members are append-only'); END;
-                CREATE TRIGGER IF NOT EXISTS prevent_broker_read_member_delete BEFORE DELETE ON broker_read_manifest_members BEGIN SELECT RAISE(ABORT, 'broker read manifest members are append-only'); END;
-                CREATE TRIGGER IF NOT EXISTS prevent_capacity_decision_update BEFORE UPDATE ON capacity_decisions BEGIN SELECT RAISE(ABORT, 'capacity decisions are append-only'); END;
-                CREATE TRIGGER IF NOT EXISTS prevent_capacity_decision_delete BEFORE DELETE ON capacity_decisions BEGIN SELECT RAISE(ABORT, 'capacity decisions are append-only'); END;
                 CREATE TRIGGER IF NOT EXISTS prevent_intent_identity_mutation BEFORE UPDATE ON order_intents
                 WHEN OLD.account_id != NEW.account_id OR OLD.environment != NEW.environment OR OLD.strategy_id != NEW.strategy_id
                    OR OLD.decision_id != NEW.decision_id OR OLD.idempotency_scope != NEW.idempotency_scope
@@ -2979,11 +4058,109 @@ class OrderIntentLedger:
                 BEGIN SELECT RAISE(ABORT, 'terminal order intent cannot transition'); END;
                 """
             )
+            for definition in _REQUIRED_TRIGGER_DEFINITIONS.values():
+                conn.execute(
+                    definition.replace(
+                        "CREATE TRIGGER ",
+                        "CREATE TRIGGER IF NOT EXISTS ",
+                        1,
+                    )
+                )
+            self._migrate_legacy_opening_reservations(
+                conn, current_schema_version
+            )
             if current_schema_version != SCHEMA_VERSION:
                 conn.execute("UPDATE ledger_metadata SET schema_version = ? WHERE singleton = 1", (SCHEMA_VERSION,))
             self._verify_schema_structure(conn)
             conn.execute("COMMIT")
             self._secure_sqlite_sidecars()
+
+    def _migrate_legacy_opening_reservations(
+        self,
+        conn: sqlite3.Connection,
+        source_schema_version: int,
+    ) -> None:
+        """Retain conservative risk for pre-reservation opening intents."""
+
+        if source_schema_version not in {8, 9}:
+            return
+        rows = conn.execute(
+            """
+            SELECT intent.*
+            FROM order_intents AS intent
+            LEFT JOIN margin_reservations AS reservation
+              ON reservation.intent_id = intent.intent_id
+            WHERE intent.intent_kind = 'OPENING'
+              AND intent.state != 'FAILED'
+              AND reservation.intent_id IS NULL
+            ORDER BY intent.intent_id
+            """
+        ).fetchall()
+        for intent in rows:
+            exposure = _canonical_amount(
+                _opening_exposure_floor(
+                    json.loads(intent["wire_payload"])
+                )
+            )
+            migration_material = {
+                "source_schema_version": source_schema_version,
+                "intent_id": intent["intent_id"],
+                "payload_hash": intent["payload_hash"],
+            }
+            quote_digest = _domain_json_hash(
+                b"etrade-legacy-reservation-quote.v1\0",
+                migration_material,
+            )
+            portfolio_digest = _domain_json_hash(
+                b"etrade-legacy-reservation-portfolio.v1\0",
+                migration_material,
+            )
+            reservation_state = (
+                "FILLED_PENDING_ABSORPTION"
+                if intent["state"]
+                in {"FILLED", "CANCELLED", "REJECTED", "EXPIRED"}
+                else "ACTIVE"
+            )
+            observed_at = int(intent["created_at"])
+            conn.execute(
+                """
+                INSERT INTO margin_reservations (
+                    intent_id, account_id, environment, amount,
+                    risk_decision_id, max_loss_amount,
+                    quote_observed_at, quote_digest,
+                    portfolio_observed_at,
+                    portfolio_snapshot_digest,
+                    capacity_decision_sha256, state,
+                    released_reason_code, created_at, released_at
+                ) VALUES (
+                    ?, ?, ?, ?, 'legacy-opening-migration', ?, ?, ?, ?,
+                    ?, NULL, ?, NULL, ?, NULL
+                )
+                """,
+                (
+                    intent["intent_id"],
+                    intent["account_id"],
+                    intent["environment"],
+                    exposure,
+                    exposure,
+                    observed_at,
+                    quote_digest,
+                    observed_at,
+                    portfolio_digest,
+                    reservation_state,
+                    observed_at,
+                ),
+            )
+            self._append_event(
+                conn,
+                intent["intent_id"],
+                "RESERVATION_CREATED",
+                intent["state"],
+                intent["state"],
+                "schema-migration",
+                "RESERVATION_CREATED",
+                observed_at,
+            )
 
     @staticmethod
     def _ensure_broker_read_schema(conn: sqlite3.Connection) -> None:
@@ -3133,6 +4310,14 @@ class OrderIntentLedger:
                 account_id, environment, evidence_kind, observed_at
             )
             """,
+            """
+            CREATE INDEX IF NOT EXISTS idx_broker_read_manifest_heads
+            ON broker_read_manifests (
+                account_id, environment, evidence_kind,
+                target_broker_order_id, completeness,
+                observed_at DESC, created_at
+            )
+            """,
         )
         for statement in statements:
             conn.execute(statement)
@@ -3177,8 +4362,7 @@ class OrderIntentLedger:
                     f"ALTER TABLE {table} ADD COLUMN {column} {definition}"
                 )
 
-    @staticmethod
-    def _verify_schema_structure(conn: sqlite3.Connection) -> None:
+    def _verify_schema_structure(self, conn: sqlite3.Connection) -> None:
         if (
             str(conn.execute("PRAGMA journal_mode").fetchone()[0]).lower()
             != "delete"
@@ -3252,6 +4436,28 @@ class OrderIntentLedger:
             "reservation_caps": {"capacity_decision_sha256"},
             "margin_reservations": {"capacity_decision_sha256"},
             "order_events": {"broker_read_evidence_sha256"},
+            "reservation_absorptions": {
+                "absorption_sha256",
+                "intent_id",
+                "account_id",
+                "environment",
+                "broker_order_id",
+                "terminal_state",
+                "classification",
+                "terminal_order_evidence_sha256",
+                "baseline_capacity_decision_sha256",
+                "post_capacity_decision_sha256",
+                "post_capacity_evidence_sha256",
+                "ordered_quantity",
+                "filled_quantity",
+                "placed_time_epoch_ms",
+                "executed_time_epoch_ms",
+                "canonical_lot_proof_json",
+                "lot_proof_sha256",
+                "absorbed_margin_amount",
+                "observed_at",
+                "recorded_at",
+            },
         }
         table_columns: dict[str, dict[str, sqlite3.Row]] = {}
         for table, required in required_columns.items():
@@ -3295,16 +4501,7 @@ class OrderIntentLedger:
                 raise OrderIntentLedgerError(
                     "broker read receipt schema permits missing provenance"
                 )
-        required_triggers = {
-            "prevent_broker_read_receipt_update",
-            "prevent_broker_read_receipt_delete",
-            "prevent_broker_read_manifest_update",
-            "prevent_broker_read_manifest_delete",
-            "prevent_broker_read_member_update",
-            "prevent_broker_read_member_delete",
-            "prevent_capacity_decision_update",
-            "prevent_capacity_decision_delete",
-        }
+        required_triggers = set(_REQUIRED_TRIGGER_DEFINITIONS)
         trigger_rows = conn.execute(
             """
             SELECT name, sql FROM sqlite_master
@@ -3316,12 +4513,10 @@ class OrderIntentLedger:
             raise OrderIntentLedgerError(
                 "ledger append-only provenance triggers are incomplete"
             )
-        for name in required_triggers:
-            sql = " ".join(str(triggers[name]).lower().split())
-            expected_action = (
-                "before update" if name.endswith("_update") else "before delete"
-            )
-            if expected_action not in sql or "raise(abort" not in sql:
+        for name, definition in _REQUIRED_TRIGGER_DEFINITIONS.items():
+            if _normalized_schema_sql(str(triggers[name])) != (
+                _normalized_schema_sql(definition)
+            ):
                 raise OrderIntentLedgerError(
                     "ledger provenance trigger definition is invalid"
                 )
@@ -3332,6 +4527,9 @@ class OrderIntentLedger:
             ("reservation_caps", "capacity_decisions"),
             ("margin_reservations", "capacity_decisions"),
             ("order_events", "broker_read_manifests"),
+            ("reservation_absorptions", "order_intents"),
+            ("reservation_absorptions", "broker_read_manifests"),
+            ("reservation_absorptions", "capacity_decisions"),
         }
         actual_foreign_keys = {
             (table, row["table"])
@@ -3365,6 +4563,7 @@ class OrderIntentLedger:
             raise OrderIntentLedgerError(
                 "ledger schema metadata is inconsistent"
             )
+        self._verify_durable_risk_state(conn)
 
     @contextmanager
     def _connection(self) -> Iterator[sqlite3.Connection]:
@@ -3373,6 +4572,24 @@ class OrderIntentLedger:
         conn = sqlite3.connect(str(self.path), timeout=_BUSY_TIMEOUT_MS / 1000, isolation_level=None)
         try:
             conn.row_factory = sqlite3.Row
+            conn.create_function(
+                "etrade_opening_exposure_floor",
+                1,
+                _sqlite_opening_exposure_floor,
+                deterministic=True,
+            )
+            conn.create_function(
+                "etrade_decimal_gte",
+                2,
+                _sqlite_decimal_gte,
+                deterministic=True,
+            )
+            conn.create_function(
+                "etrade_legacy_reservation_digest",
+                4,
+                _sqlite_legacy_reservation_digest,
+                deterministic=True,
+            )
             conn.execute("PRAGMA foreign_keys = ON")
             conn.execute(f"PRAGMA busy_timeout = {_BUSY_TIMEOUT_MS}")
             conn.execute("PRAGMA synchronous = FULL")
@@ -4073,12 +5290,664 @@ class OrderIntentLedger:
         _validate_sha256("expected_order_payload_hash", result)
         return result
 
-    @staticmethod
-    def _active_reservation_total(conn: sqlite3.Connection, account_id: str, environment: str) -> Decimal:
-        rows = conn.execute("SELECT amount FROM margin_reservations WHERE account_id = ? AND environment = ? AND state IN ('ACTIVE', 'FILLED_PENDING_ABSORPTION')", (account_id, environment)).fetchall()
+    def _active_reservation_total(
+        self,
+        conn: sqlite3.Connection,
+        account_id: str,
+        environment: str,
+    ) -> Decimal:
+        self._verify_durable_risk_state(
+            conn, account_id=account_id, environment=environment
+        )
+        rows = conn.execute(
+            """
+            SELECT reservation.amount, reservation.state,
+                   reservation.released_reason_code
+            FROM margin_reservations AS reservation
+            JOIN order_intents AS intent USING (intent_id)
+            WHERE (
+                    (
+                        reservation.account_id = ?
+                        AND reservation.environment = ?
+                    )
+                    OR
+                    (
+                        intent.account_id = ?
+                        AND intent.environment = ?
+                    )
+                  )
+              AND (
+                    reservation.state IN (
+                        'ACTIVE','FILLED_PENDING_ABSORPTION'
+                    )
+                    OR (
+                        reservation.state = 'RELEASED'
+                        AND reservation.released_reason_code =
+                            'FULL_FILL_POSITION_ABSORBED'
+                    )
+                  )
+            """,
+            (account_id, environment, account_id, environment),
+        ).fetchall()
         with localcontext() as decimal_context:
             decimal_context.prec = _DECIMAL_PRECISION
-            return sum((Decimal(row["amount"]) for row in rows), Decimal("0"))
+            return sum(
+                (Decimal(row["amount"]) for row in rows), Decimal("0")
+            )
+
+    def _verify_reservation_creation_provenance(
+        self,
+        conn: sqlite3.Connection,
+        reservation: sqlite3.Row,
+        amount: Decimal,
+    ) -> None:
+        """Rebuild the immutable opening floor and its creation event."""
+
+        try:
+            wire_payload = json.loads(
+                reservation["intent_wire_payload"]
+            )
+        except (TypeError, json.JSONDecodeError) as exc:
+            raise OrderIntentIntegrityError(
+                "reservation intent payload is not valid JSON"
+            ) from exc
+        if type(wire_payload) is not dict:
+            raise OrderIntentIntegrityError(
+                "reservation intent payload is not an object"
+            )
+        try:
+            exposure_floor = _opening_exposure_floor(wire_payload)
+        except OrderIntentLedgerError as exc:
+            raise OrderIntentIntegrityError(
+                "reservation intent no longer has a defensible exposure floor"
+            ) from exc
+        max_loss = _canonical_signed_decimal_text(
+            reservation["max_loss_amount"],
+            "margin reservation max loss",
+        )
+        if amount < exposure_floor or max_loss < exposure_floor:
+            raise OrderIntentIntegrityError(
+                "margin reservation understates its immutable opening exposure"
+            )
+
+        creation_events = conn.execute(
+            """
+            SELECT * FROM order_events
+            WHERE intent_id = ?
+              AND event_type = 'RESERVATION_CREATED'
+            ORDER BY sequence
+            """,
+            (reservation["intent_id"],),
+        ).fetchall()
+        if len(creation_events) != 1:
+            raise OrderIntentIntegrityError(
+                "margin reservation lacks one creation event"
+            )
+        event = creation_events[0]
+        if (
+            event["account_id"] != reservation["account_id"]
+            or event["environment"] != reservation["environment"]
+            or event["client_order_id"]
+            != reservation["intent_client_order_id"]
+            or event["reason_code"] != "RESERVATION_CREATED"
+            or int(event["created_at"])
+            != int(reservation["created_at"])
+            or any(
+                event[field] is not None
+                for field in (
+                    "broker_status",
+                    "broker_order_id",
+                    "observed_at",
+                    "evidence_operation",
+                    "http_status",
+                    "raw_response_digest",
+                    "broker_read_evidence_sha256",
+                )
+            )
+        ):
+            raise OrderIntentIntegrityError(
+                "margin reservation creation event is disconnected"
+            )
+
+        decision_sha256 = reservation["capacity_decision_sha256"]
+        if decision_sha256 is None:
+            matching_versions = []
+            for source_version in (8, 9):
+                material = {
+                    "source_schema_version": source_version,
+                    "intent_id": reservation["intent_id"],
+                    "payload_hash": reservation["intent_payload_hash"],
+                }
+                if (
+                    reservation["quote_digest"]
+                    == _domain_json_hash(
+                        b"etrade-legacy-reservation-quote.v1\0",
+                        material,
+                    )
+                    and reservation["portfolio_snapshot_digest"]
+                    == _domain_json_hash(
+                        b"etrade-legacy-reservation-portfolio.v1\0",
+                        material,
+                    )
+                ):
+                    matching_versions.append(source_version)
+            synthetic_migration = (
+                matching_versions in ([8], [9])
+                and reservation["risk_decision_id"]
+                == "legacy-opening-migration"
+                and amount == exposure_floor
+                and max_loss == exposure_floor
+                and int(reservation["quote_observed_at"])
+                == int(reservation["intent_created_at"])
+                and int(reservation["portfolio_observed_at"])
+                == int(reservation["intent_created_at"])
+                and int(reservation["created_at"])
+                == int(reservation["intent_created_at"])
+                and event["actor"] == "schema-migration"
+                and event["from_state"] == event["to_state"]
+                and event["from_state"]
+                in {
+                    "INTENT",
+                    "CLAIMED",
+                    "SUBMISSION_UNKNOWN",
+                    "SUBMITTED",
+                    "FILLED",
+                    "CANCELLED",
+                    "REJECTED",
+                    "EXPIRED",
+                }
+            )
+            historical_uncapped = (
+                reservation["risk_decision_id"]
+                == reservation["intent_decision_id"]
+                and int(reservation["created_at"])
+                >= int(reservation["intent_created_at"])
+                and event["actor"] == "system"
+                and event["from_state"] == "INTENT"
+                and event["to_state"] == "INTENT"
+            )
+            if not synthetic_migration and not historical_uncapped:
+                raise OrderIntentIntegrityError(
+                    "uncapped reservation lacks exact legacy migration provenance"
+                )
+        elif (
+            reservation["risk_decision_id"]
+            != reservation["intent_decision_id"]
+            or int(reservation["created_at"])
+            < int(reservation["intent_created_at"])
+            or event["actor"] != "system"
+            or event["from_state"] != "INTENT"
+            or event["to_state"] != "INTENT"
+        ):
+            raise OrderIntentIntegrityError(
+                "margin reservation creation provenance changed"
+            )
+
+        state = reservation["state"]
+        intent_state = reservation["intent_state"]
+        if (
+            state == "ACTIVE"
+            and intent_state
+            not in {
+                "INTENT",
+                "CLAIMED",
+                "SUBMISSION_UNKNOWN",
+                "SUBMITTED",
+            }
+        ) or (
+            state == "FILLED_PENDING_ABSORPTION"
+            and intent_state
+            not in {"FILLED", "CANCELLED", "REJECTED", "EXPIRED"}
+        ):
+            raise OrderIntentIntegrityError(
+                "margin reservation lifecycle diverges from its intent"
+            )
+
+    @staticmethod
+    def _verify_pre_post_release_provenance(
+        conn: sqlite3.Connection,
+        reservation: sqlite3.Row,
+    ) -> None:
+        if (
+            reservation["intent_kind"] != "OPENING"
+            or reservation["intent_state"] != "FAILED"
+            or reservation["intent_broker_order_id"] is not None
+            or reservation["released_reason_code"]
+            != "PRE_POST_ABORTED"
+            or reservation["released_at"] is None
+            or int(reservation["released_at"])
+            != int(reservation["intent_updated_at"])
+        ):
+            raise OrderIntentIntegrityError(
+                "non-absorption reservation release is not a pre-post failure"
+            )
+        posted = conn.execute(
+            """
+            SELECT 1
+            FROM order_events
+            WHERE intent_id = ? AND event_type = 'POST_STARTED'
+            UNION ALL
+            SELECT 1
+            FROM transport_send_attempts
+            WHERE intent_id = ?
+              AND transport_operation = 'SUBMIT_PLACE'
+            UNION ALL
+            SELECT 1
+            FROM transport_response_receipts
+            WHERE intent_id = ?
+              AND transport_operation = 'SUBMIT_PLACE'
+            LIMIT 1
+            """,
+            (
+                reservation["intent_id"],
+                reservation["intent_id"],
+                reservation["intent_id"],
+            ),
+        ).fetchone()
+        if posted is not None:
+            raise OrderIntentIntegrityError(
+                "pre-post reservation release has durable POST evidence"
+            )
+        events = conn.execute(
+            """
+            SELECT * FROM order_events
+            WHERE intent_id = ?
+              AND event_type IN (
+                    'SUBMISSION_CLAIMED',
+                    'RESERVATION_RELEASED',
+                    'PRE_POST_FAILED'
+              )
+            ORDER BY sequence
+            """,
+            (reservation["intent_id"],),
+        ).fetchall()
+        claims = [
+            event
+            for event in events
+            if event["event_type"] == "SUBMISSION_CLAIMED"
+        ]
+        releases = [
+            event
+            for event in events
+            if event["event_type"] == "RESERVATION_RELEASED"
+        ]
+        failures = [
+            event
+            for event in events
+            if event["event_type"] == "PRE_POST_FAILED"
+        ]
+        if len(claims) != 1 or len(releases) != 1 or len(failures) != 1:
+            raise OrderIntentIntegrityError(
+                "pre-post reservation release event chain is incomplete"
+            )
+        claim, release, failure = claims[0], releases[0], failures[0]
+        released_at = int(reservation["released_at"])
+        identity = (
+            reservation["account_id"],
+            reservation["environment"],
+            reservation["intent_client_order_id"],
+        )
+        empty_evidence_fields = (
+            "broker_status",
+            "broker_order_id",
+            "observed_at",
+            "evidence_operation",
+            "http_status",
+            "raw_response_digest",
+            "broker_read_evidence_sha256",
+        )
+        if (
+            (
+                claim["account_id"],
+                claim["environment"],
+                claim["client_order_id"],
+            )
+            != identity
+            or claim["from_state"] != "INTENT"
+            or claim["to_state"] != "CLAIMED"
+            or claim["reason_code"] != "SUBMISSION_CLAIMED"
+            or (
+                release["account_id"],
+                release["environment"],
+                release["client_order_id"],
+            )
+            != identity
+            or release["from_state"] != "FAILED"
+            or release["to_state"] != "FAILED"
+            or release["actor"] != "system"
+            or release["reason_code"] != "RESERVATION_RELEASED"
+            or int(release["created_at"]) != released_at
+            or (
+                failure["account_id"],
+                failure["environment"],
+                failure["client_order_id"],
+            )
+            != identity
+            or failure["from_state"] != "CLAIMED"
+            or failure["to_state"] != "FAILED"
+            or failure["actor"] != claim["actor"]
+            or failure["reason_code"] != "PRE_POST_ABORTED"
+            or int(failure["created_at"]) != released_at
+            or int(release["sequence"]) + 1
+            != int(failure["sequence"])
+            or int(claim["sequence"]) >= int(release["sequence"])
+            or any(
+                event[field] is not None
+                for event in (claim, release, failure)
+                for field in empty_evidence_fields
+            )
+        ):
+            raise OrderIntentIntegrityError(
+                "pre-post reservation release event semantics changed"
+            )
+
+    def _verify_durable_risk_state(
+        self,
+        conn: sqlite3.Connection,
+        *,
+        account_id: str | None = None,
+        environment: str | None = None,
+    ) -> None:
+        """Fail closed if durable reservation and absorption state diverge."""
+
+        if (account_id is None) != (environment is None):
+            raise OrderIntentIntegrityError(
+                "durable risk verification scope is incomplete"
+            )
+        parameters: tuple[str, ...] = ()
+        reservation_scope = ""
+        intent_scope = ""
+        absorption_scope = ""
+        cap_scope = ""
+        decision_cache: dict[
+            str, tuple[sqlite3.Row, sqlite3.Row, dict[str, Any]]
+        ] = {}
+        absorption_cache: dict[
+            str, ReservationAbsorptionReceipt
+        ] = {}
+        if account_id is not None and environment is not None:
+            parameters = (
+                account_id,
+                environment,
+                account_id,
+                environment,
+            )
+            reservation_scope = """
+                WHERE (
+                    (
+                        reservation.account_id = ?
+                        AND reservation.environment = ?
+                    )
+                    OR
+                    (
+                        intent.account_id = ?
+                        AND intent.environment = ?
+                    )
+                )
+            """
+            intent_scope = """
+                AND intent.account_id = ? AND intent.environment = ?
+            """
+            absorption_scope = """
+                WHERE (
+                    (
+                        absorption.account_id = ?
+                        AND absorption.environment = ?
+                    )
+                    OR
+                    (
+                        intent.account_id = ?
+                        AND intent.environment = ?
+                    )
+                )
+            """
+            cap_scope = """
+                WHERE (
+                    (
+                        cap.account_id = ?
+                        AND cap.environment = ?
+                    )
+                    OR
+                    (
+                        decision.account_id = ?
+                        AND decision.environment = ?
+                    )
+                )
+            """
+
+        missing_reservation = conn.execute(
+            f"""
+            SELECT intent.intent_id
+            FROM order_intents AS intent
+            LEFT JOIN margin_reservations AS reservation
+              ON reservation.intent_id = intent.intent_id
+            WHERE intent.intent_kind = 'OPENING'
+              AND intent.state != 'FAILED'
+              AND reservation.intent_id IS NULL
+              AND (
+                    intent.state != 'INTENT'
+                    OR EXISTS (
+                        SELECT 1
+                        FROM order_events AS event
+                        WHERE event.intent_id = intent.intent_id
+                          AND event.event_type = 'RESERVATION_CREATED'
+                    )
+                  )
+              {intent_scope}
+            LIMIT 1
+            """,
+            (() if account_id is None else (account_id, environment)),
+        ).fetchone()
+        if missing_reservation is not None:
+            raise OrderIntentIntegrityError(
+                "opening intent lost its durable margin reservation"
+            )
+
+        reservations = conn.execute(
+            f"""
+            SELECT reservation.*, intent.account_id AS intent_account_id,
+                   intent.environment AS intent_environment,
+                   intent.intent_kind AS intent_kind,
+                   intent.state AS intent_state,
+                   intent.decision_id AS intent_decision_id,
+                   intent.wire_payload AS intent_wire_payload,
+                   intent.payload_hash AS intent_payload_hash,
+                   intent.client_order_id AS intent_client_order_id,
+                   intent.broker_order_id AS intent_broker_order_id,
+                   intent.created_at AS intent_created_at,
+                   intent.updated_at AS intent_updated_at
+            FROM margin_reservations AS reservation
+            JOIN order_intents AS intent USING (intent_id)
+            {reservation_scope}
+            ORDER BY reservation.intent_id
+            """,
+            parameters,
+        ).fetchall()
+        for reservation in reservations:
+            if (
+                reservation["intent_kind"] != "OPENING"
+                or reservation["account_id"]
+                != reservation["intent_account_id"]
+                or reservation["environment"]
+                != reservation["intent_environment"]
+            ):
+                raise OrderIntentIntegrityError(
+                    "margin reservation identity diverges from its opening intent"
+                )
+            amount = _canonical_signed_decimal_text(
+                reservation["amount"], "margin reservation amount"
+            )
+            if amount <= 0:
+                raise OrderIntentIntegrityError(
+                    "margin reservation amount is not positive"
+                )
+            self._verify_reservation_creation_provenance(
+                conn, reservation, amount
+            )
+            decision_sha256 = reservation["capacity_decision_sha256"]
+            if decision_sha256 is not None:
+                decision, _manifest, _result = (
+                    self._cached_capacity_decision_row(
+                        conn, decision_sha256, decision_cache
+                    )
+                )
+                if (
+                    decision["account_id"] != reservation["account_id"]
+                    or decision["environment"] != reservation["environment"]
+                    or int(decision["observed_at"])
+                    != int(reservation["portfolio_observed_at"])
+                    or decision["capacity_snapshot_sha256"]
+                    != reservation["portfolio_snapshot_digest"]
+                ):
+                    raise OrderIntentIntegrityError(
+                        "margin reservation baseline decision chain diverges"
+                    )
+            absorption = conn.execute(
+                """
+                SELECT * FROM reservation_absorptions
+                WHERE intent_id = ?
+                """,
+                (reservation["intent_id"],),
+            ).fetchone()
+            absorption_reason = reservation["released_reason_code"] in {
+                "ZERO_FILL_CONFIRMED",
+                "FULL_FILL_POSITION_ABSORBED",
+            }
+            if reservation["state"] == "RELEASED" and absorption_reason:
+                if absorption is None:
+                    raise OrderIntentIntegrityError(
+                        "released terminal reservation lost its absorption receipt"
+                    )
+                absorption_sha256 = absorption["absorption_sha256"]
+                receipt = absorption_cache.get(absorption_sha256)
+                if receipt is None:
+                    receipt = self._reservation_absorption_from_row(
+                        conn,
+                        absorption,
+                        decision_cache=decision_cache,
+                    )
+                    absorption_cache[absorption_sha256] = receipt
+                expected_classification = (
+                    "ZERO_FILL"
+                    if reservation["released_reason_code"]
+                    == "ZERO_FILL_CONFIRMED"
+                    else "FULL_FILL"
+                )
+                if receipt.classification != expected_classification:
+                    raise OrderIntentIntegrityError(
+                        "released terminal reservation has the wrong absorption class"
+                    )
+            elif absorption is not None:
+                raise OrderIntentIntegrityError(
+                    "absorption receipt is disconnected from released terminal risk"
+                )
+            elif reservation["state"] == "RELEASED":
+                self._verify_pre_post_release_provenance(
+                    conn, reservation
+                )
+            if (
+                reservation["intent_state"] == "FILLED"
+                and reservation["state"] == "RELEASED"
+                and reservation["released_reason_code"]
+                != "FULL_FILL_POSITION_ABSORBED"
+            ):
+                raise OrderIntentIntegrityError(
+                    "filled opening reservation was released without retained risk"
+                )
+
+        absorptions = conn.execute(
+            f"""
+            SELECT absorption.*
+            FROM reservation_absorptions AS absorption
+            JOIN order_intents AS intent USING (intent_id)
+            {absorption_scope}
+            ORDER BY absorption.intent_id
+            """,
+            parameters,
+        ).fetchall()
+        for absorption in absorptions:
+            absorption_sha256 = absorption["absorption_sha256"]
+            if absorption_sha256 not in absorption_cache:
+                absorption_cache[absorption_sha256] = (
+                    self._reservation_absorption_from_row(
+                        conn,
+                        absorption,
+                        decision_cache=decision_cache,
+                    )
+                )
+
+        caps = conn.execute(
+            f"""
+            SELECT cap.*
+            FROM reservation_caps AS cap
+            LEFT JOIN capacity_decisions AS decision
+              ON decision.capacity_decision_sha256 =
+                    cap.capacity_decision_sha256
+            {cap_scope}
+            ORDER BY cap.account_id, cap.environment
+            """,
+            parameters,
+        ).fetchall()
+        for cap in caps:
+            if cap["capacity_decision_sha256"] is not None:
+                self._verified_reservation_cap_row(
+                    conn, cap, decision_cache=decision_cache
+                )
+
+    def _cached_capacity_decision_row(
+        self,
+        conn: sqlite3.Connection,
+        decision_sha256: str,
+        cache: dict[
+            str, tuple[sqlite3.Row, sqlite3.Row, dict[str, Any]]
+        ] | None,
+    ) -> tuple[sqlite3.Row, sqlite3.Row, dict[str, Any]]:
+        if cache is None:
+            return self._verified_capacity_decision_row(
+                conn, decision_sha256
+            )
+        cached = cache.get(decision_sha256)
+        if cached is None:
+            cached = self._verified_capacity_decision_row(
+                conn, decision_sha256
+            )
+            cache[decision_sha256] = cached
+        return cached
+
+    def _verified_reservation_cap_row(
+        self,
+        conn: sqlite3.Connection,
+        cap: sqlite3.Row,
+        *,
+        decision_cache: dict[
+            str, tuple[sqlite3.Row, sqlite3.Row, dict[str, Any]]
+        ] | None = None,
+    ) -> sqlite3.Row:
+        decision_sha256 = cap["capacity_decision_sha256"]
+        if decision_sha256 is None:
+            raise OrderIntentIntegrityError(
+                "reservation cap lacks a durable capacity decision"
+            )
+        decision, _manifest, _result = (
+            self._cached_capacity_decision_row(
+                conn, decision_sha256, decision_cache
+            )
+        )
+        if (
+            cap["account_id"] != decision["account_id"]
+            or cap["environment"] != decision["environment"]
+            or cap["cap_amount"] != decision["cap_amount"]
+            or cap["broker_buying_power"]
+            != decision["broker_buying_power"]
+            or cap["risk_budget"] != decision["risk_budget"]
+            or int(cap["observed_at"]) != int(decision["observed_at"])
+            or cap["portfolio_snapshot_digest"]
+            != decision["capacity_snapshot_sha256"]
+        ):
+            raise OrderIntentIntegrityError(
+                "reservation cap conflicts with its content-addressed decision"
+            )
+        return decision
 
     def _release_reservation(self, conn: sqlite3.Connection, intent_id: str, reason_code: str, now: int) -> None:
         reservation = conn.execute("SELECT * FROM margin_reservations WHERE intent_id = ?", (intent_id,)).fetchone()
@@ -4247,6 +6116,740 @@ class OrderIntentLedger:
                 "broker read manifest content hash does not verify"
             )
         return manifest, result
+
+    def _require_latest_complete_manifest_head(
+        self,
+        conn: sqlite3.Connection,
+        selected: sqlite3.Row,
+        *,
+        recorded_at_boundary: int,
+    ) -> None:
+        """Require selected evidence to be the unique semantic head at a time."""
+
+        if int(selected["created_at"]) > recorded_at_boundary:
+            raise OrderIntentReconciliationRequired(
+                "selected broker evidence did not exist at the decision boundary"
+            )
+        candidates = conn.execute(
+            """
+            SELECT evidence_sha256
+            FROM broker_read_manifests
+            WHERE evidence_kind = ?
+              AND account_id = ?
+              AND environment = ?
+              AND completeness = 'COMPLETE'
+              AND created_at <= ?
+              AND observed_at >= ?
+              AND (
+                    (
+                        ? IS NULL
+                        AND target_broker_order_id IS NULL
+                    )
+                    OR target_broker_order_id = ?
+                  )
+            ORDER BY observed_at DESC, evidence_sha256
+            """,
+            (
+                selected["evidence_kind"],
+                selected["account_id"],
+                selected["environment"],
+                recorded_at_boundary,
+                int(selected["observed_at"]),
+                selected["target_broker_order_id"],
+                selected["target_broker_order_id"],
+            ),
+        ).fetchall()
+        if not candidates:
+            raise OrderIntentReconciliationRequired(
+                "selected broker evidence has no complete durable head"
+            )
+        selected_observed_at = int(selected["observed_at"])
+        selected_result_sha256 = selected["canonical_result_sha256"]
+        for candidate_ref in candidates:
+            candidate, _result = self._verified_broker_read_manifest(
+                conn, candidate_ref["evidence_sha256"]
+            )
+            if (
+                candidate["account_id_key"]
+                != selected["account_id_key"]
+                or candidate["institution_type"]
+                != selected["institution_type"]
+                or candidate["origin"] != selected["origin"]
+            ):
+                raise OrderIntentReconciliationRequired(
+                    "complete broker evidence heads disagree on account binding"
+                )
+            candidate_observed_at = int(candidate["observed_at"])
+            if candidate_observed_at > selected_observed_at:
+                raise OrderIntentReconciliationRequired(
+                    "selected broker evidence has been superseded"
+                )
+            if (
+                candidate_observed_at == selected_observed_at
+                and candidate["canonical_result_sha256"]
+                != selected_result_sha256
+            ):
+                raise OrderIntentReconciliationRequired(
+                    "equal-time complete broker evidence heads conflict"
+                )
+
+    @staticmethod
+    def _manifest_request_started_at(
+        conn: sqlite3.Connection, evidence_sha256: str
+    ) -> int:
+        row = conn.execute(
+            """
+            SELECT MIN(receipt.request_started_at) AS first_started_at,
+                   COUNT(*) AS receipt_count
+            FROM broker_read_manifest_members AS member
+            JOIN broker_read_receipts AS receipt
+              ON receipt.receipt_sha256 = member.receipt_sha256
+            WHERE member.evidence_sha256 = ?
+            """,
+            (evidence_sha256,),
+        ).fetchone()
+        if row is None or int(row["receipt_count"]) <= 0:
+            raise OrderIntentIntegrityError(
+                "broker read manifest lost its request sequence"
+            )
+        return int(row["first_started_at"])
+
+    def _require_no_later_order_contradiction(
+        self,
+        conn: sqlite3.Connection,
+        selected_manifest: sqlite3.Row,
+        selected_result: dict[str, Any],
+        *,
+        recorded_at_boundary: int,
+    ) -> None:
+        semantic_keys = (
+            "schema",
+            "broker_order_id",
+            "raw_status",
+            "outcome",
+            "order_payload_hashes",
+            "not_found",
+            "replacement_links",
+            "fill_summary",
+        )
+        selected_semantics = {
+            key: selected_result.get(key) for key in semantic_keys
+        }
+        rows = conn.execute(
+            """
+            SELECT evidence_sha256
+            FROM broker_read_manifests
+            WHERE evidence_kind = 'ORDER_QUERY'
+              AND account_id = ?
+              AND environment = ?
+              AND target_broker_order_id = ?
+              AND completeness = 'COMPLETE'
+              AND created_at > ?
+              AND observed_at >= ?
+            ORDER BY observed_at, evidence_sha256
+            """,
+            (
+                selected_manifest["account_id"],
+                selected_manifest["environment"],
+                selected_manifest["target_broker_order_id"],
+                recorded_at_boundary,
+                int(selected_manifest["observed_at"]),
+            ),
+        ).fetchall()
+        for row in rows:
+            candidate, result = self._verified_broker_read_manifest(
+                conn, row["evidence_sha256"]
+            )
+            if (
+                candidate["account_id_key"]
+                != selected_manifest["account_id_key"]
+                or candidate["institution_type"]
+                != selected_manifest["institution_type"]
+                or candidate["origin"] != selected_manifest["origin"]
+                or {
+                    key: result.get(key) for key in semantic_keys
+                }
+                != selected_semantics
+            ):
+                raise OrderIntentIntegrityError(
+                    "later complete order evidence contradicts absorbed risk"
+                )
+
+    def _terminal_absorption_requirement_conn(
+        self,
+        conn: sqlite3.Connection,
+        intent_id: str,
+        terminal_order_evidence: BrokerReadEvidenceRef,
+        now: int,
+    ) -> tuple[
+        TerminalAbsorptionRequirement,
+        sqlite3.Row,
+        sqlite3.Row,
+        sqlite3.Row,
+        dict[str, Any],
+    ]:
+        intent = self._require_intent(conn, intent_id)
+        reservation = conn.execute(
+            """
+            SELECT * FROM margin_reservations WHERE intent_id = ?
+            """,
+            (intent_id,),
+        ).fetchone()
+        if (
+            intent["intent_kind"] != "OPENING"
+            or intent["state"]
+            not in {"FILLED", "CANCELLED", "REJECTED", "EXPIRED"}
+            or intent["broker_order_id"] is None
+            or reservation is None
+        ):
+            raise OrderIntentReconciliationRequired(
+                "only a terminal opening intent with durable risk can be absorbed"
+            )
+        if reservation["state"] != "FILLED_PENDING_ABSORPTION":
+            raise OrderIntentReconciliationRequired(
+                "terminal reservation is not pending absorption"
+            )
+        if (
+            reservation["account_id"] != intent["account_id"]
+            or reservation["environment"] != intent["environment"]
+        ):
+            raise OrderIntentIntegrityError(
+                "terminal reservation identity conflicts with its intent"
+            )
+        manifest, result = self._verified_broker_read_manifest(
+            conn, terminal_order_evidence.evidence_sha256
+        )
+        if (
+            manifest["evidence_kind"] != "ORDER_QUERY"
+            or manifest["completeness"] != "COMPLETE"
+            or manifest["account_id"] != intent["account_id"]
+            or manifest["environment"] != intent["environment"]
+            or manifest["target_broker_order_id"]
+            != intent["broker_order_id"]
+            or result.get("schema") != "etrade-order-query.v2"
+            or result.get("broker_order_id")
+            != intent["broker_order_id"]
+            or result.get("not_found") is not False
+            or result.get("outcome") != intent["state"]
+        ):
+            raise OrderIntentReconciliationRequired(
+                "terminal evidence is not an exact complete schema-v2 read of this intent"
+            )
+        observed_at = int(manifest["observed_at"])
+        if (
+            observed_at > now + 5_000_000
+            or now - observed_at
+            > _EVIDENCE_MAX_AGE_SECONDS * 1_000_000
+        ):
+            raise OrderIntentReconciliationRequired(
+                "terminal absorption evidence is stale or from the future"
+            )
+        self._require_latest_complete_manifest_head(
+            conn, manifest, recorded_at_boundary=now
+        )
+        replacement_links = result.get("replacement_links")
+        if (
+            type(replacement_links) is not dict
+            or replacement_links
+            != {
+                "replaces_order_id": None,
+                "replaced_by_order_id": None,
+            }
+        ):
+            raise OrderIntentReconciliationRequired(
+                "replacement-linked terminal orders cannot be absorbed"
+            )
+        expected_payload_hash = self._expected_order_payload_hash_conn(
+            conn, intent
+        )
+        if expected_payload_hash not in result["order_payload_hashes"]:
+            raise OrderIntentBrokerTermsMismatch(
+                "terminal absorption order terms do not match the durable intent"
+            )
+        (
+            classification,
+            ordered_quantity,
+            filled_quantity,
+        ) = _terminal_fill_classification(
+            intent,
+            result,
+            manifest_observed_at=observed_at,
+        )
+        if (
+            classification == "FULL_FILL"
+            and reservation["capacity_decision_sha256"] is None
+        ):
+            raise OrderIntentReconciliationRequired(
+                "full-fill absorption lacks its baseline capacity decision"
+            )
+        requirement = TerminalAbsorptionRequirement(
+            intent_id=intent_id,
+            classification=classification,
+            terminal_state=intent["state"],
+            broker_order_id=intent["broker_order_id"],
+            terminal_order_evidence_sha256=(
+                terminal_order_evidence.evidence_sha256
+            ),
+            baseline_capacity_decision_sha256=(
+                reservation["capacity_decision_sha256"]
+            ),
+            ordered_quantity=ordered_quantity,
+            filled_quantity=filled_quantity,
+            post_capacity_required=classification == "FULL_FILL",
+        )
+        return requirement, intent, reservation, manifest, result
+
+    def _verified_capacity_decision_row(
+        self,
+        conn: sqlite3.Connection,
+        decision_sha256: str,
+    ) -> tuple[sqlite3.Row, sqlite3.Row, dict[str, Any]]:
+        """Rebuild one historical capacity decision from its immutable source."""
+
+        _validate_sha256("capacity decision", decision_sha256)
+        row = conn.execute(
+            """
+            SELECT * FROM capacity_decisions
+            WHERE capacity_decision_sha256 = ?
+            """,
+            (decision_sha256,),
+        ).fetchone()
+        if row is None:
+            raise OrderIntentIntegrityError(
+                "capacity decision is not durable"
+            )
+        decision_material = {
+            "evidence_sha256": row["evidence_sha256"],
+            "account_id": row["account_id"],
+            "environment": row["environment"],
+            "broker_buying_power": row["broker_buying_power"],
+            "risk_budget": row["risk_budget"],
+            "cap_amount": row["cap_amount"],
+            "observed_at": int(row["observed_at"]),
+            "capacity_snapshot_sha256":
+                row["capacity_snapshot_sha256"],
+            "decided_at": int(row["decided_at"]),
+        }
+        expected_decision_sha256 = _domain_json_hash(
+            _CAPACITY_DECISION_HASH_DOMAIN, decision_material
+        )
+        if not hmac.compare_digest(
+            expected_decision_sha256, decision_sha256
+        ):
+            raise OrderIntentIntegrityError(
+                "capacity decision digest does not verify"
+            )
+        manifest, result = self._verified_broker_read_manifest(
+            conn, row["evidence_sha256"]
+        )
+        _validate_capacity_manifest_result(result)
+        buying_power = _canonical_signed_decimal_text(
+            row["broker_buying_power"], "capacity decision buying power"
+        )
+        risk_budget = _canonical_signed_decimal_text(
+            row["risk_budget"], "capacity decision risk budget"
+        )
+        cap_amount = _canonical_signed_decimal_text(
+            row["cap_amount"], "capacity decision cap"
+        )
+        if (
+            buying_power < 0
+            or risk_budget < 0
+            or cap_amount != min(buying_power, risk_budget)
+            or manifest["evidence_kind"] != "CAPACITY"
+            or manifest["completeness"] != "COMPLETE"
+            or manifest["target_broker_order_id"] is not None
+            or manifest["account_id"] != row["account_id"]
+            or manifest["environment"] != row["environment"]
+            or int(manifest["observed_at"]) != int(row["observed_at"])
+            or int(row["decided_at"]) != int(row["observed_at"])
+            or result["broker_buying_power"]
+            != row["broker_buying_power"]
+            or result["state_sha256"]
+            != row["capacity_snapshot_sha256"]
+        ):
+            raise OrderIntentIntegrityError(
+                "capacity decision is disconnected from its durable manifest"
+            )
+        return row, manifest, result
+
+    def _verified_capacity_decision_receipt(
+        self,
+        conn: sqlite3.Connection,
+        receipt: CapacityDecisionReceipt,
+        now: int,
+    ) -> tuple[sqlite3.Row, dict[str, Any]]:
+        _validate_sha256(
+            "post capacity decision", receipt.decision_sha256
+        )
+        _validate_sha256(
+            "post capacity evidence", receipt.evidence_sha256
+        )
+        _validate_timestamp(receipt.observed_at)
+        _validate_sha256(
+            "post capacity snapshot",
+            receipt.portfolio_snapshot_digest,
+        )
+        for name in (
+            "cap_amount",
+            "broker_buying_power",
+            "risk_budget",
+        ):
+            value = getattr(receipt, name)
+            if type(value) is not Decimal or not value.is_finite() or value < 0:
+                raise OrderIntentValidationError(
+                    f"{name} must be an exact non-negative Decimal"
+                )
+        row, manifest, result = self._verified_capacity_decision_row(
+            conn, receipt.decision_sha256
+        )
+        expected_values = (
+            receipt.evidence_sha256,
+            _canonical_amount(receipt.broker_buying_power),
+            _canonical_amount(receipt.risk_budget),
+            _canonical_amount(receipt.cap_amount),
+            _to_us(receipt.observed_at),
+            receipt.portfolio_snapshot_digest,
+        )
+        actual_values = (
+            row["evidence_sha256"],
+            row["broker_buying_power"],
+            row["risk_budget"],
+            row["cap_amount"],
+            int(row["observed_at"]),
+            row["capacity_snapshot_sha256"],
+        )
+        if actual_values != expected_values:
+            raise OrderIntentIntegrityError(
+                "post capacity receipt conflicts with its durable decision"
+            )
+        observed_at = int(manifest["observed_at"])
+        if (
+            manifest["evidence_kind"] != "CAPACITY"
+            or manifest["completeness"] != "COMPLETE"
+            or manifest["target_broker_order_id"] is not None
+            or result.get("schema") != "etrade-capacity.v2"
+            or result.get("state_sha256")
+            != receipt.portfolio_snapshot_digest
+            or observed_at != _to_us(receipt.observed_at)
+            or observed_at != int(row["observed_at"])
+            or observed_at > now + 5_000_000
+            or now - observed_at
+            > _EVIDENCE_MAX_AGE_SECONDS * 1_000_000
+        ):
+            raise OrderIntentReconciliationRequired(
+                "post capacity decision lacks fresh complete schema-v2 evidence"
+            )
+        return manifest, result
+
+    def _reservation_absorption_from_row(
+        self,
+        conn: sqlite3.Connection,
+        row: sqlite3.Row,
+        *,
+        decision_cache: dict[
+            str, tuple[sqlite3.Row, sqlite3.Row, dict[str, Any]]
+        ] | None = None,
+    ) -> ReservationAbsorptionReceipt:
+        lot_proof = _load_canonical_json(
+            row["canonical_lot_proof_json"],
+            "reservation lot proof",
+        )
+        if type(lot_proof) is not list:
+            raise OrderIntentIntegrityError(
+                "reservation lot proof must be an array"
+            )
+        expected_lot_sha256 = _domain_bytes_hash(
+            _LOT_PROOF_HASH_DOMAIN,
+            row["canonical_lot_proof_json"].encode("utf-8"),
+        )
+        if not hmac.compare_digest(
+            expected_lot_sha256, row["lot_proof_sha256"]
+        ):
+            raise OrderIntentIntegrityError(
+                "reservation lot proof digest does not verify"
+            )
+        material = {
+            "intent_id": row["intent_id"],
+            "account_id": row["account_id"],
+            "environment": row["environment"],
+            "broker_order_id": row["broker_order_id"],
+            "terminal_state": row["terminal_state"],
+            "classification": row["classification"],
+            "terminal_order_evidence_sha256":
+                row["terminal_order_evidence_sha256"],
+            "baseline_capacity_decision_sha256":
+                row["baseline_capacity_decision_sha256"],
+            "post_capacity_decision_sha256":
+                row["post_capacity_decision_sha256"],
+            "post_capacity_evidence_sha256":
+                row["post_capacity_evidence_sha256"],
+            "ordered_quantity": int(row["ordered_quantity"]),
+            "filled_quantity": int(row["filled_quantity"]),
+            "placed_time_epoch_ms": row["placed_time_epoch_ms"],
+            "executed_time_epoch_ms": row["executed_time_epoch_ms"],
+            "canonical_lot_proof_json":
+                row["canonical_lot_proof_json"],
+            "lot_proof_sha256": row["lot_proof_sha256"],
+            "absorbed_margin_amount":
+                row["absorbed_margin_amount"],
+            "observed_at": int(row["observed_at"]),
+            "recorded_at": int(row["recorded_at"]),
+        }
+        expected_absorption_sha256 = _domain_json_hash(
+            _RESERVATION_ABSORPTION_HASH_DOMAIN, material
+        )
+        if not hmac.compare_digest(
+            expected_absorption_sha256, row["absorption_sha256"]
+        ):
+            raise OrderIntentIntegrityError(
+                "reservation absorption digest does not verify"
+            )
+        intent = self._require_intent(conn, row["intent_id"])
+        reservation = conn.execute(
+            """
+            SELECT * FROM margin_reservations WHERE intent_id = ?
+            """,
+            (row["intent_id"],),
+        ).fetchone()
+        expected_reason = (
+            "ZERO_FILL_CONFIRMED"
+            if row["classification"] == "ZERO_FILL"
+            else "FULL_FILL_POSITION_ABSORBED"
+        )
+        if (
+            intent["account_id"] != row["account_id"]
+            or intent["environment"] != row["environment"]
+            or intent["broker_order_id"] != row["broker_order_id"]
+            or intent["state"] != row["terminal_state"]
+            or reservation is None
+            or reservation["state"] != "RELEASED"
+            or reservation["released_reason_code"] != expected_reason
+            or reservation["capacity_decision_sha256"]
+            != row["baseline_capacity_decision_sha256"]
+            or (
+                row["classification"] == "FULL_FILL"
+                and reservation["amount"]
+                != row["absorbed_margin_amount"]
+            )
+        ):
+            raise OrderIntentIntegrityError(
+                "reservation absorption is disconnected from durable intent risk"
+            )
+        baseline_sha256 = row["baseline_capacity_decision_sha256"]
+        if baseline_sha256 is not None:
+            baseline, _baseline_manifest, _baseline_result = (
+                self._cached_capacity_decision_row(
+                    conn, baseline_sha256, decision_cache
+                )
+            )
+            if (
+                baseline["account_id"] != row["account_id"]
+                or baseline["environment"] != row["environment"]
+                or baseline["capacity_snapshot_sha256"]
+                != reservation["portfolio_snapshot_digest"]
+                or int(baseline["observed_at"])
+                != int(reservation["portfolio_observed_at"])
+            ):
+                raise OrderIntentIntegrityError(
+                    "reservation absorption baseline capacity chain changed"
+                )
+        terminal_manifest, terminal_result = (
+            self._verified_broker_read_manifest(
+                conn, row["terminal_order_evidence_sha256"]
+            )
+        )
+        try:
+            self._require_latest_complete_manifest_head(
+                conn,
+                terminal_manifest,
+                recorded_at_boundary=int(row["recorded_at"]),
+            )
+        except OrderIntentReconciliationRequired as exc:
+            raise OrderIntentIntegrityError(
+                "reservation absorption did not use the terminal evidence head"
+            ) from exc
+        if (
+            terminal_manifest["evidence_kind"] != "ORDER_QUERY"
+            or terminal_manifest["completeness"] != "COMPLETE"
+            or terminal_result.get("schema")
+            != "etrade-order-query.v2"
+            or terminal_result.get("not_found") is not False
+            or terminal_result.get("outcome") != intent["state"]
+            or terminal_result.get("broker_order_id")
+            != row["broker_order_id"]
+            or terminal_result.get("replacement_links")
+            != {
+                "replaces_order_id": None,
+                "replaced_by_order_id": None,
+            }
+            or self._expected_order_payload_hash_conn(conn, intent)
+            not in terminal_result.get("order_payload_hashes", [])
+        ):
+            raise OrderIntentIntegrityError(
+                "reservation absorption terminal evidence no longer proves the intent"
+            )
+        try:
+            (
+                terminal_classification,
+                terminal_ordered_quantity,
+                terminal_filled_quantity,
+            ) = _terminal_fill_classification(
+                intent,
+                terminal_result,
+                manifest_observed_at=int(
+                    terminal_manifest["observed_at"]
+                ),
+            )
+        except OrderIntentReconciliationRequired as exc:
+            raise OrderIntentIntegrityError(
+                "reservation absorption terminal proof no longer verifies"
+            ) from exc
+        terminal_summary = terminal_result["fill_summary"]
+        if (
+            terminal_classification != row["classification"]
+            or terminal_ordered_quantity
+            != int(row["ordered_quantity"])
+            or terminal_filled_quantity
+            != int(row["filled_quantity"])
+            or terminal_summary["placed_time_epoch_ms"]
+            != row["placed_time_epoch_ms"]
+            or terminal_summary["executed_time_epoch_ms"]
+            != row["executed_time_epoch_ms"]
+        ):
+            raise OrderIntentIntegrityError(
+                "reservation absorption terminal classification changed"
+            )
+        if (
+            terminal_manifest["account_id"] != row["account_id"]
+            or terminal_manifest["environment"] != row["environment"]
+            or terminal_manifest["target_broker_order_id"]
+            != row["broker_order_id"]
+        ):
+            raise OrderIntentIntegrityError(
+                "reservation absorption terminal evidence binding changed"
+            )
+        self._require_no_later_order_contradiction(
+            conn,
+            terminal_manifest,
+            terminal_result,
+            recorded_at_boundary=int(row["recorded_at"]),
+        )
+        amount = _canonical_signed_decimal_text(
+            row["absorbed_margin_amount"],
+            "absorbed margin amount",
+        )
+        if amount < 0:
+            raise OrderIntentIntegrityError(
+                "absorbed margin amount cannot be negative"
+            )
+        if row["classification"] == "ZERO_FILL":
+            if (
+                lot_proof
+                or int(row["observed_at"])
+                != int(terminal_manifest["observed_at"])
+                or amount != 0
+            ):
+                raise OrderIntentIntegrityError(
+                    "zero-fill absorption contains unsupported risk proof"
+                )
+        else:
+            decision, post_manifest, post_result = (
+                self._cached_capacity_decision_row(
+                    conn,
+                    row["post_capacity_decision_sha256"],
+                    decision_cache,
+                )
+            )
+            if (
+                decision["evidence_sha256"]
+                != row["post_capacity_evidence_sha256"]
+                or decision["account_id"] != row["account_id"]
+                or decision["environment"] != row["environment"]
+            ):
+                raise OrderIntentIntegrityError(
+                    "reservation absorption post-capacity chain changed"
+                )
+            try:
+                self._require_latest_complete_manifest_head(
+                    conn,
+                    post_manifest,
+                    recorded_at_boundary=int(row["recorded_at"]),
+                )
+            except OrderIntentReconciliationRequired as exc:
+                raise OrderIntentIntegrityError(
+                    "reservation absorption did not use the capacity evidence head"
+                ) from exc
+            if (
+                post_manifest["evidence_kind"] != "CAPACITY"
+                or post_manifest["completeness"] != "COMPLETE"
+                or post_manifest["account_id"] != row["account_id"]
+                or post_manifest["environment"] != row["environment"]
+                or post_result.get("schema") != "etrade-capacity.v2"
+                or int(post_manifest["observed_at"])
+                <= int(terminal_manifest["observed_at"])
+                or int(post_manifest["observed_at"])
+                != int(row["observed_at"])
+                or post_result.get("state_sha256")
+                != decision["capacity_snapshot_sha256"]
+            ):
+                raise OrderIntentIntegrityError(
+                    "reservation absorption post-capacity evidence changed"
+                )
+            if self._manifest_request_started_at(
+                conn, row["post_capacity_evidence_sha256"]
+            ) <= int(terminal_manifest["observed_at"]):
+                raise OrderIntentIntegrityError(
+                    "reservation absorption capacity read overlapped terminal evidence"
+                )
+            try:
+                rebuilt_lot_proof = _terminal_position_lot_proof(
+                    post_result,
+                    broker_order_id=row["broker_order_id"],
+                    fill_summary=terminal_summary,
+                )
+            except OrderIntentReconciliationRequired as exc:
+                raise OrderIntentIntegrityError(
+                    "reservation absorption lot proof no longer verifies"
+                ) from exc
+            if rebuilt_lot_proof != lot_proof:
+                raise OrderIntentIntegrityError(
+                    "reservation absorption lot proof is not reproducible"
+                )
+        return ReservationAbsorptionReceipt(
+            absorption_sha256=row["absorption_sha256"],
+            intent_id=row["intent_id"],
+            account_id=row["account_id"],
+            environment=row["environment"],
+            broker_order_id=row["broker_order_id"],
+            terminal_state=row["terminal_state"],
+            classification=row["classification"],
+            terminal_order_evidence_sha256=(
+                row["terminal_order_evidence_sha256"]
+            ),
+            baseline_capacity_decision_sha256=(
+                row["baseline_capacity_decision_sha256"]
+            ),
+            post_capacity_decision_sha256=(
+                row["post_capacity_decision_sha256"]
+            ),
+            post_capacity_evidence_sha256=(
+                row["post_capacity_evidence_sha256"]
+            ),
+            ordered_quantity=int(row["ordered_quantity"]),
+            filled_quantity=int(row["filled_quantity"]),
+            placed_time_epoch_ms=row["placed_time_epoch_ms"],
+            executed_time_epoch_ms=row["executed_time_epoch_ms"],
+            canonical_lot_proof_json=(
+                row["canonical_lot_proof_json"]
+            ),
+            lot_proof_sha256=row["lot_proof_sha256"],
+            absorbed_margin_amount=Decimal(
+                row["absorbed_margin_amount"]
+            ),
+            observed_at=_from_us(row["observed_at"]),
+            recorded_at=_from_us(row["recorded_at"]),
+        )
 
     def _require_intent(self, conn: sqlite3.Connection, intent_id: str) -> sqlite3.Row:
         row = conn.execute("SELECT * FROM order_intents WHERE intent_id = ?", (intent_id,)).fetchone()
@@ -5078,12 +7681,19 @@ def _validate_order_query_receipt_lineage(
         "replacement_links",
         "normalized_order",
     }
+    schema = result.get("schema")
+    if schema == "etrade-order-query.v2":
+        expected_parsed_keys.add("fill_summary")
+    elif schema != "etrade-order-query.v1":
+        raise OrderIntentIntegrityError(
+            "order query receipt uses an unsupported result schema"
+        )
     if set(parsed) != expected_parsed_keys:
         raise OrderIntentIntegrityError(
             "order query receipt parser result has an unexpected shape"
         )
     expected_result = {
-        "schema": "etrade-order-query.v1",
+        "schema": schema,
         "broker_order_id": target_broker_order_id,
         "raw_status": parsed["raw_status"],
         "outcome": parsed["outcome"],
@@ -5093,6 +7703,8 @@ def _validate_order_query_receipt_lineage(
         "not_found": parsed["not_found"],
         "replacement_links": parsed["replacement_links"],
     }
+    if schema == "etrade-order-query.v2":
+        expected_result["fill_summary"] = parsed["fill_summary"]
     if result != expected_result:
         raise OrderIntentIntegrityError(
             "order query manifest result is disconnected from its receipt"
@@ -5109,6 +7721,12 @@ def _validate_capacity_receipt_lineage(
     member_roles: tuple[str, ...],
     receipt_rows: tuple[sqlite3.Row, ...],
 ) -> None:
+    schema = result.get("schema")
+    if schema not in {"etrade-capacity.v1", "etrade-capacity.v2"}:
+        raise OrderIntentIntegrityError(
+            "capacity manifest uses an unsupported result schema"
+        )
+    lots_required = schema == "etrade-capacity.v2"
     if member_roles[0] != "binding.start" or member_roles[-1] != "binding.end":
         raise OrderIntentIntegrityError(
             "capacity manifest lacks account-binding brackets"
@@ -5207,6 +7825,7 @@ def _validate_capacity_receipt_lineage(
             portfolio_rows,
             portfolio_roles,
             account_id_key=account_id_key,
+            lots_required=lots_required,
         )
 
         orders: list[dict[str, Any]] = []
@@ -5242,7 +7861,7 @@ def _validate_capacity_receipt_lineage(
         orders.sort(key=lambda item: item["order_id"])
         scans.append(
             {
-                "schema": "etrade-capacity.v1",
+                "schema": schema,
                 "account_status": binding_start["account_status"],
                 "account_mode": binding_start["account_mode"],
                 "account_type": binding_start["account_type"],
@@ -5273,13 +7892,20 @@ def _validate_capacity_receipt_lineage(
         )
     rebuilt = dict(scans[1])
     rebuilt["state_sha256"] = _domain_json_hash(
-        b"etrade-capacity-state.v1\0", economic_scans[1]
+        (
+            b"etrade-capacity-state.v2\0"
+            if lots_required
+            else b"etrade-capacity-state.v1\0"
+        ),
+        economic_scans[1],
     )
     if result != rebuilt:
         raise OrderIntentIntegrityError(
             "capacity manifest result is disconnected from its receipts"
         )
-    _validate_capacity_manifest_result(result)
+    _validate_capacity_manifest_result(
+        result, expected_account_id=account_id
+    )
 
 
 def _verified_binding_receipt(
@@ -5355,6 +7981,7 @@ def _rebuild_portfolio_scan(
     roles: list[str],
     *,
     account_id_key: str,
+    lots_required: bool,
 ) -> list[dict[str, Any]]:
     positions: list[dict[str, Any]] = []
     seen_ids: set[str] = set()
@@ -5372,7 +7999,7 @@ def _rebuild_portfolio_scan(
         )
         expected_query = {
             "count": "50",
-            "lotsRequired": "false",
+            "lotsRequired": "true" if lots_required else "false",
             "marketSession": "REGULAR",
             "pageNumber": str(ordinal),
             "sortBy": "SYMBOL",
@@ -5593,7 +8220,697 @@ def _verify_broker_read_receipt_row(row: sqlite3.Row) -> None:
         )
 
 
-def _validate_capacity_manifest_result(result: dict[str, Any]) -> None:
+def _canonical_signed_decimal_text(
+    value: Any, label: str
+) -> Decimal:
+    if type(value) is not str or not value:
+        raise OrderIntentIntegrityError(
+            f"{label} must be a canonical decimal string"
+        )
+    try:
+        parsed = Decimal(value)
+    except (InvalidOperation, ValueError) as exc:
+        raise OrderIntentIntegrityError(
+            f"{label} must be a finite decimal"
+        ) from exc
+    if not parsed.is_finite():
+        raise OrderIntentIntegrityError(
+            f"{label} must be a finite decimal"
+        )
+    normalized = format(parsed, "f")
+    if "." in normalized:
+        normalized = normalized.rstrip("0").rstrip(".")
+    if normalized in {"", "-0"}:
+        normalized = "0"
+    if normalized != value:
+        raise OrderIntentIntegrityError(
+            f"{label} is not canonical"
+        )
+    return parsed
+
+
+def _canonical_unsigned_integer_text(
+    value: Any,
+    label: str,
+    *,
+    positive: bool,
+) -> int:
+    if (
+        type(value) is not str
+        or not value.isascii()
+        or not value.isdigit()
+        or (len(value) > 1 and value[0] == "0")
+    ):
+        raise OrderIntentIntegrityError(
+            f"{label} must be a canonical integer string"
+        )
+    parsed = int(value)
+    if (positive and parsed <= 0) or (not positive and parsed < 0):
+        raise OrderIntentIntegrityError(
+            f"{label} is outside the allowed range"
+        )
+    return parsed
+
+
+def _validate_normalized_product(
+    product: Any, label: str
+) -> None:
+    expected = {
+        "symbol",
+        "security_type",
+        "call_put",
+        "expiry_year",
+        "expiry_month",
+        "expiry_day",
+        "strike_price",
+        "product_id",
+    }
+    if type(product) is not dict or set(product) != expected:
+        raise OrderIntentIntegrityError(
+            f"{label} product shape is invalid"
+        )
+    if (
+        type(product["symbol"]) is not str
+        or not product["symbol"]
+        or product["security_type"] not in {"EQ", "OPTN"}
+        or (
+            product["product_id"] is not None
+            and (
+                type(product["product_id"]) is not dict
+                or set(product["product_id"])
+                != {"symbol", "type_code"}
+                or any(
+                    value is not None
+                    and (type(value) is not str or not value)
+                    for value in product["product_id"].values()
+                )
+            )
+        )
+    ):
+        raise OrderIntentIntegrityError(
+            f"{label} product identity is invalid"
+        )
+    if product["security_type"] == "OPTN":
+        if (
+            product["call_put"] not in {"PUT", "CALL"}
+            or any(
+                type(product[name]) is not str
+                for name in (
+                    "expiry_year",
+                    "expiry_month",
+                    "expiry_day",
+                    "strike_price",
+                )
+            )
+        ):
+            raise OrderIntentIntegrityError(
+                f"{label} option identity is incomplete"
+            )
+        for name in ("expiry_year", "expiry_month", "expiry_day"):
+            _canonical_unsigned_integer_text(
+                product[name], f"{label} {name}", positive=True
+            )
+        strike = _canonical_signed_decimal_text(
+            product["strike_price"], f"{label} strike"
+        )
+        if strike <= 0:
+            raise OrderIntentIntegrityError(
+                f"{label} strike must be positive"
+            )
+
+
+def _validate_fill_summary_shape(summary: Any) -> None:
+    if (
+        type(summary) is not dict
+        or set(summary)
+        != {
+            "classification",
+            "placed_time_epoch_ms",
+            "executed_time_epoch_ms",
+            "legs",
+        }
+        or summary["classification"]
+        not in {
+            "OPEN",
+            "FULL_FILL",
+            "ZERO_FILL_TERMINAL",
+            "UNRESOLVED",
+        }
+        or type(summary["legs"]) is not list
+    ):
+        raise OrderIntentIntegrityError(
+            "order fill summary shape is invalid"
+        )
+    for name in (
+        "placed_time_epoch_ms",
+        "executed_time_epoch_ms",
+    ):
+        value = summary[name]
+        if value is not None:
+            parsed = _canonical_unsigned_integer_text(
+                value, f"fill summary {name}", positive=True
+            )
+            if len(value) != 13 or parsed > 9_223_372_036_854_775_807:
+                raise OrderIntentIntegrityError(
+                    f"fill summary {name} is invalid"
+                )
+    legs = summary["legs"]
+    if not legs:
+        if summary["classification"] != "UNRESOLVED":
+            raise OrderIntentIntegrityError(
+                "resolved fill summary must contain exact legs"
+            )
+        return
+    if len(legs) != 2:
+        raise OrderIntentIntegrityError(
+            "fill summary must contain exactly two legs"
+        )
+    numbers: set[int] = set()
+    quantities: list[tuple[Decimal, Decimal, Decimal]] = []
+    for leg in legs:
+        if (
+            type(leg) is not dict
+            or set(leg)
+            != {
+                "leg_number",
+                "product",
+                "order_action",
+                "ordered_quantity",
+                "filled_quantity",
+                "cancel_quantity",
+            }
+            or type(leg["leg_number"]) is not int
+            or leg["leg_number"] not in {1, 2}
+            or leg["order_action"] not in {
+                "BUY_OPEN",
+                "SELL_OPEN",
+            }
+        ):
+            raise OrderIntentIntegrityError(
+                "fill summary leg shape is invalid"
+            )
+        numbers.add(leg["leg_number"])
+        _validate_normalized_product(
+            leg["product"], "fill summary leg"
+        )
+        ordered = _canonical_signed_decimal_text(
+            leg["ordered_quantity"], "ordered quantity"
+        )
+        filled = _canonical_signed_decimal_text(
+            leg["filled_quantity"], "filled quantity"
+        )
+        cancelled = _canonical_signed_decimal_text(
+            leg["cancel_quantity"], "cancel quantity"
+        )
+        if (
+            ordered <= 0
+            or ordered != ordered.to_integral_value()
+            or filled < 0
+            or cancelled < 0
+            or filled + cancelled > ordered
+        ):
+            raise OrderIntentIntegrityError(
+                "fill summary quantities are inconsistent"
+            )
+        quantities.append((ordered, filled, cancelled))
+    if numbers != {1, 2}:
+        raise OrderIntentIntegrityError(
+            "fill summary leg numbers are ambiguous"
+        )
+    classification = summary["classification"]
+    executed = summary["executed_time_epoch_ms"]
+    if classification == "OPEN" and (
+        executed is not None
+        or any(filled != 0 or cancelled != 0 for _, filled, cancelled in quantities)
+    ):
+        raise OrderIntentIntegrityError(
+            "open fill summary is inconsistent"
+        )
+    if classification == "FULL_FILL" and (
+        executed is None
+        or any(
+            filled != ordered or cancelled != 0
+            for ordered, filled, cancelled in quantities
+        )
+    ):
+        raise OrderIntentIntegrityError(
+            "full-fill summary is inconsistent"
+        )
+    if classification == "ZERO_FILL_TERMINAL" and (
+        executed is not None
+        or any(
+            filled != 0 or cancelled != ordered
+            for ordered, filled, cancelled in quantities
+        )
+    ):
+        raise OrderIntentIntegrityError(
+            "zero-fill terminal summary is inconsistent"
+        )
+
+
+def _validate_capacity_v2_positions(
+    positions: list[Any],
+) -> None:
+    position_ids: list[str] = []
+    lot_ids: set[str] = set()
+    for position in positions:
+        if (
+            type(position) is not dict
+            or set(position)
+            != {
+                "position_id",
+                "account_id",
+                "product",
+                "quantity",
+                "position_type",
+                "position_indicator",
+                "osi_key",
+                "lots",
+            }
+        ):
+            raise OrderIntentIntegrityError(
+                "schema-v2 position shape is invalid"
+            )
+        _canonical_unsigned_integer_text(
+            position["position_id"],
+            "position id",
+            positive=True,
+        )
+        _canonical_unsigned_integer_text(
+            position["account_id"],
+            "position account id",
+            positive=True,
+        )
+        _canonical_signed_decimal_text(
+            position["quantity"], "position quantity"
+        )
+        _validate_normalized_product(
+            position["product"], "position"
+        )
+        for name in (
+            "position_type",
+            "position_indicator",
+            "osi_key",
+        ):
+            value = position[name]
+            if value is not None and (
+                type(value) is not str or not value
+            ):
+                raise OrderIntentIntegrityError(
+                    f"position {name} is invalid"
+                )
+        if type(position["lots"]) is not list:
+            raise OrderIntentIntegrityError(
+                "position lots must be an array"
+            )
+        if position["lots"] != sorted(
+            position["lots"], key=_canonical_read_json
+        ):
+            raise OrderIntentIntegrityError(
+                "position lots are not canonically ordered"
+            )
+        position_ids.append(position["position_id"])
+        for lot in position["lots"]:
+            if (
+                type(lot) is not dict
+                or set(lot)
+                != {
+                    "position_id",
+                    "position_lot_id",
+                    "order_no",
+                    "leg_no",
+                    "original_quantity",
+                    "remaining_quantity",
+                    "available_quantity",
+                    "acquired_date_epoch_ms",
+                }
+                or lot["position_id"] != position["position_id"]
+            ):
+                raise OrderIntentIntegrityError(
+                    "position lot shape or parent identity is invalid"
+                )
+            _canonical_unsigned_integer_text(
+                lot["position_lot_id"],
+                "position lot id",
+                positive=True,
+            )
+            if lot["position_lot_id"] in lot_ids:
+                raise OrderIntentIntegrityError(
+                    "capacity positions contain a duplicate lot id"
+                )
+            lot_ids.add(lot["position_lot_id"])
+            if lot["order_no"] is not None:
+                _canonical_unsigned_integer_text(
+                    lot["order_no"],
+                    "position lot order number",
+                    positive=False,
+                )
+            if lot["leg_no"] is not None:
+                leg_no = _canonical_unsigned_integer_text(
+                    lot["leg_no"],
+                    "position lot leg number",
+                    positive=False,
+                )
+                if leg_no > 2_147_483_647:
+                    raise OrderIntentIntegrityError(
+                        "position lot leg number exceeds signed int32"
+                    )
+            for name in (
+                "original_quantity",
+                "remaining_quantity",
+                "available_quantity",
+            ):
+                _canonical_signed_decimal_text(
+                    lot[name], f"position lot {name}"
+                )
+            acquired = lot["acquired_date_epoch_ms"]
+            if (
+                type(acquired) is not str
+                or not acquired
+                or acquired in {"+0", "-0"}
+            ):
+                raise OrderIntentIntegrityError(
+                    "position lot acquired date is invalid"
+                )
+            acquired_digits = (
+                acquired[1:] if acquired.startswith("-") else acquired
+            )
+            if (
+                not acquired_digits.isascii()
+                or not acquired_digits.isdigit()
+                or (
+                    len(acquired_digits) > 1
+                    and acquired_digits[0] == "0"
+                )
+                or not -(2**63) <= int(acquired) <= 2**63 - 1
+            ):
+                raise OrderIntentIntegrityError(
+                    "position lot acquired date is invalid"
+                )
+    if position_ids != sorted(position_ids) or len(position_ids) != len(
+        set(position_ids)
+    ):
+        raise OrderIntentIntegrityError(
+            "capacity position identities are ambiguous"
+        )
+
+
+def _terminal_fill_classification(
+    intent: sqlite3.Row,
+    result: dict[str, Any],
+    *,
+    manifest_observed_at: int,
+) -> tuple[Literal["ZERO_FILL", "FULL_FILL"], int, int]:
+    summary = result["fill_summary"]
+    _validate_fill_summary_shape(summary)
+    terminal_state = intent["state"]
+    if terminal_state == "FILLED":
+        expected_summary = "FULL_FILL"
+        expected_raw_status = "EXECUTED"
+        classification: Literal["ZERO_FILL", "FULL_FILL"] = "FULL_FILL"
+    else:
+        expected_summary = "ZERO_FILL_TERMINAL"
+        expected_raw_status = terminal_state
+        classification = "ZERO_FILL"
+    if (
+        summary["classification"] != expected_summary
+        or result["raw_status"] != expected_raw_status
+    ):
+        raise OrderIntentReconciliationRequired(
+            "terminal status and exact fill classification disagree"
+        )
+    placed = summary["placed_time_epoch_ms"]
+    if placed is None:
+        raise OrderIntentReconciliationRequired(
+            "terminal fill evidence lacks a placement timestamp"
+        )
+    placed_ms = int(placed)
+    if placed_ms * 1_000 > manifest_observed_at + 5_000_000:
+        raise OrderIntentReconciliationRequired(
+            "terminal placement timestamp is in the future"
+        )
+    executed = summary["executed_time_epoch_ms"]
+    if classification == "FULL_FILL":
+        if (
+            executed is None
+            or int(executed) < placed_ms
+            or int(executed) * 1_000
+            > manifest_observed_at + 5_000_000
+        ):
+            raise OrderIntentReconciliationRequired(
+                "full-fill execution timestamp is missing or inconsistent"
+            )
+    elif executed is not None:
+        raise OrderIntentReconciliationRequired(
+            "zero-fill terminal evidence contains an execution timestamp"
+        )
+    try:
+        payload = json.loads(intent["wire_payload"])
+    except (TypeError, json.JSONDecodeError) as exc:
+        raise OrderIntentIntegrityError(
+            "durable intent payload cannot be decoded"
+        ) from exc
+    intent_legs = payload.get("legs")
+    if type(intent_legs) is not list or len(intent_legs) != 2:
+        raise OrderIntentIntegrityError(
+            "terminal opening intent is not an exact vertical"
+        )
+    unmatched = list(intent_legs)
+    ordered_values: set[int] = set()
+    filled_values: set[int] = set()
+    for fill_leg in summary["legs"]:
+        product = fill_leg["product"]
+        matches = [
+            leg
+            for leg in unmatched
+            if (
+                leg["symbol"] == product["symbol"]
+                and product["security_type"] == "OPTN"
+                and leg["callPut"] == product["call_put"]
+                and str(leg["expiryYear"]) == product["expiry_year"]
+                and str(leg["expiryMonth"]) == product["expiry_month"]
+                and str(leg["expiryDay"]) == product["expiry_day"]
+                and _canonical_amount(leg["strikePrice"])
+                == product["strike_price"]
+                and leg["orderAction"]
+                == fill_leg["order_action"]
+            )
+        ]
+        if len(matches) != 1:
+            raise OrderIntentReconciliationRequired(
+                "terminal fill legs do not match immutable intent products/actions"
+            )
+        intent_leg = matches[0]
+        unmatched.remove(intent_leg)
+        ordered = _canonical_signed_decimal_text(
+            fill_leg["ordered_quantity"], "terminal ordered quantity"
+        )
+        filled = _canonical_signed_decimal_text(
+            fill_leg["filled_quantity"], "terminal filled quantity"
+        )
+        if (
+            ordered != Decimal(intent_leg["quantity"])
+            or ordered != ordered.to_integral_value()
+            or filled != filled.to_integral_value()
+        ):
+            raise OrderIntentReconciliationRequired(
+                "terminal fill quantities do not match immutable intent"
+            )
+        ordered_values.add(int(ordered))
+        filled_values.add(int(filled))
+    if unmatched or len(ordered_values) != 1 or len(filled_values) != 1:
+        raise OrderIntentReconciliationRequired(
+            "terminal fill leg quantities are ambiguous"
+        )
+    ordered_quantity = next(iter(ordered_values))
+    filled_quantity = next(iter(filled_values))
+    if (
+        classification == "ZERO_FILL"
+        and filled_quantity != 0
+    ) or (
+        classification == "FULL_FILL"
+        and filled_quantity != ordered_quantity
+    ):
+        raise OrderIntentReconciliationRequired(
+            "terminal fill quantity is partial or unresolved"
+        )
+    return classification, ordered_quantity, filled_quantity
+
+
+def _terminal_position_lot_proof(
+    capacity_result: dict[str, Any],
+    *,
+    broker_order_id: str,
+    fill_summary: dict[str, Any],
+) -> list[dict[str, Any]]:
+    _validate_capacity_manifest_result(capacity_result)
+    if capacity_result["schema"] != "etrade-capacity.v2":
+        raise OrderIntentReconciliationRequired(
+            "full-fill absorption requires schema-v2 position lots"
+        )
+    if any(
+        type(order) is dict
+        and order.get("order_id") == broker_order_id
+        for order in capacity_result["open_orders"]
+    ):
+        raise OrderIntentReconciliationRequired(
+            "terminal order remains present in active orders"
+        )
+    fill_legs = {
+        leg["leg_number"]: leg for leg in fill_summary["legs"]
+    }
+    matched_by_leg: dict[int, list[dict[str, Any]]] = {
+        1: [],
+        2: [],
+    }
+    proof: list[dict[str, Any]] = []
+    for position in capacity_result["positions"]:
+        target_lots = [
+            lot
+            for lot in position["lots"]
+            if lot["order_no"] == broker_order_id
+        ]
+        if not target_lots:
+            continue
+        parent_quantity = _canonical_signed_decimal_text(
+            position["quantity"], "target parent position quantity"
+        )
+        matched_parent_remaining = Decimal("0")
+        for lot in target_lots:
+            if lot["leg_no"] is None:
+                raise OrderIntentReconciliationRequired(
+                    "target position lot lacks an exact leg number"
+                )
+            leg_number = _canonical_unsigned_integer_text(
+                lot["leg_no"],
+                "target position lot leg number",
+                positive=True,
+            )
+            if leg_number not in {1, 2}:
+                raise OrderIntentReconciliationRequired(
+                    "target position lot has an unsupported leg number"
+                )
+            fill_leg = fill_legs[leg_number]
+            action = fill_leg["order_action"]
+            expected_type = (
+                "LONG" if action == "BUY_OPEN" else "SHORT"
+            )
+            expected_sign = Decimal("1") if action == "BUY_OPEN" else Decimal("-1")
+            if (
+                not _absorption_products_match(
+                    position["product"], fill_leg["product"]
+                )
+                or position["position_type"] != expected_type
+                or parent_quantity * expected_sign <= 0
+            ):
+                raise OrderIntentReconciliationRequired(
+                    "target lot product/action direction is inconsistent"
+                )
+            original = _canonical_signed_decimal_text(
+                lot["original_quantity"], "target lot original quantity"
+            )
+            remaining = _canonical_signed_decimal_text(
+                lot["remaining_quantity"], "target lot remaining quantity"
+            )
+            available = _canonical_signed_decimal_text(
+                lot["available_quantity"], "target lot available quantity"
+            )
+            if (
+                original * expected_sign <= 0
+                or remaining * expected_sign <= 0
+                or available * expected_sign <= 0
+                or abs(available) > abs(remaining)
+                or abs(remaining) > abs(original)
+            ):
+                raise OrderIntentReconciliationRequired(
+                    "target lot quantities do not prove intact opening exposure"
+                )
+            matched_parent_remaining += abs(remaining)
+            item = {
+                "leg_number": leg_number,
+                "order_action": action,
+                "filled_quantity": fill_leg["filled_quantity"],
+                "position_id": position["position_id"],
+                "position_type": position["position_type"],
+                "position_quantity": position["quantity"],
+                "product": position["product"],
+                "lot": lot,
+            }
+            matched_by_leg[leg_number].append(item)
+            proof.append(item)
+        if abs(parent_quantity) < matched_parent_remaining:
+            raise OrderIntentReconciliationRequired(
+                "target lots exceed their parent position quantity"
+            )
+    if {number for number, items in matched_by_leg.items() if items} != {
+        1,
+        2,
+    }:
+        raise OrderIntentReconciliationRequired(
+            "post-fill positions lack exact lots for both spread legs"
+        )
+    for leg_number, items in matched_by_leg.items():
+        expected = _canonical_signed_decimal_text(
+            fill_legs[leg_number]["filled_quantity"],
+            "full-fill quantity",
+        )
+        for quantity_name in (
+            "original_quantity",
+            "remaining_quantity",
+            "available_quantity",
+        ):
+            actual = sum(
+                (
+                    abs(
+                        _canonical_signed_decimal_text(
+                            item["lot"][quantity_name],
+                            f"target lot {quantity_name}",
+                        )
+                    )
+                    for item in items
+                ),
+                Decimal("0"),
+            )
+            if actual != expected:
+                raise OrderIntentReconciliationRequired(
+                    "post-fill target lot quantities do not equal exact fills"
+                )
+    proof.sort(key=_canonical_read_json)
+    return proof
+
+
+def _absorption_products_match(
+    position_product: dict[str, Any],
+    fill_product: dict[str, Any],
+) -> bool:
+    economic_keys = (
+        "symbol",
+        "security_type",
+        "call_put",
+        "expiry_year",
+        "expiry_month",
+        "expiry_day",
+        "strike_price",
+    )
+    if any(
+        position_product[key] != fill_product[key]
+        for key in economic_keys
+    ):
+        return False
+    position_id = position_product["product_id"]
+    fill_id = fill_product["product_id"]
+    return (
+        position_id is None
+        or fill_id is None
+        or position_id == fill_id
+    )
+
+
+def _validate_capacity_manifest_result(
+    result: dict[str, Any],
+    *,
+    expected_account_id: str | None = None,
+) -> None:
     expected = {
         "schema",
         "account_status",
@@ -5609,8 +8926,9 @@ def _validate_capacity_manifest_result(result: dict[str, Any]) -> None:
         raise OrderIntentIntegrityError(
             "capacity manifest result shape is invalid"
         )
+    schema = result["schema"]
     if (
-        result["schema"] != "etrade-capacity.v1"
+        schema not in {"etrade-capacity.v1", "etrade-capacity.v2"}
         or result["account_status"] != "ACTIVE"
         or result["account_mode"] != "MARGIN"
         or type(result["account_type"]) is not str
@@ -5633,13 +8951,27 @@ def _validate_capacity_manifest_result(result: dict[str, Any]) -> None:
             "capacity manifest buying power is not canonical"
         )
     _validate_sha256("capacity state digest", result["state_sha256"])
+    if schema == "etrade-capacity.v2":
+        _validate_capacity_v2_positions(result["positions"])
+        if expected_account_id is not None and any(
+            position["account_id"] != expected_account_id
+            for position in result["positions"]
+        ):
+            raise OrderIntentIntegrityError(
+                "capacity position belongs to a different account"
+            )
     state = {
         key: result[key]
         for key in expected
         if key not in {"state_sha256", "broker_buying_power_as_of"}
     }
     expected_digest = _domain_json_hash(
-        b"etrade-capacity-state.v1\0", state
+        (
+            b"etrade-capacity-state.v2\0"
+            if schema == "etrade-capacity.v2"
+            else b"etrade-capacity-state.v1\0"
+        ),
+        state,
     )
     if not hmac.compare_digest(expected_digest, result["state_sha256"]):
         raise OrderIntentIntegrityError(
@@ -5661,12 +8993,18 @@ def _validate_order_query_manifest_result(
         "not_found",
         "replacement_links",
     }
+    schema = result.get("schema")
+    if schema == "etrade-order-query.v2":
+        expected.add("fill_summary")
     if set(result) != expected:
         raise OrderIntentIntegrityError(
             "order query manifest result shape is invalid"
         )
     if (
-        result["schema"] != "etrade-order-query.v1"
+        schema not in {
+            "etrade-order-query.v1",
+            "etrade-order-query.v2",
+        }
         or type(result["broker_order_id"]) is not str
         or type(result["raw_status"]) is not str
         or result["outcome"]
@@ -5704,6 +9042,31 @@ def _validate_order_query_manifest_result(
     for payload_hash in hashes:
         _validate_sha256("order query payload hash", payload_hash)
     replacement_links = result["replacement_links"]
+    if schema == "etrade-order-query.v2":
+        _validate_fill_summary_shape(result["fill_summary"])
+        classification = result["fill_summary"]["classification"]
+        if result["not_found"]:
+            expected_outcome = "UNRESOLVED"
+        elif classification == "OPEN":
+            expected_outcome = "OPEN"
+        elif classification == "FULL_FILL":
+            expected_outcome = "FILLED"
+        elif classification == "ZERO_FILL_TERMINAL":
+            expected_outcome = result["raw_status"]
+            if expected_outcome not in {
+                "CANCELLED",
+                "REJECTED",
+                "EXPIRED",
+            }:
+                raise OrderIntentIntegrityError(
+                    "zero-fill classification lacks a terminal broker status"
+                )
+        else:
+            expected_outcome = "UNRESOLVED"
+        if result["outcome"] != expected_outcome:
+            raise OrderIntentIntegrityError(
+                "order outcome conflicts with its exact fill classification"
+            )
     if result["not_found"]:
         if replacement_links:
             raise OrderIntentIntegrityError(

--- a/etrade_python_client/tests/test_broker_read_ledger.py
+++ b/etrade_python_client/tests/test_broker_read_ledger.py
@@ -11,6 +11,7 @@ from datetime import datetime, timedelta, timezone
 from decimal import Decimal
 from pathlib import Path
 from typing import Any
+from unittest.mock import patch
 
 from live_trading.etrade_broker_reader import (
     _PARSER_CODE_SHA256,
@@ -29,8 +30,11 @@ from live_trading.order_intent_ledger import (
     OrderIntentIntegrityError,
     OrderIntentLedger,
     OrderIntentLedgerError,
+    OrderIntentReconciliationRequired,
+    OrderIntentReservationError,
     OrderIntentValidationError,
     RiskEvidence,
+    _validate_capacity_manifest_result,
     canonical_order_payload_hash,
 )
 
@@ -146,7 +150,56 @@ def _balance_raw(buying_power: str, as_of_date: str) -> bytes:
     ).encode("ascii")
 
 
-def _portfolio_raw() -> bytes:
+def _portfolio_raw(
+    positions: list[dict[str, Any]] | None = None,
+) -> bytes:
+    raw_positions = []
+    for position in positions or []:
+        product = position["product"]
+        raw_product = {
+            "symbol": product["symbol"],
+            "securityType": product["security_type"],
+        }
+        for normalized, broker in (
+            ("call_put", "callPut"),
+            ("expiry_year", "expiryYear"),
+            ("expiry_month", "expiryMonth"),
+            ("expiry_day", "expiryDay"),
+            ("strike_price", "strikePrice"),
+        ):
+            if product[normalized] is not None:
+                raw_product[broker] = product[normalized]
+        if product["product_id"] is not None:
+            raw_product["ProductId"] = {
+                "symbol": product["product_id"]["symbol"],
+                "typeCode": product["product_id"]["type_code"],
+            }
+        raw_positions.append(
+            {
+                "positionId": position["position_id"],
+                "accountId": position["account_id"],
+                "Product": raw_product,
+                "quantity": position["quantity"],
+                "positionType": position["position_type"],
+                "positionIndicator": position["position_indicator"],
+                "osiKey": position["osi_key"],
+                "PositionLot": [
+                    {
+                        "positionId": lot["position_id"],
+                        "positionLotId": lot["position_lot_id"],
+                        "orderNo": lot["order_no"],
+                        "legNo": lot["leg_no"],
+                        "originalQty": lot["original_quantity"],
+                        "remainingQty": lot["remaining_quantity"],
+                        "availableQty": lot["available_quantity"],
+                        "acquiredDate": lot[
+                            "acquired_date_epoch_ms"
+                        ],
+                    }
+                    for lot in position.get("lots", [])
+                ],
+            }
+        )
     return _canonical_json(
         {
             "PortfolioResponse": {
@@ -154,7 +207,7 @@ def _portfolio_raw() -> bytes:
                     {
                         "accountId": ACCOUNT_ID,
                         "totalNoOfPages": "1",
-                        "Position": [],
+                        "Position": raw_positions,
                     }
                 ]
             }
@@ -173,7 +226,15 @@ def _known_order_raw(
     *,
     limit_price: str = "1.25",
     status: str = "OPEN",
+    product_id_type: str | None = None,
 ) -> bytes:
+    placed_time = "1785167940000"
+    executed = status == "EXECUTED"
+    zero_fill_terminal = status in {
+        "CANCELLED",
+        "REJECTED",
+        "EXPIRED",
+    }
     return _canonical_json(
         {
             "OrdersResponse": {
@@ -186,6 +247,12 @@ def _known_order_raw(
                                 "accountId": ACCOUNT_ID,
                                 "orderNumber": broker_order_id,
                                 "status": status,
+                                "placedTime": placed_time,
+                                **(
+                                    {"executedTime": "1785167970000"}
+                                    if executed
+                                    else {}
+                                ),
                                 "priceType": "NET_CREDIT",
                                 "limitPrice": limit_price,
                                 "orderTerm": "GOOD_FOR_DAY",
@@ -202,12 +269,30 @@ def _known_order_raw(
                                             "expiryMonth": "8",
                                             "expiryDay": "21",
                                             "strikePrice": "620",
+                                            **(
+                                                {
+                                                    "ProductId": {
+                                                        "symbol": "SPY",
+                                                        "typeCode":
+                                                            product_id_type,
+                                                    }
+                                                }
+                                                if product_id_type
+                                                is not None
+                                                else {}
+                                            ),
                                         },
                                         "orderAction": "SELL_OPEN",
                                         "quantityType": "QUANTITY",
                                         "orderedQuantity": "1",
-                                        "filledQuantity": "0",
-                                        "cancelQuantity": "0",
+                                        "filledQuantity": (
+                                            "1" if executed else "0"
+                                        ),
+                                        "cancelQuantity": (
+                                            "1"
+                                            if zero_fill_terminal
+                                            else "0"
+                                        ),
                                     },
                                     {
                                         "Product": {
@@ -218,12 +303,30 @@ def _known_order_raw(
                                             "expiryMonth": "8",
                                             "expiryDay": "21",
                                             "strikePrice": "615",
+                                            **(
+                                                {
+                                                    "ProductId": {
+                                                        "symbol": "SPY",
+                                                        "typeCode":
+                                                            product_id_type,
+                                                    }
+                                                }
+                                                if product_id_type
+                                                is not None
+                                                else {}
+                                            ),
                                         },
                                         "orderAction": "BUY_OPEN",
                                         "quantityType": "QUANTITY",
                                         "orderedQuantity": "1",
-                                        "filledQuantity": "0",
-                                        "cancelQuantity": "0",
+                                        "filledQuantity": (
+                                            "1" if executed else "0"
+                                        ),
+                                        "cancelQuantity": (
+                                            "1"
+                                            if zero_fill_terminal
+                                            else "0"
+                                        ),
                                     },
                                 ],
                             }
@@ -243,6 +346,77 @@ def _vertical_hashes(limit_price: str) -> tuple[str, ...]:
     reverse_payload["legs"] = list(reversed(payload["legs"]))
     reverse = canonical_order_payload_hash(reverse_payload)
     return tuple(sorted({forward, reverse}))
+
+
+def _filled_vertical_positions(
+    broker_order_id: str,
+) -> list[dict[str, Any]]:
+    products = (
+        {
+            "symbol": "SPY",
+            "security_type": "OPTN",
+            "call_put": "PUT",
+            "expiry_year": "2026",
+            "expiry_month": "8",
+            "expiry_day": "21",
+            "strike_price": "620",
+            "product_id": None,
+        },
+        {
+            "symbol": "SPY",
+            "security_type": "OPTN",
+            "call_put": "PUT",
+            "expiry_year": "2026",
+            "expiry_month": "8",
+            "expiry_day": "21",
+            "strike_price": "615",
+            "product_id": None,
+        },
+    )
+    return [
+        {
+            "position_id": "101",
+            "account_id": ACCOUNT_ID,
+            "product": products[0],
+            "quantity": "-1",
+            "position_type": "SHORT",
+            "position_indicator": "TYPE1",
+            "osi_key": "SPY---260821P00620000",
+            "lots": [
+                {
+                    "position_id": "101",
+                    "position_lot_id": "1001",
+                    "order_no": broker_order_id,
+                    "leg_no": "1",
+                    "original_quantity": "-1",
+                    "remaining_quantity": "-1",
+                    "available_quantity": "-1",
+                    "acquired_date_epoch_ms": "1785167970000",
+                }
+            ],
+        },
+        {
+            "position_id": "102",
+            "account_id": ACCOUNT_ID,
+            "product": products[1],
+            "quantity": "1",
+            "position_type": "LONG",
+            "position_indicator": "TYPE1",
+            "osi_key": "SPY---260821P00615000",
+            "lots": [
+                {
+                    "position_id": "102",
+                    "position_lot_id": "1002",
+                    "order_no": broker_order_id,
+                    "leg_no": "2",
+                    "original_quantity": "1",
+                    "remaining_quantity": "1",
+                    "available_quantity": "1",
+                    "acquired_date_epoch_ms": "1785167970000",
+                }
+            ],
+        },
+    ]
 
 
 class BrokerReadLedgerTests(unittest.TestCase):
@@ -346,8 +520,19 @@ class BrokerReadLedgerTests(unittest.TestCase):
         return parsed
 
     def _capacity_manifest(
-        self, *, buying_power: str = "1000"
+        self,
+        *,
+        buying_power: str = "1000",
+        positions: list[dict[str, Any]] | None = None,
+        schema: str = "etrade-capacity.v1",
     ) -> tuple[BrokerReadEvidenceRef, str, tuple[str, ...]]:
+        if schema not in {
+            "etrade-capacity.v1",
+            "etrade-capacity.v2",
+        }:
+            raise AssertionError("unsupported capacity test schema")
+        normalized_positions = positions or []
+        lots_required = schema == "etrade-capacity.v2"
         buying_power_as_of = str(
             int(
                 (
@@ -388,7 +573,10 @@ class BrokerReadLedgerTests(unittest.TestCase):
                         f"/v1/accounts/{ACCOUNT_ID_KEY}/portfolio.json",
                         (
                             ("count", "50"),
-                            ("lotsRequired", "false"),
+                            (
+                                "lotsRequired",
+                                "true" if lots_required else "false",
+                            ),
                             ("marketSession", "REGULAR"),
                             ("pageNumber", "1"),
                             ("sortBy", "SYMBOL"),
@@ -396,7 +584,7 @@ class BrokerReadLedgerTests(unittest.TestCase):
                             ("totalsRequired", "false"),
                             ("view", "COMPLETE"),
                         ),
-                        _portfolio_raw(),
+                        _portfolio_raw(normalized_positions),
                     ),
                 )
             )
@@ -441,19 +629,24 @@ class BrokerReadLedgerTests(unittest.TestCase):
             )
 
         state = {
-            "schema": "etrade-capacity.v1",
+            "schema": schema,
             "account_status": "ACTIVE",
             "account_mode": "MARGIN",
             "account_type": "INDIVIDUAL",
             "broker_buying_power": buying_power,
             "broker_buying_power_as_of": buying_power_as_of,
-            "positions": [],
+            "positions": normalized_positions,
             "open_orders": [],
         }
         economic_state = dict(state)
         economic_state.pop("broker_buying_power_as_of")
         state_sha256 = _domain_json_sha256(
-            b"etrade-capacity-state.v1\0", economic_state
+            (
+                b"etrade-capacity-state.v2\0"
+                if lots_required
+                else b"etrade-capacity-state.v1\0"
+            ),
+            economic_state,
         )
         result = dict(state)
         result["state_sha256"] = state_sha256
@@ -480,6 +673,7 @@ class BrokerReadLedgerTests(unittest.TestCase):
         broker_order_id: str,
         payload_hashes: tuple[str, ...],
         outcome: str = "OPEN",
+        product_id_type: str | None = None,
     ) -> tuple[BrokerReadEvidenceRef, str]:
         default_hashes = _vertical_hashes("1.25")
         limit_price = (
@@ -490,7 +684,8 @@ class BrokerReadLedgerTests(unittest.TestCase):
         raw = _known_order_raw(
             broker_order_id,
             limit_price=limit_price,
-            status=outcome,
+            status="EXECUTED" if outcome == "FILLED" else outcome,
+            product_id_type=product_id_type,
         )
         binding_start = self._record_response(
             read_kind="ACCOUNT_LIST",
@@ -514,10 +709,11 @@ class BrokerReadLedgerTests(unittest.TestCase):
             final_response=True,
         )
         result = {
-            "schema": "etrade-order-query.v1",
+            "schema": "etrade-order-query.v2",
             "broker_order_id": broker_order_id,
             "raw_status": parsed["raw_status"],
             "outcome": parsed["outcome"],
+            "fill_summary": parsed["fill_summary"],
             "order_payload_hashes": parsed["order_payload_hashes"],
             "http_status": 200,
             "raw_response_digest": hashlib.sha256(raw).hexdigest(),
@@ -613,6 +809,36 @@ class BrokerReadLedgerTests(unittest.TestCase):
                 )
             )
 
+    def test_capacity_v2_rejects_position_from_different_account(
+        self,
+    ) -> None:
+        positions = _filled_vertical_positions("9000000")
+        positions[0]["account_id"] = "999999999"
+        state = {
+            "schema": "etrade-capacity.v2",
+            "account_status": "ACTIVE",
+            "account_mode": "MARGIN",
+            "account_type": "INDIVIDUAL",
+            "broker_buying_power": "1000",
+            "positions": positions,
+            "open_orders": [],
+        }
+        result = {
+            **state,
+            "broker_buying_power_as_of": "1785167970000",
+            "state_sha256": _domain_json_sha256(
+                b"etrade-capacity-state.v2\0", state
+            ),
+        }
+        with self.assertRaisesRegex(
+            OrderIntentIntegrityError,
+            "different account",
+        ):
+            _validate_capacity_manifest_result(
+                result,
+                expected_account_id=ACCOUNT_ID,
+            )
+
     def test_complete_capacity_manifest_drives_decision_and_reservation(
         self,
     ) -> None:
@@ -706,6 +932,94 @@ class BrokerReadLedgerTests(unittest.TestCase):
                 ),
             )
 
+    def test_mutable_cap_row_cannot_override_content_addressed_decision(
+        self,
+    ) -> None:
+        first, decision = self._create_reserved_unknown_intent()
+        second = self.ledger.create_intent(
+            _opening_intent(key="cap-row-tamper")
+        ).intent
+        risk = RiskEvidence(
+            decision_id=second.envelope.decision_id,
+            max_loss_amount=Decimal("500"),
+            collateral_amount=Decimal("500"),
+            quote_observed_at=self.clock.now,
+            quote_digest="d" * 64,
+            portfolio_observed_at=decision.observed_at,
+            portfolio_snapshot_digest=(
+                decision.portfolio_snapshot_digest
+            ),
+            capacity_decision_sha256=decision.decision_sha256,
+        )
+        with self.assertRaises(OrderIntentReservationError):
+            self.ledger.reserve_margin(second.intent_id, risk)
+
+        with sqlite3.connect(self.path) as connection:
+            connection.execute(
+                """
+                UPDATE reservation_caps SET cap_amount = '1000'
+                WHERE account_id = ? AND environment = ?
+                """,
+                (first.envelope.account_id, first.envelope.environment),
+            )
+
+        with self.assertRaises(OrderIntentIntegrityError):
+            self.ledger.reserve_margin(second.intent_id, risk)
+        with self.assertRaises(OrderIntentIntegrityError):
+            OrderIntentLedger(
+                self.path,
+                clock=self.clock,
+                run_id="cap-row-tamper-restart",
+            )
+
+    def test_active_risk_fails_closed_after_reservation_identity_tamper(
+        self,
+    ) -> None:
+        self._create_reserved_unknown_intent()
+        with sqlite3.connect(self.path) as connection:
+            connection.execute(
+                "DROP TRIGGER prevent_margin_reservation_identity_update"
+            )
+            connection.execute(
+                """
+                UPDATE margin_reservations SET account_id = ?
+                WHERE account_id = ? AND environment = ?
+                """,
+                ("moved-account", ACCOUNT_ID, ENVIRONMENT),
+            )
+
+        with self.assertRaises(OrderIntentIntegrityError):
+            self.ledger.active_reserved_margin(
+                ACCOUNT_ID, ENVIRONMENT
+            )
+        with self.assertRaises(OrderIntentIntegrityError):
+            OrderIntentLedger(
+                self.path,
+                clock=self.clock,
+                run_id="reservation-identity-tamper-restart",
+            )
+
+    def test_active_risk_fails_closed_after_reservation_deletion(
+        self,
+    ) -> None:
+        self._create_reserved_unknown_intent()
+        with sqlite3.connect(self.path) as connection:
+            connection.execute(
+                "DROP TRIGGER prevent_margin_reservation_delete"
+            )
+            connection.execute("DELETE FROM margin_reservations")
+
+        with self.assertRaises(OrderIntentIntegrityError):
+            self.ledger.active_reserved_margin(
+                ACCOUNT_ID, ENVIRONMENT
+            )
+        with self.assertRaises(OrderIntentIntegrityError):
+            OrderIntentLedger(
+                self.path,
+                clock=self.clock,
+                run_id="reservation-deletion-restart",
+            )
+
     def test_query_manifest_provenance_and_economic_mismatch_rejection(
         self,
     ) -> None:
@@ -752,6 +1066,381 @@ class BrokerReadLedgerTests(unittest.TestCase):
             .broker_read_evidence_sha256,
             valid_query.evidence_sha256,
         )
+
+    def test_latest_head_verification_does_not_replay_older_history(
+        self,
+    ) -> None:
+        broker_order_id = "9000093"
+        record, _ = self._create_reserved_unknown_intent()
+        historical = []
+        for _index in range(16):
+            manifest, _ = self._order_query_manifest(
+                broker_order_id=broker_order_id,
+                payload_hashes=(record.envelope.payload_hash,),
+                outcome="CANCELLED",
+            )
+            historical.append(manifest.evidence_sha256)
+            self.clock.now += timedelta(seconds=1)
+        terminal = self.ledger.broker_evidence_from_read(
+            record.intent_id,
+            BrokerReadEvidenceRef(
+                historical[-1], "ORDER_QUERY"
+            ),
+            operation="ORDER_QUERY",
+        )
+        self.assertIsNotNone(terminal)
+        self.ledger.reconcile_terminal(
+            record.intent_id, "CANCELLED", terminal
+        )
+        latest, _ = self._order_query_manifest(
+            broker_order_id=broker_order_id,
+            payload_hashes=(record.envelope.payload_hash,),
+            outcome="CANCELLED",
+        )
+
+        with patch.object(
+            self.ledger,
+            "_verified_broker_read_manifest",
+            wraps=self.ledger._verified_broker_read_manifest,
+        ) as verified:
+            requirement = (
+                self.ledger.terminal_absorption_requirement(
+                    record.intent_id, latest
+                )
+            )
+        self.assertEqual(requirement.classification, "ZERO_FILL")
+        replayed = {
+            call.args[-1] for call in verified.call_args_list
+        }
+        self.assertEqual(replayed, {latest.evidence_sha256})
+        self.assertTrue(set(historical).isdisjoint(replayed))
+
+    def test_full_fill_absorption_retains_verified_risk_and_lot_chain(
+        self,
+    ) -> None:
+        broker_order_id = "9000094"
+        record, baseline = self._create_reserved_unknown_intent()
+        terminal_read, _ = self._order_query_manifest(
+            broker_order_id=broker_order_id,
+            payload_hashes=(record.envelope.payload_hash,),
+            outcome="FILLED",
+            product_id_type="ORDER",
+        )
+        terminal = self.ledger.broker_evidence_from_read(
+            record.intent_id,
+            terminal_read,
+            operation="ORDER_QUERY",
+        )
+        self.assertIsNotNone(terminal)
+        self.ledger.reconcile_terminal(
+            record.intent_id, "FILLED", terminal
+        )
+        self.clock.now += timedelta(seconds=1)
+        superseded_terminal, _ = self._order_query_manifest(
+            broker_order_id=broker_order_id,
+            payload_hashes=(record.envelope.payload_hash,),
+            outcome="FILLED",
+            product_id_type="ORDER",
+        )
+        self.clock.now += timedelta(seconds=1)
+        fresh_terminal, _ = self._order_query_manifest(
+            broker_order_id=broker_order_id,
+            payload_hashes=(record.envelope.payload_hash,),
+            outcome="FILLED",
+            product_id_type="ORDER",
+        )
+        with self.assertRaisesRegex(
+            OrderIntentReconciliationRequired, "superseded"
+        ):
+            self.ledger.terminal_absorption_requirement(
+                record.intent_id, superseded_terminal
+            )
+        terminal_observed_at = self.clock.now
+        requirement = self.ledger.terminal_absorption_requirement(
+            record.intent_id, fresh_terminal
+        )
+        self.assertEqual(requirement.classification, "FULL_FILL")
+        self.assertTrue(requirement.post_capacity_required)
+        self.assertEqual(
+            requirement.baseline_capacity_decision_sha256,
+            baseline.decision_sha256,
+        )
+        positions = _filled_vertical_positions(broker_order_id)
+        self.clock.now += timedelta(seconds=1)
+        overlapping_capacity, _, _ = self._capacity_manifest(
+            positions=positions,
+            schema="etrade-capacity.v2",
+        )
+        overlapping_post = self.ledger.set_reservation_cap_from_read(
+            overlapping_capacity, risk_budget=Decimal("750")
+        )
+        with self.assertRaisesRegex(
+            OrderIntentReconciliationRequired,
+            "began before terminal order evidence",
+        ):
+            self.ledger.absorb_terminal_reservation(
+                record.intent_id,
+                fresh_terminal,
+                post_capacity_decision=overlapping_post,
+            )
+        # Every request in the post-fill capacity scan must begin strictly
+        # after the selected terminal order observation. This fixture models a
+        # bounded 30-second read window.
+        self.clock.now += timedelta(seconds=31)
+        legacy_capacity, _, _ = self._capacity_manifest()
+        legacy_post = self.ledger.set_reservation_cap_from_read(
+            legacy_capacity, risk_budget=Decimal("750")
+        )
+        with self.assertRaises(OrderIntentReconciliationRequired):
+            self.ledger.absorb_terminal_reservation(
+                record.intent_id,
+                fresh_terminal,
+                post_capacity_decision=legacy_post,
+            )
+
+        conflicting_positions = _filled_vertical_positions(
+            broker_order_id
+        )
+        conflicting_positions[0]["product"] = {
+            **conflicting_positions[0]["product"],
+            "product_id": {
+                "symbol": "SPY",
+                "type_code": "OPTN",
+            },
+        }
+        self.clock.now += timedelta(seconds=1)
+        capacity, _, _ = self._capacity_manifest(
+            positions=conflicting_positions,
+            schema="etrade-capacity.v2",
+        )
+        conflicting_post = self.ledger.set_reservation_cap_from_read(
+            capacity, risk_budget=Decimal("750")
+        )
+        with self.assertRaises(OrderIntentReconciliationRequired):
+            self.ledger.absorb_terminal_reservation(
+                record.intent_id,
+                fresh_terminal,
+                post_capacity_decision=conflicting_post,
+            )
+        self.assertEqual(
+            self.ledger.get_margin_reservation(record.intent_id).state,
+            "FILLED_PENDING_ABSORPTION",
+        )
+
+        self.clock.now += timedelta(seconds=1)
+        superseded_capacity, _, _ = self._capacity_manifest(
+            positions=positions,
+            schema="etrade-capacity.v2",
+        )
+        superseded_post = self.ledger.set_reservation_cap_from_read(
+            superseded_capacity, risk_budget=Decimal("750")
+        )
+        self.clock.now += timedelta(seconds=1)
+        compatible_capacity, _, _ = self._capacity_manifest(
+            positions=positions,
+            schema="etrade-capacity.v2",
+        )
+        post = self.ledger.set_reservation_cap_from_read(
+            compatible_capacity, risk_budget=Decimal("750")
+        )
+        post_observed_at = self.clock.now
+        with self.assertRaisesRegex(
+            OrderIntentReconciliationRequired, "superseded"
+        ):
+            self.ledger.absorb_terminal_reservation(
+                record.intent_id,
+                fresh_terminal,
+                post_capacity_decision=superseded_post,
+            )
+        receipt = self.ledger.absorb_terminal_reservation(
+            record.intent_id,
+            fresh_terminal,
+            post_capacity_decision=post,
+        )
+        self.assertEqual(receipt.classification, "FULL_FILL")
+        self.assertEqual(
+            receipt.baseline_capacity_decision_sha256,
+            baseline.decision_sha256,
+        )
+        self.assertEqual(
+            receipt.post_capacity_decision_sha256,
+            post.decision_sha256,
+        )
+        self.assertEqual(
+            receipt.absorbed_margin_amount, Decimal("500")
+        )
+        self.assertEqual(receipt.observed_at, post_observed_at)
+        final_event = self.ledger.events(record.intent_id)[-1]
+        self.assertEqual(final_event.event_type, "FILLED_ABSORBED")
+        self.assertEqual(final_event.observed_at, terminal_observed_at)
+        self.assertNotEqual(
+            final_event.observed_at, receipt.observed_at
+        )
+        with patch.object(
+            self.ledger,
+            "_verified_capacity_decision_row",
+            wraps=self.ledger._verified_capacity_decision_row,
+        ) as verified_decision, patch.object(
+            self.ledger,
+            "_reservation_absorption_from_row",
+            wraps=self.ledger._reservation_absorption_from_row,
+        ) as verified_absorption:
+            active_margin = self.ledger.active_reserved_margin(
+                ACCOUNT_ID, ENVIRONMENT
+            )
+        self.assertEqual(
+            active_margin, Decimal("500")
+        )
+        self.assertEqual(verified_absorption.call_count, 1)
+        decision_replays = [
+            call.args[-1]
+            for call in verified_decision.call_args_list
+        ]
+        self.assertEqual(
+            decision_replays.count(baseline.decision_sha256), 1
+        )
+        self.assertEqual(
+            decision_replays.count(post.decision_sha256), 1
+        )
+        self.assertEqual(len(decision_replays), 2)
+        self.assertEqual(
+            self.ledger.absorb_terminal_reservation(
+                record.intent_id,
+                fresh_terminal,
+                post_capacity_decision=post,
+            ),
+            receipt,
+        )
+        with self.assertRaises(OrderIntentIntegrityError):
+            self.ledger.absorb_terminal_reservation(
+                record.intent_id, fresh_terminal
+            )
+
+        second = self.ledger.create_intent(
+            _opening_intent(key="absorbed-cap-not-recycled")
+        ).intent
+        with self.assertRaisesRegex(
+            OrderIntentReservationError,
+            "exceeds account/environment cap",
+        ):
+            self.ledger.reserve_margin(
+                second.intent_id,
+                RiskEvidence(
+                    decision_id=second.envelope.decision_id,
+                    max_loss_amount=Decimal("500"),
+                    collateral_amount=Decimal("500"),
+                    quote_observed_at=self.clock.now,
+                    quote_digest="d" * 64,
+                    portfolio_observed_at=post.observed_at,
+                    portfolio_snapshot_digest=(
+                        post.portfolio_snapshot_digest
+                    ),
+                    capacity_decision_sha256=post.decision_sha256,
+                ),
+            )
+
+        with sqlite3.connect(self.path) as connection:
+            with self.assertRaises(sqlite3.DatabaseError):
+                connection.execute(
+                    """
+                    UPDATE reservation_absorptions
+                    SET absorbed_margin_amount = '1'
+                    WHERE intent_id = ?
+                    """,
+                    (record.intent_id,),
+                )
+            with self.assertRaises(sqlite3.DatabaseError):
+                connection.execute(
+                    """
+                    UPDATE margin_reservations
+                    SET released_reason_code = 'tampered'
+                    WHERE intent_id = ?
+                    """,
+                    (record.intent_id,),
+                )
+            connection.execute(
+                "DROP TRIGGER prevent_reservation_absorption_update"
+            )
+            connection.execute(
+                """
+                UPDATE reservation_absorptions
+                SET absorbed_margin_amount = '1'
+                WHERE intent_id = ?
+                """,
+                (record.intent_id,),
+            )
+        with self.assertRaises(OrderIntentIntegrityError):
+            self.ledger.active_reserved_margin(
+                ACCOUNT_ID, ENVIRONMENT
+            )
+
+    def test_deleted_full_fill_receipt_never_recycles_risk(
+        self,
+    ) -> None:
+        broker_order_id = "9000095"
+        record, _baseline = self._create_reserved_unknown_intent()
+        terminal_read, _ = self._order_query_manifest(
+            broker_order_id=broker_order_id,
+            payload_hashes=(record.envelope.payload_hash,),
+            outcome="FILLED",
+        )
+        terminal = self.ledger.broker_evidence_from_read(
+            record.intent_id,
+            terminal_read,
+            operation="ORDER_QUERY",
+        )
+        self.assertIsNotNone(terminal)
+        self.ledger.reconcile_terminal(
+            record.intent_id, "FILLED", terminal
+        )
+        self.clock.now += timedelta(seconds=1)
+        fresh_terminal, _ = self._order_query_manifest(
+            broker_order_id=broker_order_id,
+            payload_hashes=(record.envelope.payload_hash,),
+            outcome="FILLED",
+        )
+        self.clock.now += timedelta(seconds=31)
+        capacity, _, _ = self._capacity_manifest(
+            positions=_filled_vertical_positions(broker_order_id),
+            schema="etrade-capacity.v2",
+        )
+        post = self.ledger.set_reservation_cap_from_read(
+            capacity, risk_budget=Decimal("750")
+        )
+        self.ledger.absorb_terminal_reservation(
+            record.intent_id,
+            fresh_terminal,
+            post_capacity_decision=post,
+        )
+        self.assertEqual(
+            self.ledger.active_reserved_margin(
+                ACCOUNT_ID, ENVIRONMENT
+            ),
+            Decimal("500"),
+        )
+
+        with sqlite3.connect(self.path) as connection:
+            connection.execute(
+                "DROP TRIGGER prevent_reservation_absorption_delete"
+            )
+            connection.execute(
+                """
+                DELETE FROM reservation_absorptions
+                WHERE intent_id = ?
+                """,
+                (record.intent_id,),
+            )
+
+        with self.assertRaises(OrderIntentIntegrityError):
+            self.ledger.active_reserved_margin(
+                ACCOUNT_ID, ENVIRONMENT
+            )
+        with self.assertRaises(OrderIntentIntegrityError):
+            OrderIntentLedger(
+                self.path,
+                clock=self.clock,
+                run_id="deleted-full-fill-receipt-restart",
+            )
 
     def test_query_manifest_rejects_receipt_for_a_different_order(
         self,
@@ -1020,8 +1709,27 @@ class BrokerReadLedgerTests(unittest.TestCase):
             ("reservation_caps", "capacity_decisions"),
             ("margin_reservations", "capacity_decisions"),
             ("order_events", "broker_read_manifests"),
+            ("reservation_absorptions", "order_intents"),
+            ("reservation_absorptions", "broker_read_manifests"),
+            ("reservation_absorptions", "capacity_decisions"),
         }
         required_triggers = {
+            "prevent_order_event_update": "before update",
+            "prevent_order_event_delete": "before delete",
+            "prevent_amendment_history_update": "before update",
+            "prevent_amendment_history_delete": "before delete",
+            "prevent_outbound_authorization_update": "before update",
+            "prevent_outbound_authorization_delete": "before delete",
+            "prevent_transport_send_attempt_update": "before update",
+            "prevent_transport_send_attempt_delete": "before delete",
+            "prevent_broker_preview_receipt_update": "before update",
+            "prevent_broker_preview_receipt_delete": "before delete",
+            "prevent_transport_response_receipt_update": "before update",
+            "prevent_transport_response_receipt_delete": "before delete",
+            "prevent_broker_order_history_update": "before update",
+            "prevent_broker_order_history_delete": "before delete",
+            "prevent_intent_identity_mutation": "before update",
+            "prevent_terminal_rewrite": "before update",
             "prevent_broker_read_receipt_update": "before update",
             "prevent_broker_read_receipt_delete": "before delete",
             "prevent_broker_read_manifest_update": "before update",
@@ -1030,6 +1738,17 @@ class BrokerReadLedgerTests(unittest.TestCase):
             "prevent_broker_read_member_delete": "before delete",
             "prevent_capacity_decision_update": "before update",
             "prevent_capacity_decision_delete": "before delete",
+            "prevent_reservation_absorption_update": "before update",
+            "prevent_reservation_absorption_delete": "before delete",
+            "prevent_margin_reservation_delete": "before delete",
+            "prevent_margin_reservation_identity_update": "before update",
+            "prevent_margin_reservation_invalid_transition": "before update",
+            "prevent_margin_reservation_release_rewrite": "before update",
+            "validate_margin_reservation_insert": "before insert",
+            "validate_reservation_created_event_insert": "before insert",
+            "validate_margin_reservation_pre_post_release": "before update",
+            "validate_reservation_absorption_insert": "before insert",
+            "require_terminal_absorption_receipt": "before update",
         }
         with sqlite3.connect(self.path) as connection:
             actual_foreign_keys = {
@@ -1056,6 +1775,132 @@ class BrokerReadLedgerTests(unittest.TestCase):
                 normalized = " ".join(triggers[name].lower().split())
                 self.assertIn(expected_action, normalized)
                 self.assertIn("raise(abort", normalized)
+
+    def test_durable_legacy_triggers_are_repaired_or_rejected_exactly(
+        self,
+    ) -> None:
+        triggers = (
+            ("prevent_order_event_update", "UPDATE", "order_events"),
+            ("prevent_order_event_delete", "DELETE", "order_events"),
+            (
+                "prevent_amendment_history_update",
+                "UPDATE",
+                "amendment_history",
+            ),
+            (
+                "prevent_amendment_history_delete",
+                "DELETE",
+                "amendment_history",
+            ),
+            (
+                "prevent_outbound_authorization_update",
+                "UPDATE",
+                "outbound_authorizations",
+            ),
+            (
+                "prevent_outbound_authorization_delete",
+                "DELETE",
+                "outbound_authorizations",
+            ),
+            (
+                "prevent_transport_send_attempt_update",
+                "UPDATE",
+                "transport_send_attempts",
+            ),
+            (
+                "prevent_transport_send_attempt_delete",
+                "DELETE",
+                "transport_send_attempts",
+            ),
+            (
+                "prevent_broker_preview_receipt_update",
+                "UPDATE",
+                "broker_preview_receipts",
+            ),
+            (
+                "prevent_broker_preview_receipt_delete",
+                "DELETE",
+                "broker_preview_receipts",
+            ),
+            (
+                "prevent_transport_response_receipt_update",
+                "UPDATE",
+                "transport_response_receipts",
+            ),
+            (
+                "prevent_transport_response_receipt_delete",
+                "DELETE",
+                "transport_response_receipts",
+            ),
+            (
+                "prevent_broker_order_history_update",
+                "UPDATE",
+                "broker_order_history",
+            ),
+            (
+                "prevent_broker_order_history_delete",
+                "DELETE",
+                "broker_order_history",
+            ),
+            (
+                "prevent_intent_identity_mutation",
+                "UPDATE",
+                "order_intents",
+            ),
+            ("prevent_terminal_rewrite", "UPDATE", "order_intents"),
+        )
+        for name, operation, table in triggers:
+            with self.subTest(trigger=name):
+                path = (
+                    Path(self.tmp.name)
+                    / "durable-trigger-audit"
+                    / f"{name}.sqlite3"
+                )
+                OrderIntentLedger(
+                    path,
+                    clock=self.clock,
+                    run_id=f"before-drop-{name}",
+                )
+                with sqlite3.connect(path) as connection:
+                    connection.execute(f'DROP TRIGGER "{name}"')
+
+                OrderIntentLedger(
+                    path,
+                    clock=self.clock,
+                    run_id=f"repair-{name}",
+                )
+                with sqlite3.connect(path) as connection:
+                    sql = connection.execute(
+                        """
+                        SELECT sql FROM sqlite_master
+                        WHERE type = 'trigger' AND name = ?
+                        """,
+                        (name,),
+                    ).fetchone()[0]
+                    normalized = " ".join(sql.lower().split())
+                    self.assertIn(
+                        f"before {operation.lower()} on {table}",
+                        normalized,
+                    )
+                    self.assertIn("raise(abort", normalized)
+                    connection.execute(f'DROP TRIGGER "{name}"')
+                    connection.execute(
+                        f"""
+                        CREATE TRIGGER "{name}"
+                        BEFORE {operation} ON "{table}"
+                        WHEN 0
+                        BEGIN
+                            SELECT RAISE(ABORT, 'never runs');
+                        END
+                        """
+                    )
+
+                with self.assertRaises(OrderIntentLedgerError):
+                    OrderIntentLedger(
+                        path,
+                        clock=self.clock,
+                        run_id=f"reject-replacement-{name}",
+                    )
 
     def test_malformed_provenance_schema_does_not_promote_metadata(
         self,
@@ -1096,6 +1941,64 @@ class BrokerReadLedgerTests(unittest.TestCase):
                 10,
             )
 
+    def test_schema_11_migrates_to_immutable_absorption_receipts(
+        self,
+    ) -> None:
+        new_triggers = (
+            "prevent_reservation_absorption_update",
+            "prevent_reservation_absorption_delete",
+            "prevent_margin_reservation_delete",
+            "prevent_margin_reservation_identity_update",
+            "prevent_margin_reservation_invalid_transition",
+            "prevent_margin_reservation_release_rewrite",
+            "validate_margin_reservation_insert",
+            "validate_reservation_created_event_insert",
+            "validate_margin_reservation_pre_post_release",
+            "validate_reservation_absorption_insert",
+            "require_terminal_absorption_receipt",
+        )
+        with sqlite3.connect(self.path) as connection:
+            for trigger in new_triggers:
+                connection.execute(f"DROP TRIGGER {trigger}")
+            connection.execute("DROP TABLE reservation_absorptions")
+            connection.execute(
+                """
+                UPDATE ledger_metadata SET schema_version = 11
+                WHERE singleton = 1
+                """
+            )
+
+        migrated = OrderIntentLedger(
+            self.path, clock=self.clock, run_id="schema-11-migration"
+        )
+        self.assertIsNotNone(migrated)
+        with sqlite3.connect(self.path) as connection:
+            self.assertEqual(
+                connection.execute(
+                    "SELECT schema_version FROM ledger_metadata"
+                ).fetchone()[0],
+                SCHEMA_VERSION,
+            )
+            self.assertIsNotNone(
+                connection.execute(
+                    """
+                    SELECT 1 FROM sqlite_master
+                    WHERE type = 'table'
+                      AND name = 'reservation_absorptions'
+                    """
+                ).fetchone()
+            )
+            trigger_names = {
+                row[0]
+                for row in connection.execute(
+                    """
+                    SELECT name FROM sqlite_master
+                    WHERE type = 'trigger'
+                    """
+                )
+            }
+            self.assertTrue(set(new_triggers) <= trigger_names)
+
         malformed_trigger_path = (
             Path(self.tmp.name)
             / "malformed-trigger"
@@ -1132,6 +2035,39 @@ class BrokerReadLedgerTests(unittest.TestCase):
                     "SELECT schema_version FROM ledger_metadata"
                 ).fetchone()[0],
                 10,
+            )
+
+    def test_schema_verifier_rejects_inert_required_trigger(
+        self,
+    ) -> None:
+        inert_trigger_path = (
+            Path(self.tmp.name)
+            / "inert-trigger"
+            / "orders.sqlite3"
+        )
+        OrderIntentLedger(
+            inert_trigger_path,
+            clock=self.clock,
+            run_id="valid-before-inert-trigger",
+        )
+        with sqlite3.connect(inert_trigger_path) as connection:
+            connection.executescript(
+                """
+                DROP TRIGGER require_terminal_absorption_receipt;
+                CREATE TRIGGER require_terminal_absorption_receipt
+                BEFORE UPDATE ON margin_reservations
+                WHEN 0
+                BEGIN
+                    SELECT RAISE(ABORT, 'never runs');
+                END;
+                """
+            )
+
+        with self.assertRaises(OrderIntentLedgerError):
+            OrderIntentLedger(
+                inert_trigger_path,
+                clock=self.clock,
+                run_id="inert-trigger",
             )
 
     def test_schema_10_migration_adds_read_provenance_columns(self) -> None:

--- a/etrade_python_client/tests/test_etrade_broker_reader.py
+++ b/etrade_python_client/tests/test_etrade_broker_reader.py
@@ -19,12 +19,18 @@ from live_trading.etrade_broker_reader import (
     ETradeBrokerReader,
     ETradeBrokerReaderIntegrityError,
     ETradeBrokerReaderUnavailable,
+    _PARSER_CODE_SHA256,
+    _PARSER_CONFIG_SHA256,
+    _PARSER_SCHEMA,
+    _canonical_fill_summary_legs,
+    _reparse_broker_read_response,
 )
 from live_trading.etrade_broker_transport import (
     SelectedBrokerAccount,
     _ExchangeResult,
 )
 from live_trading.order_intent_ledger import (
+    BrokerReadResponseEvidence,
     OrderIntentLedger,
     canonical_order_payload_hash,
 )
@@ -152,7 +158,43 @@ def balance(
     )
 
 
-def position(position_id: str, strike: str) -> dict:
+def position_lot(
+    position_id: str,
+    *,
+    lot_id: str,
+    order_no: str = ORDER_ID,
+    leg_no: str = "1",
+    original_quantity: str = "1",
+    remaining_quantity: str = "1",
+    available_quantity: str = "1",
+    acquired_date: str = "1785167100000",
+) -> dict:
+    return {
+        "positionId": position_id,
+        "positionLotId": lot_id,
+        "orderNo": order_no,
+        "legNo": leg_no,
+        "originalQty": original_quantity,
+        "remainingQty": remaining_quantity,
+        "availableQty": available_quantity,
+        "acquiredDate": acquired_date,
+    }
+
+
+def position(
+    position_id: str,
+    strike: str,
+    *,
+    lots: list[dict] | None = None,
+) -> dict:
+    if lots is None:
+        lots = [
+            position_lot(
+                position_id,
+                lot_id=str(1_000 + int(position_id)),
+                leg_no="1" if strike == "620" else "2",
+            )
+        ]
     return {
         "positionId": position_id,
         "accountId": ACCOUNT_ID,
@@ -169,6 +211,7 @@ def position(position_id: str, strike: str) -> dict:
             "expiryDay": "21",
             "strikePrice": strike,
         },
+        "PositionLot": lots,
     }
 
 
@@ -235,6 +278,7 @@ def option_leg(
     strike: str,
     *,
     filled_quantity: str,
+    cancel_quantity: str = "0",
 ) -> dict:
     return {
         "Product": {
@@ -250,7 +294,7 @@ def option_leg(
         "quantityType": "QUANTITY",
         "orderedQuantity": "1",
         "filledQuantity": filled_quantity,
-        "cancelQuantity": "0",
+        "cancelQuantity": cancel_quantity,
     }
 
 
@@ -259,42 +303,60 @@ def known_order(
     *,
     filled_quantity: str = "0",
     second_filled_quantity: str | None = None,
+    cancel_quantity: str | None = None,
+    second_cancel_quantity: str | None = None,
     order_id: str = ORDER_ID,
     replaces_order_id: str | None = None,
     replaced_by_order_id: str | None = None,
 ) -> Reply:
+    second_filled = (
+        filled_quantity
+        if second_filled_quantity is None
+        else second_filled_quantity
+    )
+    terminal_zero = status in {"CANCELLED", "REJECTED", "EXPIRED"}
+    first_cancel = (
+        ("1" if terminal_zero and filled_quantity == "0" else "0")
+        if cancel_quantity is None
+        else cancel_quantity
+    )
+    second_cancel = (
+        ("1" if terminal_zero and second_filled == "0" else "0")
+        if second_cancel_quantity is None
+        else second_cancel_quantity
+    )
+    detail = {
+        "accountId": ACCOUNT_ID,
+        "orderNumber": order_id,
+        "placedTime": "1785167000000",
+        "status": status,
+        "priceType": "NET_CREDIT",
+        "limitPrice": "1.25",
+        "orderTerm": "GOOD_FOR_DAY",
+        "marketSession": "REGULAR",
+        "allOrNone": False,
+        "stopPrice": "0",
+        "Instrument": [
+            option_leg(
+                "SELL_OPEN",
+                "620",
+                filled_quantity=filled_quantity,
+                cancel_quantity=first_cancel,
+            ),
+            option_leg(
+                "BUY_OPEN",
+                "615",
+                filled_quantity=second_filled,
+                cancel_quantity=second_cancel,
+            ),
+        ],
+    }
+    if status == "EXECUTED":
+        detail["executedTime"] = "1785167100000"
     outer_order = {
         "orderId": order_id,
         "orderType": "SPREADS",
-        "OrderDetail": [
-            {
-                "accountId": ACCOUNT_ID,
-                "orderNumber": order_id,
-                "status": status,
-                "priceType": "NET_CREDIT",
-                "limitPrice": "1.25",
-                "orderTerm": "GOOD_FOR_DAY",
-                "marketSession": "REGULAR",
-                "allOrNone": False,
-                "stopPrice": "0",
-                "Instrument": [
-                    option_leg(
-                        "SELL_OPEN",
-                        "620",
-                        filled_quantity=filled_quantity,
-                    ),
-                    option_leg(
-                        "BUY_OPEN",
-                        "615",
-                        filled_quantity=(
-                            filled_quantity
-                            if second_filled_quantity is None
-                            else second_filled_quantity
-                        ),
-                    ),
-                ],
-            }
-        ],
+        "OrderDetail": [detail],
     }
     if replaces_order_id is not None:
         outer_order["replacesOrderId"] = replaces_order_id
@@ -307,6 +369,10 @@ def known_order(
             }
         }
     )
+
+
+def reply_document(reply: Reply) -> dict:
+    return json.loads(reply.raw)
 
 
 def expected_vertical_payload() -> dict:
@@ -569,6 +635,15 @@ class ETradeBrokerReaderTests(unittest.TestCase):
             if urlsplit(prepared.url).path.endswith("/portfolio.json")
         ]
         self.assertEqual(len(portfolio_calls), 4)
+        self.assertTrue(
+            all(
+                parse_qs(urlsplit(prepared.url).query)[
+                    "lotsRequired"
+                ]
+                == ["true"]
+                for prepared in portfolio_calls
+            )
+        )
         self.assertEqual(
             [
                 parse_qs(urlsplit(prepared.url).query)["pageNumber"][0]
@@ -579,12 +654,26 @@ class ETradeBrokerReaderTests(unittest.TestCase):
         result = self.manifest_result(
             case, evidence.evidence_sha256
         )
+        self.assertEqual(result["schema"], "etrade-capacity.v2")
         self.assertEqual(result["broker_buying_power"], "1000")
         self.assertEqual(
             [item["position_id"] for item in result["positions"]],
             ["11", "12"],
         )
         self.assertEqual(result["open_orders"], [])
+        self.assertEqual(
+            result["positions"][0]["lots"][0],
+            {
+                "position_id": "11",
+                "position_lot_id": "1011",
+                "order_no": ORDER_ID,
+                "leg_no": "2",
+                "original_quantity": "1",
+                "remaining_quantity": "1",
+                "available_quantity": "1",
+                "acquired_date_epoch_ms": "1785167100000",
+            },
+        )
         self.assertEqual(len(result["state_sha256"]), 64)
         receipt_rows = self.rows(
             case,
@@ -704,6 +793,349 @@ class ETradeBrokerReaderTests(unittest.TestCase):
             ),
             12,
         )
+
+    def test_capacity_stability_includes_exact_position_lots(self) -> None:
+        first_position = position(
+            "12",
+            "620",
+            lots=[
+                position_lot(
+                    "12",
+                    lot_id="1012",
+                    remaining_quantity="1",
+                )
+            ],
+        )
+        second_position = position(
+            "12",
+            "620",
+            lots=[
+                position_lot(
+                    "12",
+                    lot_id="1012",
+                    remaining_quantity="0",
+                )
+            ],
+        )
+        first_scan = [
+            balance("1000"),
+            portfolio_page(1, 1, [first_position]),
+            no_content(),
+            no_content(),
+            no_content(),
+        ]
+        second_scan = [
+            balance("1000"),
+            portfolio_page(1, 1, [second_position]),
+            no_content(),
+            no_content(),
+            no_content(),
+        ]
+        case = self.case(
+            [
+                account_list(account()),
+                *first_scan,
+                *second_scan,
+                account_list(account()),
+            ]
+        )
+
+        with self.assertRaisesRegex(
+            ETradeBrokerReaderUnavailable,
+            "capacity state changed between complete scans",
+        ):
+            case.reader.read_capacity(case.account)
+
+    def test_position_lots_require_valid_parent_and_unique_ids(self) -> None:
+        malformed_positions = []
+        malformed_positions.append(
+            position(
+                "12",
+                "620",
+                lots=[
+                    position_lot("13", lot_id="1012")
+                ],
+            )
+        )
+        malformed_positions.append(
+            position(
+                "12",
+                "620",
+                lots=[
+                    position_lot("12", lot_id="1012"),
+                    position_lot("12", lot_id="1012"),
+                ],
+            )
+        )
+        for malformed in malformed_positions:
+            with self.subTest(position=malformed):
+                case = self.case(
+                    [
+                        account_list(account()),
+                        balance("1000"),
+                        portfolio_page(1, 1, [malformed]),
+                    ]
+                )
+                with self.assertRaises(ETradeBrokerReaderIntegrityError):
+                    case.reader.read_capacity(case.account)
+                receipt = self.rows(
+                    case,
+                    """
+                    SELECT completeness, canonical_parsed_json
+                    FROM broker_read_receipts
+                    WHERE read_kind = 'PORTFOLIO_PAGE'
+                    """,
+                )
+                self.assertEqual(len(receipt), 1)
+                self.assertEqual(receipt[0]["completeness"], "INELIGIBLE")
+                self.assertEqual(
+                    receipt[0]["canonical_parsed_json"], "null"
+                )
+
+    def test_position_account_must_match_the_selected_account(self) -> None:
+        cross_account = position("12", "620")
+        cross_account["accountId"] = "999999999"
+        case = self.case(
+            [
+                account_list(account()),
+                balance("1000"),
+                portfolio_page(1, 1, [cross_account]),
+            ]
+        )
+
+        with self.assertRaisesRegex(
+            ETradeBrokerReaderIntegrityError,
+            "position account id does not match configured account",
+        ):
+            case.reader.read_capacity(case.account)
+
+        receipt = self.rows(
+            case,
+            """
+            SELECT completeness, canonical_parsed_json
+            FROM broker_read_receipts
+            WHERE read_kind = 'PORTFOLIO_PAGE'
+            """,
+        )
+        self.assertEqual(len(receipt), 1)
+        self.assertEqual(receipt[0]["completeness"], "INELIGIBLE")
+        self.assertEqual(receipt[0]["canonical_parsed_json"], "null")
+
+    def test_missing_or_empty_option_lots_normalize_to_empty(self) -> None:
+        missing = position("12", "620")
+        missing.pop("PositionLot")
+        empty = position("12", "620", lots=[])
+        case = self.case([])
+        for raw_position in (missing, empty):
+            with self.subTest(raw_position=raw_position):
+                parsed, completeness = (
+                    case.reader._parse_portfolio_page(
+                        200,
+                        portfolio_page(1, 1, [raw_position]).raw,
+                        1,
+                        lots_required=True,
+                    )
+                )
+                self.assertEqual(completeness, "COMPLETE")
+                self.assertEqual(
+                    parsed["positions"][0]["lots"], []
+                )
+
+    def test_unrelated_lot_order_and_leg_sentinels_are_preserved(
+        self,
+    ) -> None:
+        missing_links = position_lot("12", lot_id="1013")
+        missing_links.pop("orderNo")
+        missing_links.pop("legNo")
+        raw_position = position(
+            "12",
+            "620",
+            lots=[
+                position_lot(
+                    "12",
+                    lot_id="1012",
+                    order_no="0",
+                    leg_no="0",
+                ),
+                missing_links,
+            ],
+        )
+        case = self.case([])
+
+        parsed, completeness = case.reader._parse_portfolio_page(
+            200,
+            portfolio_page(1, 1, [raw_position]).raw,
+            1,
+            lots_required=True,
+        )
+
+        self.assertEqual(completeness, "COMPLETE")
+        links = {
+            lot["position_lot_id"]: (
+                lot["order_no"],
+                lot["leg_no"],
+            )
+            for lot in parsed["positions"][0]["lots"]
+        }
+        self.assertEqual(
+            links, {"1012": ("0", "0"), "1013": (None, None)}
+        )
+
+    def test_short_option_lot_quantities_preserve_their_sign(self) -> None:
+        short_lot = position_lot(
+            "12",
+            lot_id="1012",
+            original_quantity="-1",
+            remaining_quantity="-1",
+            available_quantity="-1",
+        )
+        raw_position = position("12", "620", lots=[short_lot])
+        raw_position["quantity"] = "-1"
+        raw_position["positionType"] = "SHORT"
+        case = self.case([])
+
+        parsed, completeness = case.reader._parse_portfolio_page(
+            200,
+            portfolio_page(1, 1, [raw_position]).raw,
+            1,
+            lots_required=True,
+        )
+
+        self.assertEqual(completeness, "COMPLETE")
+        normalized = parsed["positions"][0]
+        self.assertEqual(normalized["quantity"], "-1")
+        self.assertEqual(normalized["position_type"], "SHORT")
+        self.assertEqual(
+            normalized["lots"][0]["original_quantity"], "-1"
+        )
+        self.assertEqual(
+            normalized["lots"][0]["remaining_quantity"], "-1"
+        )
+        self.assertEqual(
+            normalized["lots"][0]["available_quantity"], "-1"
+        )
+
+    def test_position_lots_are_canonically_sorted(self) -> None:
+        case = self.case([])
+        raw_position = position(
+            "12",
+            "620",
+            lots=[
+                position_lot("12", lot_id="1014", leg_no="2"),
+                position_lot(
+                    "12",
+                    lot_id="1013",
+                    leg_no="1",
+                    acquired_date="-2208988800000",
+                ),
+            ],
+        )
+
+        parsed, completeness = case.reader._parse_portfolio_page(
+            200,
+            portfolio_page(1, 1, [raw_position]).raw,
+            1,
+            lots_required=True,
+        )
+
+        self.assertEqual(completeness, "COMPLETE")
+        self.assertEqual(
+            [
+                lot["position_lot_id"]
+                for lot in parsed["positions"][0]["lots"]
+            ],
+            ["1013", "1014"],
+        )
+        self.assertEqual(
+            parsed["positions"][0]["lots"][0][
+                "acquired_date_epoch_ms"
+            ],
+            "-2208988800000",
+        )
+
+    def test_position_lot_ids_are_unique_across_the_full_scan(self) -> None:
+        duplicate_lot_id = "1012"
+        case = self.case(
+            [
+                account_list(account()),
+                balance("1000"),
+                portfolio_page(
+                    1,
+                    1,
+                    [
+                        position(
+                            "12",
+                            "620",
+                            lots=[
+                                position_lot(
+                                    "12", lot_id=duplicate_lot_id
+                                )
+                            ],
+                        ),
+                        position(
+                            "11",
+                            "615",
+                            lots=[
+                                position_lot(
+                                    "11", lot_id=duplicate_lot_id
+                                )
+                            ],
+                        ),
+                    ],
+                ),
+            ]
+        )
+
+        with self.assertRaisesRegex(
+            ETradeBrokerReaderIntegrityError,
+            "duplicate position lot id",
+        ):
+            case.reader.read_capacity(case.account)
+
+    def test_reparse_preserves_legacy_lots_required_false_shape(
+        self,
+    ) -> None:
+        legacy_position = position("12", "620")
+        legacy_position.pop("PositionLot")
+        raw = portfolio_page(1, 1, [legacy_position]).raw
+        completed_at = datetime(
+            2026, 7, 27, 16, 0, tzinfo=timezone.utc
+        )
+        evidence = BrokerReadResponseEvidence(
+            read_kind="PORTFOLIO_PAGE",
+            account_id=ACCOUNT_ID,
+            account_id_key=ACCOUNT_KEY,
+            institution_type=INSTITUTION_TYPE,
+            environment="production",
+            origin=ORIGIN,
+            route=f"/v1/accounts/{ACCOUNT_KEY}/portfolio.json",
+            query_json=json.dumps(
+                [
+                    ["lotsRequired", "false"],
+                    ["pageNumber", "1"],
+                ],
+                separators=(",", ":"),
+            ),
+            authorization_sha256="a" * 64,
+            target_broker_order_id=None,
+            request_started_at=completed_at - timedelta(milliseconds=1),
+            response_completed_at=completed_at,
+            http_status=200,
+            raw_response_bytes=raw,
+            parser_schema=_PARSER_SCHEMA,
+            parser_code_sha256=_PARSER_CODE_SHA256,
+            parser_config_sha256=_PARSER_CONFIG_SHA256,
+            canonical_parsed_json="null",
+            completeness="INELIGIBLE",
+        )
+
+        parsed_json, completeness = _reparse_broker_read_response(
+            evidence
+        )
+
+        self.assertEqual(completeness, "COMPLETE")
+        parsed = json.loads(parsed_json)
+        self.assertNotIn("lots", parsed["positions"][0])
 
     def test_balance_requires_a_present_and_fresh_as_of_date(self) -> None:
         missing_scan = [
@@ -864,6 +1296,28 @@ class ETradeBrokerReaderTests(unittest.TestCase):
             self.rows(case, "SELECT * FROM broker_read_manifests"), []
         )
 
+    def test_active_order_quantities_never_default_missing_fields(
+        self,
+    ) -> None:
+        for missing_field in ("filledQuantity", "cancelQuantity"):
+            with self.subTest(missing_field=missing_field):
+                active = active_order_with_detail_statuses("OPEN")
+                del active["OrderDetail"][0]["Instrument"][0][
+                    missing_field
+                ]
+                case = self.case([])
+                with self.assertRaises(
+                    ETradeBrokerReaderIntegrityError
+                ):
+                    case.reader._parse_orders_page(
+                        200,
+                        orders_page(
+                            marker=None, orders=[active]
+                        ).raw,
+                        "OPEN",
+                        True,
+                    )
+
     def test_order_error_message_cannot_become_complete_empty_capacity(
         self,
     ) -> None:
@@ -921,21 +1375,46 @@ class ETradeBrokerReaderTests(unittest.TestCase):
                     [],
                 )
 
-    def test_known_order_statuses_map_to_closed_outcomes_and_payload_hash(
+    def test_known_order_statuses_map_to_fill_classification_and_payload_hash(
         self,
     ) -> None:
         expected_hash = canonical_order_payload_hash(
             expected_vertical_payload()
         )
         variants = (
-            ("OPEN", "0", "OPEN"),
-            ("EXECUTED", "1", "FILLED"),
-            ("CANCELLED", "0", "CANCELLED"),
-            ("REJECTED", "0", "REJECTED"),
-            ("EXPIRED", "0", "EXPIRED"),
-            ("CANCEL_REQUESTED", "0", "UNRESOLVED"),
+            ("OPEN", "0", "OPEN", "OPEN"),
+            ("EXECUTED", "1", "FILLED", "FULL_FILL"),
+            (
+                "CANCELLED",
+                "0",
+                "CANCELLED",
+                "ZERO_FILL_TERMINAL",
+            ),
+            (
+                "REJECTED",
+                "0",
+                "REJECTED",
+                "ZERO_FILL_TERMINAL",
+            ),
+            (
+                "EXPIRED",
+                "0",
+                "EXPIRED",
+                "ZERO_FILL_TERMINAL",
+            ),
+            (
+                "CANCEL_REQUESTED",
+                "0",
+                "UNRESOLVED",
+                "UNRESOLVED",
+            ),
         )
-        for status, filled_quantity, expected_outcome in variants:
+        for (
+            status,
+            filled_quantity,
+            expected_outcome,
+            expected_classification,
+        ) in variants:
             with self.subTest(status=status):
                 case = self.case(
                     [
@@ -953,8 +1432,48 @@ class ETradeBrokerReaderTests(unittest.TestCase):
                 result = self.manifest_result(
                     case, evidence.evidence_sha256
                 )
+                self.assertEqual(
+                    result["schema"], "etrade-order-query.v2"
+                )
                 self.assertEqual(result["raw_status"], status)
                 self.assertEqual(result["outcome"], expected_outcome)
+                summary = result["fill_summary"]
+                self.assertEqual(
+                    summary["classification"],
+                    expected_classification,
+                )
+                self.assertEqual(
+                    summary["placed_time_epoch_ms"],
+                    "1785167000000",
+                )
+                self.assertEqual(
+                    summary["executed_time_epoch_ms"],
+                    (
+                        "1785167100000"
+                        if status == "EXECUTED"
+                        else None
+                    ),
+                )
+                self.assertEqual(len(summary["legs"]), 2)
+                self.assertEqual(
+                    {
+                        leg["order_action"]
+                        for leg in summary["legs"]
+                    },
+                    {"BUY_OPEN", "SELL_OPEN"},
+                )
+                for leg in summary["legs"]:
+                    self.assertEqual(
+                        set(leg),
+                        {
+                            "product",
+                            "leg_number",
+                            "order_action",
+                            "ordered_quantity",
+                            "filled_quantity",
+                            "cancel_quantity",
+                        },
+                    )
                 self.assertFalse(result["not_found"])
                 self.assertIn(
                     expected_hash, result["order_payload_hashes"]
@@ -1000,6 +1519,185 @@ class ETradeBrokerReaderTests(unittest.TestCase):
                 )
                 self.assertEqual(result["outcome"], "UNRESOLVED")
 
+    def test_fill_summary_preserves_raw_leg_numbers_before_sorting(
+        self,
+    ) -> None:
+        reply = known_order("EXECUTED", filled_quantity="1")
+        document = reply_document(reply)
+        instruments = document["OrdersResponse"]["Order"][0][
+            "OrderDetail"
+        ][0]["Instrument"]
+        instruments.reverse()
+        case = self.case([])
+
+        parsed, completeness = case.reader._parse_order_detail(
+            200,
+            Reply.json(document).raw,
+            ORDER_ID,
+        )
+
+        self.assertEqual(completeness, "COMPLETE")
+        by_action = {
+            leg["order_action"]: leg["leg_number"]
+            for leg in parsed["fill_summary"]["legs"]
+        }
+        self.assertEqual(
+            by_action, {"BUY_OPEN": 1, "SELL_OPEN": 2}
+        )
+        normalized_legs = parsed["normalized_order"]["legs"]
+        with self.assertRaises(ETradeBrokerReaderIntegrityError):
+            _canonical_fill_summary_legs(normalized_legs[:1])
+        duplicate = [dict(leg) for leg in normalized_legs]
+        duplicate[1]["legNumber"] = duplicate[0]["legNumber"]
+        with self.assertRaises(ETradeBrokerReaderIntegrityError):
+            _canonical_fill_summary_legs(duplicate)
+
+    def test_missing_fill_or_cancel_quantity_never_defaults_to_zero(
+        self,
+    ) -> None:
+        for missing_field in ("filledQuantity", "cancelQuantity"):
+            with self.subTest(missing_field=missing_field):
+                document = reply_document(known_order("OPEN"))
+                del document["OrdersResponse"]["Order"][0][
+                    "OrderDetail"
+                ][0]["Instrument"][0][missing_field]
+                case = self.case(
+                    [
+                        account_list(account()),
+                        Reply.json(document),
+                    ]
+                )
+
+                with self.assertRaises(ETradeBrokerReaderIntegrityError):
+                    case.reader.query_order(case.account, ORDER_ID)
+
+                detail = self.rows(
+                    case,
+                    """
+                    SELECT completeness, canonical_parsed_json
+                    FROM broker_read_receipts
+                    WHERE read_kind = 'ORDER_DETAIL'
+                    """,
+                )
+                self.assertEqual(len(detail), 1)
+                self.assertEqual(detail[0]["completeness"], "INELIGIBLE")
+                self.assertEqual(
+                    detail[0]["canonical_parsed_json"], "null"
+                )
+
+    def test_full_fill_requires_execution_time_balance_and_zero_cancel(
+        self,
+    ) -> None:
+        variants: list[dict] = []
+        missing_execution = reply_document(
+            known_order("EXECUTED", filled_quantity="1")
+        )
+        del missing_execution["OrdersResponse"]["Order"][0][
+            "OrderDetail"
+        ][0]["executedTime"]
+        variants.append(missing_execution)
+
+        nonzero_cancel = reply_document(
+            known_order("EXECUTED", filled_quantity="0")
+        )
+        nonzero_cancel["OrdersResponse"]["Order"][0]["OrderDetail"][0][
+            "Instrument"
+        ][0]["cancelQuantity"] = "1"
+        variants.append(nonzero_cancel)
+
+        unbalanced = reply_document(
+            known_order("EXECUTED", filled_quantity="1")
+        )
+        second_leg = unbalanced["OrdersResponse"]["Order"][0][
+            "OrderDetail"
+        ][0]["Instrument"][1]
+        second_leg["orderedQuantity"] = "2"
+        second_leg["filledQuantity"] = "2"
+        variants.append(unbalanced)
+
+        case = self.case([])
+        for document in variants:
+            with self.subTest(document=document):
+                parsed, completeness = case.reader._parse_order_detail(
+                    200, Reply.json(document).raw, ORDER_ID
+                )
+                self.assertEqual(completeness, "COMPLETE")
+                self.assertEqual(parsed["outcome"], "UNRESOLVED")
+                self.assertEqual(
+                    parsed["fill_summary"]["classification"],
+                    "UNRESOLVED",
+                )
+
+    def test_zero_fill_terminal_requires_complete_cancel_arithmetic(
+        self,
+    ) -> None:
+        document = reply_document(
+            known_order(
+                "CANCELLED",
+                filled_quantity="0",
+                cancel_quantity="0",
+                second_cancel_quantity="0",
+            )
+        )
+        case = self.case([])
+
+        parsed, completeness = case.reader._parse_order_detail(
+            200, Reply.json(document).raw, ORDER_ID
+        )
+
+        self.assertEqual(completeness, "COMPLETE")
+        self.assertEqual(parsed["outcome"], "UNRESOLVED")
+        self.assertEqual(
+            parsed["fill_summary"]["classification"], "UNRESOLVED"
+        )
+
+    def test_zero_fill_terminal_rejects_an_execution_timestamp(
+        self,
+    ) -> None:
+        document = reply_document(known_order("CANCELLED"))
+        document["OrdersResponse"]["Order"][0]["OrderDetail"][0][
+            "executedTime"
+        ] = "1785167100000"
+        case = self.case([])
+
+        parsed, completeness = case.reader._parse_order_detail(
+            200, Reply.json(document).raw, ORDER_ID
+        )
+
+        self.assertEqual(completeness, "COMPLETE")
+        self.assertEqual(parsed["outcome"], "UNRESOLVED")
+        self.assertEqual(
+            parsed["fill_summary"]["classification"], "UNRESOLVED"
+        )
+
+    def test_order_epoch_milliseconds_are_exact_and_chronological(
+        self,
+    ) -> None:
+        invalid_documents: list[dict] = []
+        short_epoch = reply_document(
+            known_order("EXECUTED", filled_quantity="1")
+        )
+        short_epoch["OrdersResponse"]["Order"][0]["OrderDetail"][0][
+            "executedTime"
+        ] = "123"
+        invalid_documents.append(short_epoch)
+        reversed_times = reply_document(
+            known_order("EXECUTED", filled_quantity="1")
+        )
+        reversed_times["OrdersResponse"]["Order"][0]["OrderDetail"][0][
+            "executedTime"
+        ] = "1785166000000"
+        invalid_documents.append(reversed_times)
+        case = self.case([])
+        for document in invalid_documents:
+            with self.subTest(document=document):
+                with self.assertRaises(
+                    ETradeBrokerReaderIntegrityError
+                ):
+                    case.reader._parse_order_detail(
+                        200, Reply.json(document).raw, ORDER_ID
+                    )
+
     def test_order_404_is_complete_durable_but_remains_a_blocker(self) -> None:
         case = self.case(
             [
@@ -1017,6 +1715,15 @@ class ETradeBrokerReaderTests(unittest.TestCase):
         self.assertTrue(result["not_found"])
         self.assertEqual(result["outcome"], "UNRESOLVED")
         self.assertEqual(result["raw_status"], "NOT_FOUND")
+        self.assertEqual(
+            result["fill_summary"],
+            {
+                "classification": "UNRESOLVED",
+                "placed_time_epoch_ms": None,
+                "executed_time_epoch_ms": None,
+                "legs": [],
+            },
+        )
         self.assertEqual(result["order_payload_hashes"], [])
         detail = self.rows(
             case,

--- a/etrade_python_client/tests/test_etrade_order_gateway.py
+++ b/etrade_python_client/tests/test_etrade_order_gateway.py
@@ -19,6 +19,7 @@ from rauth import OAuth1Session
 import live_trading.etrade_order_gateway as gateway_module
 from live_trading.etrade_broker_reader import (
     ETradeBrokerReader as ConcreteETradeBrokerReader,
+    ETradeBrokerReaderUnavailable,
     _PARSER_CODE_SHA256,
     _PARSER_CONFIG_SHA256,
     _PARSER_SCHEMA,
@@ -235,6 +236,8 @@ class FakeReader:
         self.environment = environment
         self.capacity_digest = "a" * 64
         self.capacity_complete = True
+        self.capacity_order_ids = ()
+        self.capacity_calls = []
         self.selected_hook = None
         self.query_behaviors = {}
         self.query_calls = []
@@ -263,6 +266,7 @@ class FakeReader:
         return self.account
 
     def read_capacity(self, account):
+        self.capacity_calls.append(account)
         if account != self.account:
             raise RuntimeSafetyError("reader account mismatch")
         if not self.capacity_complete:
@@ -294,9 +298,12 @@ class FakeReader:
                 ),
             )
 
+        if self.capacity_order_ids:
+            self.clock.advance(1)
         binding = self._binding()
         encoded_account = quote(self.account.account_id_key, safe="")
         as_of = str(int(self.clock.now.timestamp() * 1_000))
+        positions = self._filled_positions()
         sources = [
             (
                 "binding.start",
@@ -335,7 +342,7 @@ class FakeReader:
                         f"/v1/accounts/{encoded_account}/portfolio.json",
                         (
                             ("count", "50"),
-                            ("lotsRequired", "false"),
+                            ("lotsRequired", "true"),
                             ("marketSession", "REGULAR"),
                             ("pageNumber", "1"),
                             ("sortBy", "SYMBOL"),
@@ -349,7 +356,7 @@ class FakeReader:
                             "total_pages": 1,
                             "metadata_field": "totalNoOfPages",
                             "next_page": None,
-                            "positions": [],
+                            "positions": positions,
                         },
                     ),
                 )
@@ -395,18 +402,18 @@ class FakeReader:
                 )
             )
         economic_state = {
-            "schema": "etrade-capacity.v1",
+            "schema": "etrade-capacity.v2",
             "account_status": "ACTIVE",
             "account_mode": "MARGIN",
             "account_type": "INDIVIDUAL",
             "broker_buying_power": "2000",
-            "positions": [],
+            "positions": positions,
             "open_orders": [],
         }
         result = dict(economic_state)
         result["broker_buying_power_as_of"] = as_of
         result["state_sha256"] = _domain_json_sha256(
-            b"etrade-capacity-state.v1\0", economic_state
+            b"etrade-capacity-state.v2\0", economic_state
         )
         return self.ledger.record_broker_read_manifest(
             BrokerReadManifestEvidence(
@@ -423,6 +430,56 @@ class FakeReader:
             ),
             tuple(members),
         )
+
+    def _filled_positions(self):
+        positions = []
+        acquired = str(int(self.clock.now.timestamp() * 1_000) - 1)
+        for offset, broker_order_id in enumerate(
+            self.capacity_order_ids, start=1
+        ):
+            for leg_no, (strike, quantity, position_type) in enumerate(
+                (("620", "-1", "SHORT"), ("615", "1", "LONG")),
+                start=1,
+            ):
+                position_id = str(
+                    int(broker_order_id) * 100 + offset * 10 + leg_no
+                )
+                positions.append(
+                    {
+                        "position_id": position_id,
+                        "account_id": self.account.account_id,
+                        "product": {
+                            "symbol": "SPY",
+                            "security_type": "OPTN",
+                            "call_put": "PUT",
+                            "expiry_year": "2027",
+                            "expiry_month": "1",
+                            "expiry_day": "15",
+                            "strike_price": strike,
+                            "product_id": None,
+                        },
+                        "quantity": quantity,
+                        "position_type": position_type,
+                        "position_indicator": "TYPE1",
+                        "osi_key": None,
+                        "lots": [
+                            {
+                                "position_id": position_id,
+                                "position_lot_id": str(
+                                    int(position_id) * 100 + 1
+                                ),
+                                "order_no": broker_order_id,
+                                "leg_no": str(leg_no),
+                                "original_quantity": quantity,
+                                "remaining_quantity": quantity,
+                                "available_quantity": quantity,
+                                "acquired_date_epoch_ms": acquired,
+                            }
+                        ],
+                    }
+                )
+        positions.sort(key=lambda item: item["position_id"])
+        return positions
 
     def query_order(self, account, broker_order_id):
         self.query_calls.append((account, broker_order_id))
@@ -534,7 +591,10 @@ class FakeReader:
                             {
                                 "accountId": self.account.account_id,
                                 "totalNoOfPages": "1",
-                                "Position": [],
+                                "Position": [
+                                    self._raw_position(position)
+                                    for position in parsed["positions"]
+                                ],
                             }
                         ]
                     }
@@ -585,6 +645,45 @@ class FakeReader:
         )
         return receipt
 
+    @staticmethod
+    def _raw_position(position):
+        product = position["product"]
+        raw_product = {
+            "symbol": product["symbol"],
+            "securityType": product["security_type"],
+        }
+        for raw_name, normalized_name in (
+            ("callPut", "call_put"),
+            ("expiryYear", "expiry_year"),
+            ("expiryMonth", "expiry_month"),
+            ("expiryDay", "expiry_day"),
+            ("strikePrice", "strike_price"),
+        ):
+            value = product[normalized_name]
+            if value is not None:
+                raw_product[raw_name] = value
+        return {
+            "positionId": position["position_id"],
+            "accountId": position["account_id"],
+            "Product": raw_product,
+            "quantity": position["quantity"],
+            "positionType": position["position_type"],
+            "positionIndicator": position["position_indicator"],
+            "PositionLot": [
+                {
+                    "positionId": lot["position_id"],
+                    "positionLotId": lot["position_lot_id"],
+                    "orderNo": lot["order_no"],
+                    "legNo": lot["leg_no"],
+                    "originalQty": lot["original_quantity"],
+                    "remainingQty": lot["remaining_quantity"],
+                    "availableQty": lot["available_quantity"],
+                    "acquiredDate": lot["acquired_date_epoch_ms"],
+                }
+                for lot in position["lots"]
+            ],
+        }
+
     def _order_manifest(
         self,
         *,
@@ -601,6 +700,18 @@ class FakeReader:
             route="/v1/accounts/list.json",
             raw=b'{"AccountListResponse":{"binding":"query-start"}}',
             parsed=binding,
+        )
+        terminal = outcome in {
+            "FILLED",
+            "CANCELLED",
+            "REJECTED",
+            "EXPIRED",
+        }
+        placed_time = str(
+            int((self.clock.now - timedelta(seconds=2)).timestamp() * 1_000)
+        )
+        executed_time = str(
+            int((self.clock.now - timedelta(seconds=1)).timestamp() * 1_000)
         )
         raw = (
             b""
@@ -621,6 +732,12 @@ class FakeReader:
                                             if outcome == "FILLED"
                                             else outcome
                                         ),
+                                        "placedTime": placed_time,
+                                        **(
+                                            {"executedTime": executed_time}
+                                            if outcome == "FILLED"
+                                            else {}
+                                        ),
                                         "priceType": "NET_CREDIT",
                                         "limitPrice": (
                                             "1.50"
@@ -637,11 +754,19 @@ class FakeReader:
                                                 "SELL_OPEN",
                                                 "620",
                                                 filled=outcome == "FILLED",
+                                                cancelled=(
+                                                    terminal
+                                                    and outcome != "FILLED"
+                                                ),
                                             ),
                                             self._known_leg(
                                                 "BUY_OPEN",
                                                 "615",
                                                 filled=outcome == "FILLED",
+                                                cancelled=(
+                                                    terminal
+                                                    and outcome != "FILLED"
+                                                ),
                                             ),
                                         ],
                                     }
@@ -674,10 +799,11 @@ class FakeReader:
             final_response=True,
         )
         result = {
-            "schema": "etrade-order-query.v1",
+            "schema": "etrade-order-query.v2",
             "broker_order_id": broker_order_id,
             "raw_status": parsed["raw_status"],
             "outcome": parsed["outcome"],
+            "fill_summary": parsed["fill_summary"],
             "order_payload_hashes": parsed["order_payload_hashes"],
             "http_status": 404 if not_found else 200,
             "raw_response_digest": hashlib.sha256(raw).hexdigest(),
@@ -713,7 +839,7 @@ class FakeReader:
             ),
         )
 
-    def _known_leg(self, action, strike, *, filled):
+    def _known_leg(self, action, strike, *, filled, cancelled=False):
         return {
             "Product": {
                 "symbol": "SPY",
@@ -728,7 +854,7 @@ class FakeReader:
             "quantityType": "QUANTITY",
             "orderedQuantity": "1",
             "filledQuantity": "1" if filled else "0",
-            "cancelQuantity": "0",
+            "cancelQuantity": "1" if cancelled else "0",
         }
 
     def _receipt_parsed_json(self, receipt_sha256):
@@ -841,6 +967,54 @@ class EtradeOrderGatewayTests(unittest.TestCase):
         self.harness.add(preview_result(), place_result())
         return self.gateway.submit_opening(self.command())
 
+    def make_pending_terminal(
+        self,
+        *,
+        key,
+        decision,
+        broker_order_id,
+        outcome,
+    ):
+        submitted = self.submit_named_order(
+            key=key,
+            decision=decision,
+            broker_order_id=broker_order_id,
+        )
+        self.terminalize(submitted, broker_order_id, outcome)
+        return submitted
+
+    def submit_named_order(self, *, key, decision, broker_order_id):
+        self.harness.add(
+            preview_result(preview_id=str(1_020_563_000 + int(broker_order_id))),
+            place_result(order_id=broker_order_id),
+        )
+        return self.gateway.submit_opening(
+            self.command(key=key, decision=decision)
+        )
+
+    def terminalize(self, submitted, broker_order_id, outcome):
+        snapshot = BrokerOrderSnapshot(
+            account=self.account,
+            environment="sandbox",
+            broker_order_id=broker_order_id,
+            outcome=outcome,
+            observed_at=self.clock.now,
+            http_status=200,
+            raw_response_digest="4" * 64,
+            order_payload_hash=order_payload_hash(),
+            complete=True,
+        )
+        self.reader.query_behaviors[broker_order_id] = snapshot
+        read = self.reader.query_order(self.account, broker_order_id)
+        terminal_evidence = self.ledger.broker_evidence_from_read(
+            submitted.intent_id, read, operation="ORDER_QUERY"
+        )
+        self.assertIsNotNone(terminal_evidence)
+        self.ledger.reconcile_terminal(
+            submitted.intent_id, outcome, terminal_evidence
+        )
+        self.reader.query_calls.clear()
+
     def test_real_transport_submission_is_idempotent_and_places_once(self):
         first = self.submit_success()
         replay = self.gateway.submit_opening(self.command())
@@ -930,6 +1104,9 @@ class EtradeOrderGatewayTests(unittest.TestCase):
             order_payload_hash=order_payload_hash(),
             complete=True,
         )
+        # A newer stable portfolio may contain unrelated lots, but it cannot
+        # absorb this fill without lots bound to broker order 94.
+        reader.capacity_order_ids = ("93",)
         restarted, ledger, _ = self.restart(reader=reader)
 
         with self.assertRaises(GatewayReconciliationRequired):
@@ -942,6 +1119,322 @@ class EtradeOrderGatewayTests(unittest.TestCase):
             ),
             1,
         )
+
+    def test_start_absorbs_zero_fill_terminal_without_capacity_or_mutation(
+        self,
+    ):
+        pending = self.make_pending_terminal(
+            key="zero-fill",
+            decision="zero-fill-decision",
+            broker_order_id="94",
+            outcome="CANCELLED",
+        )
+        mutation_calls = len(self.harness.calls)
+        reader = FakeReader(self.clock, self.account)
+        reader.query_behaviors["94"] = BrokerOrderSnapshot(
+            account=self.account,
+            environment="sandbox",
+            broker_order_id="94",
+            outcome="CANCELLED",
+            observed_at=self.clock.now,
+            http_status=200,
+            raw_response_digest="5" * 64,
+            order_payload_hash=order_payload_hash(),
+            complete=True,
+        )
+        restarted, ledger, reader = self.restart(reader=reader)
+
+        restarted.start()
+
+        self.assertEqual(
+            ledger.get_margin_reservation(pending.intent_id).state,
+            "RELEASED",
+        )
+        self.assertEqual(reader.query_calls, [(self.account, "94")])
+        self.assertEqual(reader.capacity_calls, [])
+        self.assertEqual(len(self.harness.calls), mutation_calls)
+
+    def test_start_absorbs_full_fill_and_restart_is_idempotent(self):
+        pending = self.make_pending_terminal(
+            key="full-fill",
+            decision="full-fill-decision",
+            broker_order_id="94",
+            outcome="FILLED",
+        )
+        mutation_calls = len(self.harness.calls)
+        reader = FakeReader(self.clock, self.account)
+        reader.query_behaviors["94"] = BrokerOrderSnapshot(
+            account=self.account,
+            environment="sandbox",
+            broker_order_id="94",
+            outcome="FILLED",
+            observed_at=self.clock.now,
+            http_status=200,
+            raw_response_digest="5" * 64,
+            order_payload_hash=order_payload_hash(),
+            complete=True,
+        )
+        reader.capacity_order_ids = ("94",)
+        restarted, ledger, reader = self.restart(reader=reader)
+
+        restarted.start()
+
+        self.assertEqual(
+            ledger.get_margin_reservation(pending.intent_id).state,
+            "RELEASED",
+        )
+        self.assertEqual(reader.query_calls, [(self.account, "94")])
+        self.assertEqual(reader.capacity_calls, [self.account])
+        self.assertEqual(len(self.harness.calls), mutation_calls)
+
+        replay_reader = FakeReader(self.clock, self.account)
+        replay, replay_ledger, replay_reader = self.restart(
+            reader=replay_reader
+        )
+        replay.start()
+        self.assertEqual(replay_reader.query_calls, [])
+        self.assertEqual(replay_reader.capacity_calls, [])
+        self.assertEqual(
+            replay_ledger.get_margin_reservation(pending.intent_id).state,
+            "RELEASED",
+        )
+        self.assertEqual(len(self.harness.calls), mutation_calls)
+
+    def test_start_processes_multiple_pending_reservations_in_order(self):
+        first = self.submit_named_order(
+            key="terminal-first",
+            decision="terminal-first-decision",
+            broker_order_id="94",
+        )
+        self.clock.advance(1)
+        second = self.submit_named_order(
+            key="terminal-second",
+            decision="terminal-second-decision",
+            broker_order_id="95",
+        )
+        self.terminalize(first, "94", "CANCELLED")
+        self.terminalize(second, "95", "FILLED")
+        mutation_calls = len(self.harness.calls)
+        reader = FakeReader(self.clock, self.account)
+        reader.query_behaviors.update(
+            {
+                "94": BrokerOrderSnapshot(
+                    self.account,
+                    "sandbox",
+                    "94",
+                    "CANCELLED",
+                    self.clock.now,
+                    200,
+                    "6" * 64,
+                    order_payload_hash(),
+                    True,
+                ),
+                "95": BrokerOrderSnapshot(
+                    self.account,
+                    "sandbox",
+                    "95",
+                    "FILLED",
+                    self.clock.now,
+                    200,
+                    "7" * 64,
+                    order_payload_hash(),
+                    True,
+                ),
+            }
+        )
+        reader.capacity_order_ids = ("95",)
+        restarted, ledger, reader = self.restart(reader=reader)
+
+        restarted.start()
+
+        self.assertEqual(
+            reader.query_calls,
+            [(self.account, "94"), (self.account, "95")],
+        )
+        self.assertEqual(reader.capacity_calls, [self.account])
+        self.assertEqual(
+            ledger.get_margin_reservation(first.intent_id).state,
+            "RELEASED",
+        )
+        self.assertEqual(
+            ledger.get_margin_reservation(second.intent_id).state,
+            "RELEASED",
+        )
+        self.assertEqual(len(self.harness.calls), mutation_calls)
+
+    def test_start_reuses_one_capacity_scan_for_multiple_full_fills(self):
+        first = self.submit_named_order(
+            key="full-fill-first",
+            decision="full-fill-first-decision",
+            broker_order_id="94",
+        )
+        self.clock.advance(1)
+        second = self.submit_named_order(
+            key="full-fill-second",
+            decision="full-fill-second-decision",
+            broker_order_id="95",
+        )
+        self.terminalize(first, "94", "FILLED")
+        self.terminalize(second, "95", "FILLED")
+        mutation_calls = len(self.harness.calls)
+        reader = FakeReader(self.clock, self.account)
+        reader.query_behaviors.update(
+            {
+                broker_order_id: BrokerOrderSnapshot(
+                    self.account,
+                    "sandbox",
+                    broker_order_id,
+                    "FILLED",
+                    self.clock.now,
+                    200,
+                    digest * 64,
+                    order_payload_hash(),
+                    True,
+                )
+                for broker_order_id, digest in (
+                    ("94", "6"),
+                    ("95", "7"),
+                )
+            }
+        )
+        reader.capacity_order_ids = ("94", "95")
+        restarted, ledger, reader = self.restart(reader=reader)
+
+        restarted.start()
+
+        self.assertEqual(
+            reader.query_calls,
+            [(self.account, "94"), (self.account, "95")],
+        )
+        self.assertEqual(reader.capacity_calls, [self.account])
+        self.assertEqual(
+            ledger.get_margin_reservation(first.intent_id).state,
+            "RELEASED",
+        )
+        self.assertEqual(
+            ledger.get_margin_reservation(second.intent_id).state,
+            "RELEASED",
+        )
+        self.assertEqual(
+            ledger.active_reserved_margin(ACCOUNT_ID, "sandbox"),
+            Decimal("1000"),
+        )
+        self.assertEqual(len(self.harness.calls), mutation_calls)
+
+    def test_unavailable_pending_does_not_prevent_later_safe_absorption(
+        self,
+    ):
+        first = self.submit_named_order(
+            key="unavailable-first",
+            decision="unavailable-first-decision",
+            broker_order_id="94",
+        )
+        self.clock.advance(1)
+        second = self.submit_named_order(
+            key="safe-second",
+            decision="safe-second-decision",
+            broker_order_id="95",
+        )
+        self.terminalize(first, "94", "FILLED")
+        self.terminalize(second, "95", "CANCELLED")
+        mutation_calls = len(self.harness.calls)
+        reader = FakeReader(self.clock, self.account)
+        reader.query_behaviors["94"] = ETradeBrokerReaderUnavailable(
+            "simulated read outage"
+        )
+        reader.query_behaviors["95"] = BrokerOrderSnapshot(
+            self.account,
+            "sandbox",
+            "95",
+            "CANCELLED",
+            self.clock.now,
+            200,
+            "8" * 64,
+            order_payload_hash(),
+            True,
+        )
+        restarted, ledger, reader = self.restart(reader=reader)
+
+        with self.assertRaises(GatewayReconciliationRequired):
+            restarted.start()
+
+        self.assertEqual(
+            reader.query_calls,
+            [(self.account, "94"), (self.account, "95")],
+        )
+        self.assertEqual(
+            ledger.get_margin_reservation(first.intent_id).state,
+            "FILLED_PENDING_ABSORPTION",
+        )
+        self.assertEqual(
+            ledger.get_margin_reservation(second.intent_id).state,
+            "RELEASED",
+        )
+        self.assertEqual(len(self.harness.calls), mutation_calls)
+
+    def test_full_fill_without_order_bound_lots_stays_read_only(self):
+        pending = self.make_pending_terminal(
+            key="missing-lots",
+            decision="missing-lots-decision",
+            broker_order_id="94",
+            outcome="FILLED",
+        )
+        mutation_calls = len(self.harness.calls)
+        reader = FakeReader(self.clock, self.account)
+        reader.query_behaviors["94"] = BrokerOrderSnapshot(
+            self.account,
+            "sandbox",
+            "94",
+            "FILLED",
+            self.clock.now,
+            200,
+            "9" * 64,
+            order_payload_hash(),
+            True,
+        )
+        reader.capacity_order_ids = ("93",)
+        restarted, ledger, reader = self.restart(reader=reader)
+
+        with self.assertRaises(GatewayReconciliationRequired):
+            restarted.start()
+
+        self.assertEqual(
+            ledger.get_margin_reservation(pending.intent_id).state,
+            "FILLED_PENDING_ABSORPTION",
+        )
+        self.assertEqual(reader.capacity_calls, [self.account])
+        self.assertEqual(len(self.harness.calls), mutation_calls)
+
+        reader.capacity_order_ids = ("94",)
+        restarted.start()
+        self.assertEqual(
+            ledger.get_margin_reservation(pending.intent_id).state,
+            "RELEASED",
+        )
+        self.assertEqual(len(self.harness.calls), mutation_calls)
+
+    def test_invalid_terminal_read_reference_fails_closed_without_mutation(
+        self,
+    ):
+        pending = self.make_pending_terminal(
+            key="invalid-reference",
+            decision="invalid-reference-decision",
+            broker_order_id="94",
+            outcome="CANCELLED",
+        )
+        mutation_calls = len(self.harness.calls)
+        reader = FakeReader(self.clock, self.account)
+        reader.query_behaviors["94"] = object()
+        restarted, ledger, _ = self.restart(reader=reader)
+
+        with self.assertRaises(GatewayValidationError):
+            restarted.start()
+
+        self.assertEqual(
+            ledger.get_margin_reservation(pending.intent_id).state,
+            "FILLED_PENDING_ABSORPTION",
+        )
+        self.assertEqual(len(self.harness.calls), mutation_calls)
 
     def test_known_hold_reconciles_open_and_allows_next_opening(self):
         self.harness.add(

--- a/etrade_python_client/tests/test_order_intent_ledger.py
+++ b/etrade_python_client/tests/test_order_intent_ledger.py
@@ -25,6 +25,7 @@ from live_trading.etrade_broker_reader import (
 from live_trading.order_intent_ledger import (
     SCHEMA_VERSION,
     BrokerEvidence,
+    BrokerReadEvidenceRef,
     BrokerReadManifestEvidence,
     BrokerReadManifestMember,
     BrokerReadResponseEvidence,
@@ -35,6 +36,7 @@ from live_trading.order_intent_ledger import (
     OrderIntent,
     OrderIntentIntegrityError,
     OrderIntentLedger,
+    OrderIntentLedgerError,
     OrderIntentLeaseConflict,
     OrderIntentReconciliationRequired,
     OrderIntentReservationError,
@@ -764,6 +766,12 @@ class OrderIntentLedgerTests(unittest.TestCase):
         ).encode("ascii")
         wire_payload = json.loads(record.envelope.wire_payload)
         raw_status = "EXECUTED" if outcome == "FILLED" else outcome
+        placed_time = str(
+            int((observed_at - timedelta(minutes=1)).timestamp() * 1_000)
+        )
+        executed_time = str(
+            int((observed_at - timedelta(seconds=30)).timestamp() * 1_000)
+        )
         raw = canonical_json(
             {
                 "OrdersResponse": {
@@ -776,6 +784,12 @@ class OrderIntentLedgerTests(unittest.TestCase):
                                     "accountId": account,
                                     "orderNumber": broker_order_id,
                                     "status": raw_status,
+                                    "placedTime": placed_time,
+                                    **(
+                                        {"executedTime": executed_time}
+                                        if outcome == "FILLED"
+                                        else {}
+                                    ),
                                     "priceType": wire_payload[
                                         "priceType"
                                     ],
@@ -812,6 +826,16 @@ class OrderIntentLedgerTests(unittest.TestCase):
                                             "filledQuantity": (
                                                 leg["quantity"]
                                                 if outcome == "FILLED"
+                                                else 0
+                                            ),
+                                            "cancelQuantity": (
+                                                leg["quantity"]
+                                                if outcome
+                                                in {
+                                                    "CANCELLED",
+                                                    "REJECTED",
+                                                    "EXPIRED",
+                                                }
                                                 else 0
                                             ),
                                             "orderAction": leg[
@@ -867,10 +891,11 @@ class OrderIntentLedgerTests(unittest.TestCase):
             final_response=True,
         )
         result = {
-            "schema": "etrade-order-query.v1",
+            "schema": "etrade-order-query.v2",
             "broker_order_id": broker_order_id,
             "raw_status": detail_parsed["raw_status"],
             "outcome": detail_parsed["outcome"],
+            "fill_summary": detail_parsed["fill_summary"],
             "order_payload_hashes": detail_parsed[
                 "order_payload_hashes"
             ],
@@ -1303,6 +1328,343 @@ class OrderIntentLedgerTests(unittest.TestCase):
                 ),
             )
 
+    def test_direct_sql_cannot_forge_an_understated_reservation(self):
+        record = self.ledger.create_intent(
+            make_intent(key="tiny-direct-reservation")
+        ).intent
+        decision = self.set_capacity()
+        now = int(self.clock.now.timestamp() * 1_000_000)
+        values = (
+            record.intent_id,
+            record.envelope.account_id,
+            record.envelope.environment,
+            "1",
+            record.envelope.decision_id,
+            "1",
+            now,
+            "a" * 64,
+            int(decision.observed_at.timestamp() * 1_000_000),
+            decision.portfolio_snapshot_digest,
+            decision.decision_sha256,
+            now,
+        )
+        statement = """
+            INSERT INTO margin_reservations (
+                intent_id, account_id, environment, amount,
+                risk_decision_id, max_loss_amount,
+                quote_observed_at, quote_digest,
+                portfolio_observed_at, portfolio_snapshot_digest,
+                capacity_decision_sha256, state,
+                released_reason_code, created_at, released_at
+            ) VALUES (
+                ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, 'ACTIVE',
+                NULL, ?, NULL
+            )
+        """
+        with sqlite3.connect(self.path) as connection:
+            connection.execute("PRAGMA foreign_keys = ON")
+            with self.assertRaises(sqlite3.DatabaseError):
+                connection.execute(statement, values)
+
+        with sqlite3.connect(self.path) as connection:
+            connection.execute(
+                "DROP TRIGGER validate_margin_reservation_insert"
+            )
+            connection.execute(statement, values)
+
+        with self.assertRaises(OrderIntentIntegrityError):
+            self.ledger.active_reserved_margin(
+                record.envelope.account_id,
+                record.envelope.environment,
+            )
+        with self.assertRaises(OrderIntentIntegrityError):
+            OrderIntentLedger(
+                self.path,
+                clock=self.clock,
+                run_id="tiny-direct-reservation-restart",
+            )
+
+    def test_valid_pre_post_failure_releases_reserved_margin(self):
+        record = self.opening(key="valid-pre-post-release")
+        lease = self.ledger.claim_submission(
+            record.intent_id, "worker", lease_seconds=30
+        )
+        failed = self.ledger.mark_pre_post_failed(
+            record.intent_id,
+            "worker",
+            lease.fencing_token,
+        )
+        reservation = self.ledger.get_margin_reservation(
+            record.intent_id
+        )
+        self.assertEqual(failed.state, "FAILED")
+        self.assertEqual(reservation.state, "RELEASED")
+        self.assertEqual(
+            reservation.released_reason_code, "PRE_POST_ABORTED"
+        )
+        self.assertEqual(
+            [
+                (event.event_type, event.reason_code)
+                for event in self.ledger.events(record.intent_id)[-2:]
+            ],
+            [
+                ("RESERVATION_RELEASED", "RESERVATION_RELEASED"),
+                ("PRE_POST_FAILED", "PRE_POST_ABORTED"),
+            ],
+        )
+        self.assertEqual(
+            self.ledger.active_reserved_margin(
+                record.envelope.account_id,
+                record.envelope.environment,
+            ),
+            Decimal("0"),
+        )
+        reopened = OrderIntentLedger(
+            self.path,
+            clock=self.clock,
+            run_id="valid-pre-post-release-restart",
+        )
+        self.assertEqual(
+            reopened.active_reserved_margin(
+                record.envelope.account_id,
+                record.envelope.environment,
+            ),
+            Decimal("0"),
+        )
+
+    def test_submitted_opening_cannot_forge_active_reservation_release(
+        self,
+    ):
+        record = self.opening(key="forged-active-release")
+        lease = self.ledger.claim_submission(
+            record.intent_id, "worker", lease_seconds=30
+        )
+        self.begin_submission(record, "worker", lease)
+        self.ledger.record_post_acknowledgement(
+            record.intent_id,
+            "worker",
+            lease.fencing_token,
+            evidence(record, self.clock, operation="SUBMIT_ACK"),
+        )
+        released_at = int(self.clock.now.timestamp() * 1_000_000)
+        statement = """
+            UPDATE margin_reservations
+            SET state = 'RELEASED',
+                released_reason_code = 'RESERVATION_RELEASED',
+                released_at = ?
+            WHERE intent_id = ?
+        """
+        with sqlite3.connect(self.path) as connection:
+            with self.assertRaises(sqlite3.DatabaseError):
+                connection.execute(
+                    statement, (released_at, record.intent_id)
+                )
+        self.assertEqual(
+            self.ledger.active_reserved_margin(
+                record.envelope.account_id,
+                record.envelope.environment,
+            ),
+            Decimal("500"),
+        )
+
+        with sqlite3.connect(self.path) as connection:
+            connection.execute(
+                """
+                DROP TRIGGER
+                validate_margin_reservation_pre_post_release
+                """
+            )
+            connection.execute(
+                statement, (released_at, record.intent_id)
+            )
+        with self.assertRaises(OrderIntentIntegrityError):
+            self.ledger.active_reserved_margin(
+                record.envelope.account_id,
+                record.envelope.environment,
+            )
+        with self.assertRaises(OrderIntentIntegrityError):
+            OrderIntentLedger(
+                self.path,
+                clock=self.clock,
+                run_id="forged-active-release-restart",
+            )
+
+    def test_post_started_evidence_blocks_forged_pre_post_release(
+        self,
+    ):
+        record = self.opening(key="post-started-release-forgery")
+        lease = self.ledger.claim_submission(
+            record.intent_id, "worker", lease_seconds=30
+        )
+        self.begin_submission(record, "worker", lease)
+        released_at = int(self.clock.now.timestamp() * 1_000_000)
+        fail_intent = """
+            UPDATE order_intents
+            SET state = 'FAILED', pending_operation = NULL,
+                pending_owner = NULL, pending_fence = NULL,
+                last_reconciled_run = 'forged',
+                updated_at = ?
+            WHERE intent_id = ?
+        """
+        release = """
+            UPDATE margin_reservations
+            SET state = 'RELEASED',
+                released_reason_code = 'PRE_POST_ABORTED',
+                released_at = ?
+            WHERE intent_id = ?
+        """
+        with sqlite3.connect(self.path) as connection:
+            connection.execute(
+                fail_intent, (released_at, record.intent_id)
+            )
+            with self.assertRaises(sqlite3.DatabaseError):
+                connection.execute(
+                    release, (released_at, record.intent_id)
+                )
+            connection.rollback()
+
+        with sqlite3.connect(self.path) as connection:
+            connection.execute(
+                """
+                DROP TRIGGER
+                validate_margin_reservation_pre_post_release
+                """
+            )
+            connection.execute(
+                fail_intent, (released_at, record.intent_id)
+            )
+            connection.execute(
+                release, (released_at, record.intent_id)
+            )
+            for event_type, from_state, to_state, actor, reason in (
+                (
+                    "RESERVATION_RELEASED",
+                    "FAILED",
+                    "FAILED",
+                    "system",
+                    "RESERVATION_RELEASED",
+                ),
+                (
+                    "PRE_POST_FAILED",
+                    "CLAIMED",
+                    "FAILED",
+                    "worker",
+                    "PRE_POST_ABORTED",
+                ),
+            ):
+                connection.execute(
+                    """
+                    INSERT INTO order_events (
+                        intent_id, account_id, environment,
+                        client_order_id, event_type, from_state,
+                        to_state, actor, reason_code, broker_status,
+                        broker_order_id, observed_at,
+                        evidence_operation, http_status,
+                        raw_response_digest,
+                        broker_read_evidence_sha256, created_at
+                    ) VALUES (
+                        ?, ?, ?, ?, ?, ?, ?, ?, ?,
+                        NULL, NULL, NULL, NULL, NULL, NULL, NULL, ?
+                    )
+                    """,
+                    (
+                        record.intent_id,
+                        record.envelope.account_id,
+                        record.envelope.environment,
+                        record.client_order_id,
+                        event_type,
+                        from_state,
+                        to_state,
+                        actor,
+                        reason,
+                        released_at,
+                    ),
+                )
+
+        with self.assertRaisesRegex(
+            OrderIntentIntegrityError, "durable POST evidence"
+        ):
+            self.ledger.active_reserved_margin(
+                record.envelope.account_id,
+                record.envelope.environment,
+            )
+        with self.assertRaises(OrderIntentIntegrityError):
+            OrderIntentLedger(
+                self.path,
+                clock=self.clock,
+                run_id="post-started-release-forgery-restart",
+            )
+
+    def test_order_event_delete_trigger_is_repaired_and_replacement_rejected(
+        self,
+    ):
+        record = self.opening(key="post-started-delete-trigger")
+        lease = self.ledger.claim_submission(
+            record.intent_id, "worker", lease_seconds=30
+        )
+        self.begin_submission(record, "worker", lease)
+
+        with sqlite3.connect(self.path) as connection:
+            connection.execute(
+                "DROP TRIGGER prevent_order_event_delete"
+            )
+
+        OrderIntentLedger(
+            self.path,
+            clock=self.clock,
+            run_id="repair-order-event-delete-trigger",
+        )
+        with sqlite3.connect(self.path) as connection:
+            with self.assertRaises(sqlite3.DatabaseError):
+                connection.execute(
+                    """
+                    DELETE FROM order_events
+                    WHERE intent_id = ? AND event_type = 'POST_STARTED'
+                    """,
+                    (record.intent_id,),
+                )
+            self.assertEqual(
+                connection.execute(
+                    """
+                    SELECT COUNT(*) FROM order_events
+                    WHERE intent_id = ? AND event_type = 'POST_STARTED'
+                    """,
+                    (record.intent_id,),
+                ).fetchone()[0],
+                1,
+            )
+
+        with sqlite3.connect(self.path) as connection:
+            connection.executescript(
+                """
+                DROP TRIGGER prevent_order_event_delete;
+                CREATE TRIGGER prevent_order_event_delete
+                BEFORE DELETE ON order_events
+                WHEN 0
+                BEGIN
+                    SELECT RAISE(ABORT, 'never runs');
+                END;
+                """
+            )
+
+        with self.assertRaises(OrderIntentLedgerError):
+            OrderIntentLedger(
+                self.path,
+                clock=self.clock,
+                run_id="reject-replaced-order-event-delete-trigger",
+            )
+        with sqlite3.connect(self.path) as connection:
+            self.assertEqual(
+                connection.execute(
+                    """
+                    SELECT COUNT(*) FROM order_events
+                    WHERE intent_id = ? AND event_type = 'POST_STARTED'
+                    """,
+                    (record.intent_id,),
+                ).fetchone()[0],
+                1,
+            )
+
     def test_expired_claim_without_place_attempt_returns_to_intent_with_new_fence(self):
         record = self.opening()
         lease = self.ledger.claim_submission(record.intent_id, "worker", lease_seconds=5)
@@ -1715,7 +2077,7 @@ class OrderIntentLedgerTests(unittest.TestCase):
         ack = self.ledger.record_post_acknowledgement(record.intent_id, "worker", lease.fencing_token, evidence(record, self.clock, operation="SUBMIT_ACK"))
         self.assertEqual(ack.state, "SUBMITTED")
 
-    def test_restart_reconciliation_keeps_terminal_reservation_until_r7b_position_evidence(self):
+    def test_restart_keeps_terminal_risk_until_exact_absorption_evidence(self):
         record = self.opening()
         lease = self.ledger.claim_submission(record.intent_id, "worker", lease_seconds=30)
         self.begin_submission(record, "worker", lease)
@@ -1914,7 +2276,7 @@ class OrderIntentLedgerTests(unittest.TestCase):
             self.begin_submission(record, "worker", submit)
         self.assertEqual(self.ledger.get_intent(record.intent_id).state, "CLAIMED")
 
-    def test_cancelled_and_expired_openings_hold_reservation_without_position_evidence(self):
+    def test_zero_fill_terminals_hold_risk_without_fresh_order_evidence(self):
         for terminal in ("CANCELLED", "EXPIRED"):
             with self.subTest(terminal=terminal):
                 self.clock.advance(1)
@@ -1962,6 +2324,231 @@ class OrderIntentLedgerTests(unittest.TestCase):
                 with self.assertRaises(OrderIntentReservationError):
                     self.ledger.claim_submission(blocked.intent_id, "still-blocked", lease_seconds=30)
 
+    def test_zero_fill_terminal_absorption_is_atomic_and_idempotent(self):
+        record = self.opening(key="zero-fill-absorption")
+        lease = self.ledger.claim_submission(
+            record.intent_id, "worker", lease_seconds=30
+        )
+        self.begin_submission(record, "worker", lease)
+        submitted = self.ledger.record_post_acknowledgement(
+            record.intent_id,
+            "worker",
+            lease.fencing_token,
+            evidence(
+                record,
+                self.clock,
+                operation="SUBMIT_ACK",
+                broker_order_id="2000000088",
+            ),
+        )
+        terminal = self.query_evidence(
+            submitted,
+            outcome="CANCELLED",
+            broker_order_id="2000000088",
+        )
+        self.ledger.reconcile_terminal(
+            record.intent_id, "CANCELLED", terminal
+        )
+        with sqlite3.connect(self.path) as connection:
+            with self.assertRaises(sqlite3.DatabaseError):
+                connection.execute(
+                    """
+                    UPDATE margin_reservations
+                    SET state = 'RELEASED',
+                        released_reason_code = 'ZERO_FILL_CONFIRMED',
+                        released_at = ?
+                    WHERE intent_id = ?
+                    """,
+                    (
+                        int(self.clock.now.timestamp() * 1_000_000),
+                        record.intent_id,
+                    ),
+                )
+        self.clock.advance(1)
+        fresh_terminal = self.query_evidence(
+            submitted,
+            outcome="CANCELLED",
+            broker_order_id="2000000088",
+        )
+        reference = BrokerReadEvidenceRef(
+            fresh_terminal.broker_read_evidence_sha256,
+            "ORDER_QUERY",
+        )
+        self.clock.advance(1)
+        newest_terminal = self.query_evidence(
+            submitted,
+            outcome="CANCELLED",
+            broker_order_id="2000000088",
+        )
+        newest_reference = BrokerReadEvidenceRef(
+            newest_terminal.broker_read_evidence_sha256,
+            "ORDER_QUERY",
+        )
+        with self.assertRaises(OrderIntentReconciliationRequired):
+            self.ledger.terminal_absorption_requirement(
+                record.intent_id, reference
+            )
+        reference = newest_reference
+
+        requirement = self.ledger.terminal_absorption_requirement(
+            record.intent_id, reference
+        )
+        self.assertEqual(requirement.classification, "ZERO_FILL")
+        self.assertFalse(requirement.post_capacity_required)
+        self.assertEqual(
+            requirement.baseline_capacity_decision_sha256,
+            self.ledger.get_margin_reservation(
+                record.intent_id
+            ).capacity_decision_sha256,
+        )
+        with sqlite3.connect(self.path) as connection:
+            connection.execute(
+                """
+                CREATE TRIGGER abort_zero_absorption_event
+                BEFORE INSERT ON order_events
+                WHEN NEW.event_type = 'RESERVATION_RELEASED'
+                BEGIN
+                    SELECT RAISE(ABORT, 'simulated post-receipt failure');
+                END
+                """
+            )
+        with self.assertRaises(sqlite3.DatabaseError):
+            self.ledger.absorb_terminal_reservation(
+                record.intent_id, reference
+            )
+        with sqlite3.connect(self.path) as connection:
+            self.assertEqual(
+                connection.execute(
+                    """
+                    SELECT COUNT(*) FROM reservation_absorptions
+                    WHERE intent_id = ?
+                    """,
+                    (record.intent_id,),
+                ).fetchone()[0],
+                0,
+            )
+            connection.execute("DROP TRIGGER abort_zero_absorption_event")
+        self.assertEqual(
+            self.ledger.get_margin_reservation(record.intent_id).state,
+            "FILLED_PENDING_ABSORPTION",
+        )
+        receipt = self.ledger.absorb_terminal_reservation(
+            record.intent_id, reference
+        )
+        replay = self.ledger.absorb_terminal_reservation(
+            record.intent_id, reference
+        )
+        self.assertEqual(replay, receipt)
+        self.assertEqual(receipt.absorbed_margin_amount, Decimal("0"))
+        self.assertEqual(
+            self.ledger.get_intent(record.intent_id).state,
+            "CANCELLED",
+        )
+        self.assertEqual(
+            self.ledger.get_margin_reservation(record.intent_id).state,
+            "RELEASED",
+        )
+        self.assertEqual(
+            self.ledger.active_reserved_margin(
+                record.envelope.account_id,
+                record.envelope.environment,
+            ),
+            Decimal("0"),
+        )
+        final_event = self.ledger.events(record.intent_id)[-1]
+        self.assertEqual(
+            final_event.event_type, "RESERVATION_RELEASED"
+        )
+        self.assertEqual(
+            final_event.reason_code, "RESERVATION_RELEASED"
+        )
+        conflicting = BrokerReadEvidenceRef(
+            terminal.broker_read_evidence_sha256,
+            "ORDER_QUERY",
+        )
+        with self.assertRaises(OrderIntentIntegrityError):
+            self.ledger.absorb_terminal_reservation(
+                record.intent_id, conflicting
+            )
+
+    def test_absorption_insert_trigger_rejects_zero_fill_for_filled_intent(
+        self,
+    ):
+        record = self.opening(key="forged-zero-fill")
+        lease = self.ledger.claim_submission(
+            record.intent_id, "worker", lease_seconds=30
+        )
+        self.begin_submission(record, "worker", lease)
+        submitted = self.ledger.record_post_acknowledgement(
+            record.intent_id,
+            "worker",
+            lease.fencing_token,
+            evidence(
+                record,
+                self.clock,
+                operation="SUBMIT_ACK",
+                broker_order_id="2000000089",
+            ),
+        )
+        terminal = self.query_evidence(
+            submitted,
+            outcome="FILLED",
+            broker_order_id="2000000089",
+        )
+        self.ledger.reconcile_terminal(
+            record.intent_id, "FILLED", terminal
+        )
+        reservation = self.ledger.get_margin_reservation(record.intent_id)
+        now = int(self.clock.now.timestamp() * 1_000_000)
+
+        with sqlite3.connect(self.path) as connection:
+            connection.execute("PRAGMA foreign_keys = ON")
+            with self.assertRaises(sqlite3.DatabaseError):
+                connection.execute(
+                    """
+                    INSERT INTO reservation_absorptions (
+                        absorption_sha256, intent_id, account_id,
+                        environment, broker_order_id, terminal_state,
+                        classification, terminal_order_evidence_sha256,
+                        baseline_capacity_decision_sha256,
+                        post_capacity_decision_sha256,
+                        post_capacity_evidence_sha256, ordered_quantity,
+                        filled_quantity, placed_time_epoch_ms,
+                        executed_time_epoch_ms, canonical_lot_proof_json,
+                        lot_proof_sha256, absorbed_margin_amount,
+                        observed_at, recorded_at
+                    ) VALUES (
+                        ?, ?, ?, ?, ?, 'CANCELLED', 'ZERO_FILL', ?, ?,
+                        NULL, NULL, 1, 0, ?, NULL, '[]', ?, '0', ?, ?
+                    )
+                    """,
+                    (
+                        "f" * 64,
+                        record.intent_id,
+                        record.envelope.account_id,
+                        record.envelope.environment,
+                        "2000000089",
+                        terminal.broker_read_evidence_sha256,
+                        reservation.capacity_decision_sha256,
+                        str(int(self.clock.now.timestamp() * 1_000)),
+                        "e" * 64,
+                        now,
+                        now,
+                    ),
+                )
+
+        self.assertEqual(
+            self.ledger.get_margin_reservation(record.intent_id).state,
+            "FILLED_PENDING_ABSORPTION",
+        )
+        self.assertEqual(
+            self.ledger.active_reserved_margin(
+                record.envelope.account_id,
+                record.envelope.environment,
+            ),
+            Decimal("500"),
+        )
+
     def test_concurrent_amendment_race_has_one_winner(self):
         record = self.opening()
         submit = self.ledger.claim_submission(record.intent_id, "worker", lease_seconds=30)
@@ -1977,6 +2564,32 @@ class OrderIntentLedgerTests(unittest.TestCase):
         with ThreadPoolExecutor(max_workers=2) as pool:
             outcomes = list(pool.map(acquire, ("nudger-a", "nudger-b")))
         self.assertEqual(sum(value is not None for value in outcomes), 1)
+
+    def test_concurrent_first_initialization_rechecks_metadata_under_lock(self):
+        parent = Path(self.tmp.name) / "parallel-initialize"
+        parent.mkdir(mode=0o700)
+        path = parent / "orders.sqlite3"
+        barrier = threading.Barrier(2)
+
+        def initialize(index):
+            barrier.wait()
+            return OrderIntentLedger(
+                path,
+                clock=self.clock,
+                run_id=f"parallel-initialize-{index}",
+            ).path
+
+        with ThreadPoolExecutor(max_workers=2) as pool:
+            paths = list(pool.map(initialize, (1, 2)))
+
+        self.assertEqual(paths, [path, path])
+        with sqlite3.connect(path) as connection:
+            self.assertEqual(
+                connection.execute(
+                    "SELECT schema_version FROM ledger_metadata"
+                ).fetchone()[0],
+                SCHEMA_VERSION,
+            )
 
     def test_schema_8_migrates_without_losing_the_ledger(self):
         legacy_wire = wire_order_payload(closing_payload())
@@ -2165,6 +2778,50 @@ class OrderIntentLedgerTests(unittest.TestCase):
             self.assertIsNotNone(conn.execute("SELECT 1 FROM sqlite_master WHERE type = 'table' AND name = 'transport_response_receipts'").fetchone())
             self.assertIsNotNone(conn.execute("SELECT 1 FROM sqlite_master WHERE type = 'trigger' AND name = 'prevent_transport_send_attempt_delete'").fetchone())
             self.assertIsNotNone(conn.execute("SELECT 1 FROM sqlite_master WHERE type = 'trigger' AND name = 'prevent_transport_response_receipt_delete'").fetchone())
+            legacy_reservation = conn.execute(
+                """
+                SELECT amount, max_loss_amount, risk_decision_id, state,
+                       capacity_decision_sha256, quote_digest,
+                       portfolio_snapshot_digest
+                FROM margin_reservations
+                WHERE intent_id = 'legacy-query-intent'
+                """
+            ).fetchone()
+            self.assertEqual(
+                legacy_reservation[:5],
+                (
+                    "375",
+                    "375",
+                    "legacy-opening-migration",
+                    "ACTIVE",
+                    None,
+                ),
+            )
+            self.assertEqual(len(legacy_reservation[5]), 64)
+            self.assertEqual(len(legacy_reservation[6]), 64)
+            legacy_creation = conn.execute(
+                """
+                SELECT from_state, to_state, actor, reason_code
+                FROM order_events
+                WHERE intent_id = 'legacy-query-intent'
+                  AND event_type = 'RESERVATION_CREATED'
+                """
+            ).fetchone()
+            self.assertEqual(
+                legacy_creation,
+                (
+                    "SUBMITTED",
+                    "SUBMITTED",
+                    "schema-migration",
+                    "RESERVATION_CREATED",
+                ),
+            )
+        self.assertEqual(
+            migrated.active_reserved_margin(
+                query_legacy.account_id, query_legacy.environment
+            ),
+            Decimal("375"),
+        )
         legacy_record = migrated.get_intent("legacy-closing-intent")
         self.assertEqual(legacy_record.envelope.intent_kind, "CLOSING")
         claimed_record = migrated.get_intent("legacy-claimed-intent")


### PR DESCRIPTION
## Outcome

Adds schema-12 terminal reservation absorption without weakening the fail-closed live boundary.

- classifies exact terminal order evidence as zero fill, full fill, or unresolved
- releases zero-fill risk only from complete order evidence
- retains full-fill margin until order-bound position lots and a later capacity snapshot prove absorption
- batches startup full-fill recovery behind one later capacity scan
- binds all position evidence to the selected account
- makes reservation, event, receipt, and trigger provenance tamper-evident and startup-verified
- keeps partial fills, replacements, assignments, and ambiguous evidence blocked

## Verification

- 153 R7-focused tests passed
- 318 maintained tests passed
- py_compile passed
- git diff --check passed
- independent adversarial review: clean for this diff

## Safety boundary

No E*TRADE session, broker mutation, deployment, or service restart was performed. This PR remains intentionally disconnected from legacy live execution. Live production stays no-go until legacy mutation containment, durable close/cancel flows, composition, migration drills, and operational validation are complete.